### PR TITLE
Fix screen name

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/AppStart.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/AppStart.swift
@@ -52,7 +52,7 @@ func initializeAppStartupListeners() {
     ]
     var reportedEvents = Set<Notification.Name>()
     events.forEach { event in
-        _ = NotificationCenter.default.addObserver(forName: event, object: nil, queue: nil) { (notif) in
+        _ = NotificationCenter.default.addObserver(forName: event, object: nil, queue: nil) { (_) in
             if !reportedEvents.contains(event) {
                 reportedEvents.insert(event)
                 if appStart == nil {

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/AppStart.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/AppStart.swift
@@ -53,7 +53,6 @@ func initializeAppStartupListeners() {
     var reportedEvents = Set<Notification.Name>()
     events.forEach { event in
         _ = NotificationCenter.default.addObserver(forName: event, object: nil, queue: nil) { (notif) in
-            print(notif.debugDescription)
             if !reportedEvents.contains(event) {
                 reportedEvents.insert(event)
                 if appStart == nil {

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/UIInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/UIInstrumentation.swift
@@ -168,8 +168,10 @@ private func pickVC(_ vc: UIViewController?) -> UIViewController? {
 
 private func pickWindow() -> UIWindow? {
     let app = UIApplication.shared
-    if app.keyWindow != nil {
-        return app.keyWindow
+    // just using app.keyWindow is depcrecated now
+    let key = app.windows.first { $0.isKeyWindow }
+    if key != nil {
+        return key
     }
     let wins = app.windows
     if !wins.isEmpty {

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/UIInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/UIInstrumentation.swift
@@ -166,6 +166,19 @@ private func pickVC(_ vc: UIViewController?) -> UIViewController? {
     return vc
 }
 
+private func pickWindow() -> UIWindow? {
+    let app = UIApplication.shared
+    if app.keyWindow != nil {
+        return app.keyWindow
+    }
+    let wins = app.windows
+    if !wins.isEmpty {
+        // windows are arranged in z-order, with topmost (e.g. popover) being the last in array
+        return wins[wins.count-1]
+    }
+    return nil
+}
+
 private func updateUIFields() {
     if !Thread.current.isMainThread {
         return
@@ -173,15 +186,14 @@ private func updateUIFields() {
     if isScreenNameManuallySet() {
         return
     }
-    let wins = UIApplication.shared.windows
-    print(wins)
-    if !wins.isEmpty {
+    let win = pickWindow()
+    if win != nil {
         // windows are arranged in z-order, with topmost (e.g. popover) being the last in array
-        let vc = pickVC(wins[wins.count-1].rootViewController)
+        let vc = pickVC(win!.rootViewController)
         if vc != nil {
             // FIXME SwiftUI UIHostingController vc when cast has a "rootView" var which does
             // not appear to be accessible generically
-            internal_manuallySetScreenName(String(describing: type(of: vc!)))
+            internal_setScreenName(String(describing: type(of: vc!)))
         }
     }
     // FIXME others?


### PR DESCRIPTION
    - was erroneously marked as "manually set" when automatically set
    - was not using app.keyWindow which is best source; top-most window used as fallback