### PR TITLE
Instrument WebKit to integrate with browser RUM

### DIFF
--- a/SplunkRumWorkspace/SmokeTest/SmokeTest/Info.plist
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTest/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/SplunkRumWorkspace/SmokeTest/SmokeTest/ViewController.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTest/ViewController.swift
@@ -16,8 +16,10 @@ limitations under the License.
 */
 
 import UIKit
+import WebKit
+import SplunkRum
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, WKUIDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,6 +29,14 @@ class ViewController: UIViewController {
     @IBAction
     func clickMe() {
         print("I was clicked!")
+
+        let webview = WKWebView(frame: .zero)
+        webview.uiDelegate = self
+        let url = URL(string: "http://127.0.0.1:8989/page.html")
+        let req = URLRequest(url: url!)
+        view = webview
+        SplunkRum.integrateWithBrowserRum(webview)
+        webview.load(req)
     }
 
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		866192F825ED34750035F08E /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866192F725ED34750035F08E /* UtilsTests.swift */; };
 		86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */; };
 		86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39C25E82278004DD939 /* UIInstrumentation.swift */; };
+		86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		866192F725ED34750035F08E /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentation.swift; sourceTree = "<group>"; };
 		86D3D39C25E82278004DD939 /* UIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInstrumentation.swift; sourceTree = "<group>"; };
+		86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInstrumentation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +148,7 @@
 				865DBDD82677AA7B00EFE8D5 /* RetryExporter.swift */,
 				8607AD4A267B9032004FAFFD /* AppLifecycle.swift */,
 				8624DAB4269CAE61005D65DE /* NetworkType.swift */,
+				86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */,
 			);
 			path = SplunkRum;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 				863A2F4225ED7BB100F3ECE0 /* AppStart.swift in Sources */,
 				8634EDC425FA86D20082819A /* LimitingExporter.swift in Sources */,
 				866192F425ED329E0035F08E /* Session.swift in Sources */,
+				86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */,
 				8624DAB5269CAE61005D65DE /* NetworkType.swift in Sources */,
 				8607AD4B267B9032004FAFFD /* AppLifecycle.swift in Sources */,
 				86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */,

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -19,6 +19,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import ZipkinExporter
 import StdoutExporter
+import WebKit
 
 let SplunkRumVersionString = "0.3.2"
 
@@ -312,6 +313,18 @@ var splunkRumInitializeCalledTime = Date()
      */
     public class func debugLog(_ msg: String) {
         debug_log(msg)
+    }
+
+    /**
+     Adds a window-level object to the WebKit WKWebView that allows browser SplunkRum to
+     see the native app's splunk.rumSessionId.  This allows us to integrate the data streams from the two
+     products.  Note that this exposes the (splunk) session ID to any page loaded through this view - it should
+     probably only be used for views which are definitely going to be instrumented by apps under your control, and not
+     ones that allow general browsing.  You should call this after the WKWebView is initialized but before it is
+     actually used.
+     */
+    @objc public class func integrateWithBrowserRum(_ view: WKWebView) {
+        integrateWebViewWithBrowserRum(view: view)
     }
 
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/WebViewInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/WebViewInstrumentation.swift
@@ -1,0 +1,72 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import WebKit
+
+class WebViewInstrumentation: NSObject, WKScriptMessageHandler {
+    let view: WKWebView
+    var lastSetSessionId: String
+    init(view: WKWebView) {
+        self.view = view
+        lastSetSessionId = getRumSessionId()
+    }
+    func integrate() {
+        let ucc = view.configuration.userContentController
+        // part 1: message handler for updates
+        ucc.add(self, name: "SplunkRumNativeUpdate")
+
+        // window.webkit.messageHandlers.logging.postMessage(
+        // part 2: initial script
+        lastSetSessionId = getRumSessionId()
+        let js = """
+            if (!window.SplunkRumNative) {
+                window.SplunkRumNative = {
+                    cachedSessionId: '\(lastSetSessionId)',
+                    getNativeSessionId: function() {
+                        try {
+                            window.webkit.messageHandlers.SplunkRumNativeUpdate.postMessage();
+                        } catch (e) {
+                            // ignored
+                        }
+                        return window.SplunkRumNative.cachedSessionId;
+                    },
+                };
+            }
+        """
+        let script = WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        ucc.addUserScript(script)
+    }
+
+    // called when browser calls window.webkit.messageHandlers.SplunkRumNativeUpdate.postMessage();
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        let newSessionId = getRumSessionId()
+        if newSessionId == lastSetSessionId {
+            return
+        }
+        let js = """
+            window.SplunkRumNative.cachedSessionId = '\(newSessionId)';
+        """
+        view.evaluateJavaScript(js)
+        lastSetSessionId = newSessionId
+    }
+}
+
+func integrateWebViewWithBrowserRum(view: WKWebView) {
+    let inst = WebViewInstrumentation(view: view)
+    inst.integrate()
+}


### PR DESCRIPTION
- Introduces SplunkRum.integrateWithBrowserRum(webkitView)
- Exposes the native session ID through javascript method
  window.SplunkRumNative.getNativeSessionId()
- Smoke test with a convoluted path to verifying this behavior