### PR TITLE
Use local library, not swift packages for test apps

### DIFF
--- a/SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,33 +38,6 @@
         }
       },
       {
-        "package": "PLCrashReporter",
-        "repositoryURL": "https://github.com/microsoft/plcrashreporter",
-        "state": {
-          "branch": null,
-          "revision": "d747ab5de269cd44022bbe96ff9609d8626694ab",
-          "version": "1.9.0"
-        }
-      },
-      {
-        "package": "SplunkRum",
-        "repositoryURL": "https://github.com/signalfx/splunk-otel-ios",
-        "state": {
-          "branch": null,
-          "revision": "98dee79983e44c6ed0c2e54209873e9c53c88857",
-          "version": "0.3.0"
-        }
-      },
-      {
-        "package": "SplunkRumCrashReporting",
-        "repositoryURL": "https://github.com/signalfx/splunk-otel-ios-crashreporting",
-        "state": {
-          "branch": null,
-          "revision": "256525c542e993dd87b1c51fcad7988a998704c3",
-          "version": "0.2.0"
-        }
-      },
-      {
         "package": "swift-atomics",
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {

--- a/SplunkRumWorkspace/TestApp/TestApp.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/TestApp/TestApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,9 +11,23 @@
 		86260EFC25CDC2AF009F3CB1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86260EFB25CDC2AF009F3CB1 /* ContentView.swift */; };
 		86260EFE25CDC2B0009F3CB1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 86260EFD25CDC2B0009F3CB1 /* Assets.xcassets */; };
 		86260F0125CDC2B0009F3CB1 /* PreviewAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 86260F0025CDC2B0009F3CB1 /* PreviewAssets.xcassets */; };
-		863B475126B2DC2700524BA9 /* SplunkRum in Frameworks */ = {isa = PBXBuildFile; productRef = 863B475026B2DC2700524BA9 /* SplunkRum */; };
-		863B475526B2DC3300524BA9 /* SplunkRumCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 863B475426B2DC3300524BA9 /* SplunkRumCrashReporting */; };
+		86AFA86E2714ACB30061A547 /* SplunkRum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86AFA86D2714ACB30061A547 /* SplunkRum.framework */; };
+		86AFA86F2714ACB30061A547 /* SplunkRum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 86AFA86D2714ACB30061A547 /* SplunkRum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		86AFA8702714ACB30061A547 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				86AFA86F2714ACB30061A547 /* SplunkRum.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		86260EF625CDC2AF009F3CB1 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -23,6 +37,7 @@
 		86260F0025CDC2B0009F3CB1 /* PreviewAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PreviewAssets.xcassets; sourceTree = "<group>"; };
 		86260F0225CDC2B0009F3CB1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		86260F0A25CDC2C3009F3CB1 /* SplunkRum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SplunkRum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		86AFA86D2714ACB30061A547 /* SplunkRum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SplunkRum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -30,8 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				863B475126B2DC2700524BA9 /* SplunkRum in Frameworks */,
-				863B475526B2DC3300524BA9 /* SplunkRumCrashReporting in Frameworks */,
+				86AFA86E2714ACB30061A547 /* SplunkRum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +92,7 @@
 		86260F0925CDC2C3009F3CB1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				86AFA86D2714ACB30061A547 /* SplunkRum.framework */,
 				86260F0A25CDC2C3009F3CB1 /* SplunkRum.framework */,
 			);
 			name = Frameworks;
@@ -93,6 +108,7 @@
 				86260EF225CDC2AF009F3CB1 /* Sources */,
 				86260EF325CDC2AF009F3CB1 /* Frameworks */,
 				86260EF425CDC2AF009F3CB1 /* Resources */,
+				86AFA8702714ACB30061A547 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -100,8 +116,6 @@
 			);
 			name = TestApp;
 			packageProductDependencies = (
-				863B475026B2DC2700524BA9 /* SplunkRum */,
-				863B475426B2DC3300524BA9 /* SplunkRumCrashReporting */,
 			);
 			productName = TestApp;
 			productReference = 86260EF625CDC2AF009F3CB1 /* TestApp.app */;
@@ -131,8 +145,6 @@
 			);
 			mainGroup = 86260EED25CDC2AF009F3CB1;
 			packageReferences = (
-				863B474F26B2DC2700524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */,
-				863B475326B2DC3300524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */,
 			);
 			productRefGroup = 86260EF725CDC2AF009F3CB1 /* Products */;
 			projectDirPath = "";
@@ -348,38 +360,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		863B474F26B2DC2700524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/signalfx/splunk-otel-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
-		863B475326B2DC3300524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/signalfx/splunk-otel-ios-crashreporting";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		863B475026B2DC2700524BA9 /* SplunkRum */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 863B474F26B2DC2700524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */;
-			productName = SplunkRum;
-		};
-		863B475426B2DC3300524BA9 /* SplunkRumCrashReporting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 863B475326B2DC3300524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */;
-			productName = SplunkRumCrashReporting;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 86260EEE25CDC2AF009F3CB1 /* Project object */;
 }

--- a/SplunkRumWorkspace/TestApp/TestApp/TestAppApp.swift
+++ b/SplunkRumWorkspace/TestApp/TestApp/TestAppApp.swift
@@ -16,13 +16,11 @@ limitations under the License.
 
 import SwiftUI
 import SplunkRum
-import SplunkRumCrashReporting
 
 @main
 struct TestAppApp: App {
     init() {
         SplunkRum.initialize(beaconUrl: "http://127.0.0.1:9080/api/v2/spans", rumAuth: "FAKE_RUM_AUTH", options: SplunkRumOptions(allowInsecureBeacon: true, debug: true, globalAttributes: ["strKey": "Some string", "intkey": 7]))
-        SplunkRumCrashReporting.start()
     }
     var body: some Scene {
         WindowGroup {

--- a/SplunkRumWorkspace/TestStoryboardApp/TestStoryboardApp.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/TestStoryboardApp/TestStoryboardApp.xcodeproj/project.pbxproj
@@ -3,12 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		863B474926B2DA7E00524BA9 /* SplunkRum in Frameworks */ = {isa = PBXBuildFile; productRef = 863B474826B2DA7E00524BA9 /* SplunkRum */; };
-		863B474D26B2DA9C00524BA9 /* SplunkRumCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 863B474C26B2DA9C00524BA9 /* SplunkRumCrashReporting */; };
+		86AFA8742714AD6C0061A547 /* SplunkRum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86AFA8732714AD6C0061A547 /* SplunkRum.framework */; };
+		86AFA8752714AD6C0061A547 /* SplunkRum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 86AFA8732714AD6C0061A547 /* SplunkRum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		86D3D38025E80648004DD939 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D37F25E80648004DD939 /* AppDelegate.swift */; };
 		86D3D38225E80648004DD939 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D38125E80648004DD939 /* SceneDelegate.swift */; };
 		86D3D38425E80648004DD939 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D38325E80648004DD939 /* ViewController.swift */; };
@@ -19,7 +19,22 @@
 		86D3D39825E80DBC004DD939 /* BViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39725E80DBC004DD939 /* BViewController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		86AFA8762714AD6C0061A547 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				86AFA8752714AD6C0061A547 /* SplunkRum.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		86AFA8732714AD6C0061A547 /* SplunkRum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SplunkRum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		86D3D37C25E80648004DD939 /* TestStoryboardApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestStoryboardApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		86D3D37F25E80648004DD939 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		86D3D38125E80648004DD939 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -38,8 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				863B474926B2DA7E00524BA9 /* SplunkRum in Frameworks */,
-				863B474D26B2DA9C00524BA9 /* SplunkRumCrashReporting in Frameworks */,
+				86AFA8742714AD6C0061A547 /* SplunkRum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,6 +96,7 @@
 		86D3D3A025E8240F004DD939 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				86AFA8732714AD6C0061A547 /* SplunkRum.framework */,
 				86D3D3A125E8240F004DD939 /* SplunkRum.framework */,
 			);
 			name = Frameworks;
@@ -97,6 +112,7 @@
 				86D3D37825E80648004DD939 /* Sources */,
 				86D3D37925E80648004DD939 /* Frameworks */,
 				86D3D37A25E80648004DD939 /* Resources */,
+				86AFA8762714AD6C0061A547 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -104,8 +120,6 @@
 			);
 			name = TestStoryboardApp;
 			packageProductDependencies = (
-				863B474826B2DA7E00524BA9 /* SplunkRum */,
-				863B474C26B2DA9C00524BA9 /* SplunkRumCrashReporting */,
 			);
 			productName = TestStoryboardApp;
 			productReference = 86D3D37C25E80648004DD939 /* TestStoryboardApp.app */;
@@ -135,8 +149,6 @@
 			);
 			mainGroup = 86D3D37325E80648004DD939;
 			packageReferences = (
-				863B474726B2DA7E00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */,
-				863B474B26B2DA9C00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */,
 			);
 			productRefGroup = 86D3D37D25E80648004DD939 /* Products */;
 			projectDirPath = "";
@@ -369,38 +381,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		863B474726B2DA7E00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/signalfx/splunk-otel-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
-		863B474B26B2DA9C00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/signalfx/splunk-otel-ios-crashreporting";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		863B474826B2DA7E00524BA9 /* SplunkRum */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 863B474726B2DA7E00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */;
-			productName = SplunkRum;
-		};
-		863B474C26B2DA9C00524BA9 /* SplunkRumCrashReporting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 863B474B26B2DA9C00524BA9 /* XCRemoteSwiftPackageReference "splunk-otel-ios-crashreporting" */;
-			productName = SplunkRumCrashReporting;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 86D3D37425E80648004DD939 /* Project object */;
 }

--- a/SplunkRumWorkspace/TestStoryboardApp/TestStoryboardApp/AppDelegate.swift
+++ b/SplunkRumWorkspace/TestStoryboardApp/TestStoryboardApp/AppDelegate.swift
@@ -17,7 +17,6 @@ limitations under the License.
 
 import UIKit
 import SplunkRum
-import SplunkRumCrashReporting
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -25,7 +24,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         SplunkRum.initialize(beaconUrl: "http://127.0.0.1:9080/api/v2/spans", rumAuth: "FAKE_RUM_AUTH", options: SplunkRumOptions(allowInsecureBeacon: true, debug: true))
-        SplunkRumCrashReporting.start()
         return true
     }
 


### PR DESCRIPTION
Makes quick testing much easier.  Entailed removing crash reporting.