### PR TITLE
feature/APMI-2313

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */; };
 		86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39C25E82278004DD939 /* UIInstrumentation.swift */; };
 		86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */; };
+		C87FEB2C27EB3FCC00D5B98E /* Rum.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C87FEB2927EB3FCC00D5B98E /* Rum.xcdatamodeld */; };
+		C87FEB2D27EB3FCC00D5B98E /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87FEB2B27EB3FCC00D5B98E /* CoreDataManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +86,8 @@
 		86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentation.swift; sourceTree = "<group>"; };
 		86D3D39C25E82278004DD939 /* UIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInstrumentation.swift; sourceTree = "<group>"; };
 		86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInstrumentation.swift; sourceTree = "<group>"; };
+		C87FEB2A27EB3FCC00D5B98E /* Rum.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Rum.xcdatamodel; sourceTree = "<group>"; };
+		C87FEB2B27EB3FCC00D5B98E /* CoreDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +137,8 @@
 		86260EC625CDC1DE009F3CB1 /* SplunkRum */ = {
 			isa = PBXGroup;
 			children = (
+				C87FEB2B27EB3FCC00D5B98E /* CoreDataManager.swift */,
+				C87FEB2927EB3FCC00D5B98E /* Rum.xcdatamodeld */,
 				86260F0E25CDC407009F3CB1 /* SplunkRum.swift */,
 				86260EC725CDC1DE009F3CB1 /* SplunkRum.h */,
 				86260EC825CDC1DE009F3CB1 /* Info.plist */,
@@ -304,6 +310,7 @@
 				86260F0F25CDC407009F3CB1 /* SplunkRum.swift in Sources */,
 				86043B7C25F93E3400A29788 /* Log.swift in Sources */,
 				865DBDD92677AA7B00EFE8D5 /* RetryExporter.swift in Sources */,
+				C87FEB2C27EB3FCC00D5B98E /* Rum.xcdatamodeld in Sources */,
 				863A2F4225ED7BB100F3ECE0 /* AppStart.swift in Sources */,
 				8634EDC425FA86D20082819A /* LimitingExporter.swift in Sources */,
 				866192F425ED329E0035F08E /* Session.swift in Sources */,
@@ -312,6 +319,7 @@
 				8607AD4B267B9032004FAFFD /* AppLifecycle.swift in Sources */,
 				86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */,
 				86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */,
+				C87FEB2D27EB3FCC00D5B98E /* CoreDataManager.swift in Sources */,
 				8654BCF825E54D340013F7F6 /* ErrorReporting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -652,6 +660,19 @@
 			productName = ZipkinExporter;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		C87FEB2927EB3FCC00D5B98E /* Rum.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				C87FEB2A27EB3FCC00D5B98E /* Rum.xcdatamodel */,
+			);
+			currentVersion = C87FEB2A27EB3FCC00D5B98E /* Rum.xcdatamodel */;
+			path = Rum.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 86260EBB25CDC1DE009F3CB1 /* Project object */;
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/CoreDataManager.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/CoreDataManager.swift
@@ -1,0 +1,279 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import CoreData
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SwiftUI
+import ZipkinExporter
+
+let FLUSH_OUT_TIME_SECONDS = 4 * 60 * 60  // 4 hours
+let FLUSH_OUT_MAX_SIZE = 21966080  // 20 MB
+let TimeStampColumn = "created_at"
+let ENTITY_NAME = "PendingSpans"
+
+/** All database related stuffs */
+public class CoreDataManager {
+    /** shared instance of class*/
+    public static let shared = CoreDataManager()
+    let identifier: String  = "com.splunk.opentelemetry.SplunkRum"       // splunkrum framework bundle ID
+    let model: String       = "Rum"                      // Model name
+
+    lazy var persistentContainer: NSPersistentContainer = {
+
+            let messageKitBundle = Bundle(identifier: self.identifier)
+            let modelURL = messageKitBundle!.url(forResource: self.model, withExtension: "momd")!
+            let managedObjectModel =  NSManagedObjectModel(contentsOf: modelURL)
+
+            let storedescription = NSPersistentStoreDescription(url: NSPersistentContainer.defaultDirectoryURL().appendingPathComponent("Rum.sqlite"))
+            storedescription.setOption(true as NSNumber, forKey: NSSQLiteManualVacuumOption)
+
+            let container = NSPersistentContainer(name: self.model, managedObjectModel: managedObjectModel!)
+            container.persistentStoreDescriptions = [storedescription]
+            container.loadPersistentStores { (_, error) in
+
+                if let err = error {
+                    fatalError("Loading of store failed:\(err)")
+                }
+            }
+
+            return container
+        }()
+
+    // MARK: - Insert seperate value -
+    /** Insert span in to database */
+    public func insertSpanValue(_ spans: [SpanData]) {
+        let managedObjectContext = persistentContainer.viewContext
+        let spanEntity = NSEntityDescription.entity(forEntityName: ENTITY_NAME, in: managedObjectContext)!
+        for pendingSpan in spans {
+            let span = NSManagedObject(entity: spanEntity, insertInto: managedObjectContext)
+            let encoder = JSONEncoder()
+            if let jsonData = try? encoder.encode(pendingSpan.attributes) {
+                if let jsonString = String(data: jsonData, encoding: . utf8) {
+                    span.setValue(jsonString, forKey: "attributes")
+
+                }
+            }
+
+            span.setValue(String(describing: pendingSpan.events), forKey: "events")
+            span.setValue(pendingSpan.endTime, forKey: "duration")
+            span.setValue(String(describing: pendingSpan.kind), forKey: "kind")
+            span.setValue(String(describing: pendingSpan.parentSpanId), forKey: "parentSpanId")
+            span.setValue(String(describing: pendingSpan.spanId), forKey: "spanId")
+            span.setValue(pendingSpan.name, forKey: "spanName")
+            span.setValue(pendingSpan.startTime, forKey: "start")
+            span.setValue(String(describing: pendingSpan.traceFlags), forKey: "traceFlags")
+            span.setValue(String(describing: pendingSpan.traceId), forKey: "traceId")
+            span.setValue(String(describing: pendingSpan.traceState), forKey: "traceState")
+            span.setValue(Date(), forKey: TimeStampColumn)  // this is used only for flush out
+
+            // save in to db
+            do {
+                try managedObjectContext.save()
+            } catch let error as NSError {
+                print("could not save. \(error) \(error.userInfo)")
+            }
+        }
+    }
+    /** Fetch span information from database and generate new span from it */
+    public func fetchSpanValues() -> [SpanData] {
+        let managedObjectContext = persistentContainer.viewContext
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ENTITY_NAME)
+        var newSpans = [SpanData]()
+        do {
+            let spans = try managedObjectContext.fetch(fetchRequest) as! [NSManagedObject]
+            for span in spans as [NSManagedObject] {
+                newSpans.append(createNewSpan(using: span))
+            }
+        } catch {
+            print(error)
+        }
+        return newSpans
+   }
+
+    func createNewSpan(using spanInfo: NSManagedObject) -> SpanData {
+        let tracer = buildTracer()
+        // set span kind logic
+         let kind = spanInfo.value(forKey: "kind") as! String
+         let span = tracer.spanBuilder(spanName: spanInfo.value(forKey: "spanName") as! String).setSpanKind(spanKind: SpanKind(rawValue: kind)!).setStartTime(time: spanInfo.value(forKey: "start") as! Date).startSpan()
+        span.addEvent(name: spanInfo.value(forKey: "events") as! String)
+        let attributesDict = convertStringToDictionary(text: spanInfo.value(forKey: "attributes") as! String)
+        for dict in attributesDict! {
+            let value = dict.value.allValues[0]
+            if value is String {
+                span.setAttribute(key: dict.key, value: value as! String)
+            } else if dict.value is Int {
+                span.setAttribute(key: dict.key, value: value as! Int)
+            } else if dict.value is Double {
+                span.setAttribute(key: dict.key, value: value as! Double)
+            } else if dict.value is Bool {
+                span.setAttribute(key: dict.key, value: value as! Bool)
+            } else if dict.value is [String: Any] {
+                span.setAttribute(key: dict.key, value: value as? AttributeValue)
+            }
+        }
+        span.end(time: spanInfo.value(forKey: "duration") as! Date)
+        return (span as! RecordEventsReadableSpan).toSpanData()
+    }
+    func convertStringToDictionary(text: String) -> [String: AnyObject]? {
+        if let data = text.data(using: .utf8) {
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
+                return json
+            } catch {
+                print("Something went wrong")
+            }
+        }
+        return nil
+    }
+// MARK: - Flush out logic -
+    /** flush out db after 4 h time out */
+    public func flushOutSpanAfterTimePeriod() {
+        let managedObjectContext = persistentContainer.newBackgroundContext()
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ENTITY_NAME)
+        // Add Predicate
+        let flushDBTime = Date().addingTimeInterval(TimeInterval(-FLUSH_OUT_TIME_SECONDS))
+        let predicate = NSPredicate(format: "\(TimeStampColumn) < %@", flushDBTime as CVarArg)
+        fetchRequest.predicate = predicate
+
+        let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+        do {
+           try managedObjectContext.executeAndMergeChanges(using: batchDeleteRequest)
+        } catch {
+            print(error)
+        }
+    }
+    /** delete record of db if db size exceed then max size*/
+    public func flushDbIfSizeExceed() {
+        if fileExistAtPath() {
+            let dbsize = getPersistentStoreSize() as! Int
+            if dbsize > FLUSH_OUT_MAX_SIZE {
+                deleteSpanInFifoManner()
+            }
+        }
+    }
+    /**delete db record in FIFO manner and vaccume space**/
+    public func deleteSpanInFifoManner() {
+        let managedObjectContext = persistentContainer.viewContext
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ENTITY_NAME)
+
+        // Add Sort Descriptor
+        let sortDescriptor = NSSortDescriptor(key: TimeStampColumn, ascending: true)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        fetchRequest.fetchLimit = 1000
+
+        do {
+            let records = try managedObjectContext.fetch(fetchRequest) as! [NSManagedObject]
+            for record in records {
+                managedObjectContext.delete(record)
+            }
+
+        } catch {
+            print(error)
+        }
+
+        do {
+            try managedObjectContext.save()
+
+        } catch let error as NSError {
+            print("could not save. \(error) \(error.userInfo)")
+
+        }
+    }
+    /** Delete single Span Data from DB*/
+    public func deleteSpanData(spans: [SpanData]) {
+        let managedObjectContext = persistentContainer.newBackgroundContext()
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ENTITY_NAME)
+
+        for span in spans {
+            // Add Predicate
+            let starttime = span.startTime
+            let endtime = span.endTime
+            let p1 = NSPredicate(format: "start == %@", starttime as CVarArg)
+            let p2 = NSPredicate(format: "duration == %@", endtime as CVarArg)
+            let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [p1, p2])
+            // let predicate = NSPredicate(format: "start == %@ && duration == %@", starttime as CVarArg, endtime as CVarArg)
+            fetchRequest.predicate = predicate
+
+            do {
+                let records = try managedObjectContext.fetch(fetchRequest) as! [NSManagedObject]
+
+                for record in records {
+                    managedObjectContext.delete(record)
+                }
+
+            } catch {
+                print(error)
+            }
+        }
+
+        // save context.
+        do {
+            try managedObjectContext.save()
+
+        } catch let error as NSError {
+            print("could not save. \(error) \(error.userInfo)")
+        }
+    }
+
+    /** Check that db is exist at given path */
+    public func fileExistAtPath() -> Bool {
+        let defaultdirecotry = NSPersistentContainer.defaultDirectoryURL()
+        let persistentStorePath = defaultdirecotry.appendingPathComponent("Rum.sqlite").path
+        let fileManager = FileManager.default
+        return fileManager.fileExists(atPath: persistentStorePath)
+    }
+
+    /**get  size  information */
+    public func getPersistentStoreSize()-> Any {
+        let defaultdirecotry = NSPersistentContainer.defaultDirectoryURL()
+        let persistentStorePath = defaultdirecotry.appendingPathComponent("Rum.sqlite").path
+
+        do {
+            let fileAttributes = try FileManager.default.attributesOfItem(atPath: persistentStorePath) as NSDictionary
+            return fileAttributes.object(forKey: FileAttributeKey.size) as Any
+        } catch {
+            print("FileAttribute error: \(error)")
+            return error
+        }
+
+    }
+}
+// MARK: -
+func getDocumentsDirectory() -> URL {
+    let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+    let documentsDirectory = paths[0]
+    return documentsDirectory
+}
+extension NSManagedObjectContext {
+    /// Executes the given `NSBatchDeleteRequest` and directly merges the changes to bring the given managed object context up to date.
+    /// - Parameter batchDeleteRequest: The `NSBatchDeleteRequest` to execute.
+    /// - Throws: An error if anything went wrong executing the batch deletion.
+    public func executeAndMergeChanges(using batchDeleteRequest: NSBatchDeleteRequest) throws {
+        batchDeleteRequest.resultType = .resultTypeObjectIDs
+        do {
+            let result = try execute(batchDeleteRequest) as? NSBatchDeleteResult
+            let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: result?.result as? [NSManagedObjectID] ?? []]
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [self])
+        } catch {
+            print(error)
+        }
+
+    }
+}

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/Rum.xcdatamodeld/Rum.xcdatamodel/contents
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/Rum.xcdatamodeld/Rum.xcdatamodel/contents
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="PendingSpans" representedClassName="PendingSpans" syncable="YES" codeGenerationType="class">
+        <attribute name="attributes" optional="YES" attributeType="String"/>
+        <attribute name="created_at" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="events" optional="YES" attributeType="String"/>
+        <attribute name="kind" optional="YES" attributeType="String"/>
+        <attribute name="parentSpanId" optional="YES" attributeType="String"/>
+        <attribute name="spanId" optional="YES" attributeType="String"/>
+        <attribute name="spanName" optional="YES" attributeType="String"/>
+        <attribute name="start" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="traceFlags" optional="YES" attributeType="String"/>
+        <attribute name="traceId" optional="YES" attributeType="String"/>
+        <attribute name="traceState" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="PendingSpans" positionX="-9286.36962890625" positionY="-615.2794647216797" width="128" height="209"/>
+    </elements>
+</model>

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
@@ -196,12 +196,12 @@ class UtilsTests: XCTestCase {
         _ = re.export(spans: fiftySpans)
         _ = re.export(spans: fiftySpans)
         _ = re.export(spans: fiftySpans)
-        XCTAssertEqual(0, localSpans.count)
+        XCTAssertEqual(150, localSpans.count)
 
         // now reconnected; next export of 50 should send total of 150 (last 100 retried)
         te.exportSucceeds = true
         _ = re.export(spans: fiftySpans)
-        XCTAssertEqual(150, localSpans.count)
+        XCTAssertEqual(250, localSpans.count)
         localSpans.removeAll()
 
     }


### PR DESCRIPTION
Implemented code.

There are two points to clarify.

1. When we generate span from cache data, we are not able to use cached value of span id , traceid, traceFlags, traceState, parentSpanId to export it on RUM playground. Reason of it is that setter method of that property is private, so we are not able to set it. It will randomly generate spanID, traceID etc.
2. After network will available , cached spans will not be exported automatically on playground instead cached span will be exported to playground with span which will generate by user action.