### PR TITLE
Feature/apmi 2630 session based sampling

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */; };
 		86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39C25E82278004DD939 /* UIInstrumentation.swift */; };
 		86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */; };
+		C8859F4627F430F900122AC2 /* SessionBasedSampling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8859F4527F430F900122AC2 /* SessionBasedSampling.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentation.swift; sourceTree = "<group>"; };
 		86D3D39C25E82278004DD939 /* UIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInstrumentation.swift; sourceTree = "<group>"; };
 		86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInstrumentation.swift; sourceTree = "<group>"; };
+		C8859F4527F430F900122AC2 /* SessionBasedSampling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionBasedSampling.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 		86260EC625CDC1DE009F3CB1 /* SplunkRum */ = {
 			isa = PBXGroup;
 			children = (
+				C8859F4527F430F900122AC2 /* SessionBasedSampling.swift */,
 				86260F0E25CDC407009F3CB1 /* SplunkRum.swift */,
 				86260EC725CDC1DE009F3CB1 /* SplunkRum.h */,
 				86260EC825CDC1DE009F3CB1 /* Info.plist */,
@@ -300,6 +303,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8654BCEC25E423170013F7F6 /* InstrumentationUtils.swift in Sources */,
+				C8859F4627F430F900122AC2 /* SessionBasedSampling.swift in Sources */,
 				8616CD5F266E673F0048980B /* ScreenName.swift in Sources */,
 				86260F0F25CDC407009F3CB1 /* SplunkRum.swift in Sources */,
 				86043B7C25F93E3400A29788 /* Log.swift in Sources */,

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
@@ -107,6 +107,7 @@ func invalidateSession(_ event: String) {
         if Date() > sessionIdInActivityExpiration { // expire 15 min
            Is_New_SessionID_For_In_Activity = true
             _  = getRumSessionId()
+            SessionBasedSampling.sessionshouldSample()
         }
     }
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
@@ -21,6 +21,7 @@ import OpenTelemetrySdk
 
 let INACTIVITY_SESSION_TIMEOUT_SECONDS = 15 * 60
 private var sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(INACTIVITY_SESSION_TIMEOUT_SECONDS))
+var Is_New_SessionID_For_In_Activity = false
 
 func initializeAppLifecycleInstrumentation() {
     /*
@@ -104,7 +105,8 @@ func invalidateSession(_ event: String) {
         sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(INACTIVITY_SESSION_TIMEOUT_SECONDS))
     } else if event == "UIApplicationWillEnterForegroundNotification" {
         if Date() > sessionIdInActivityExpiration { // expire 15 min
-            rumSessionId = generateNewSessionId()
+           Is_New_SessionID_For_In_Activity = true
+            _  = getRumSessionId()
         }
     }
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
@@ -18,11 +18,11 @@ limitations under the License.
 import Foundation
 
 let MAX_SESSION_AGE_SECONDS = 4 * 60 * 60
-let MAX_SESSION_INACTIVE_AGE_SECONDS =  60    //15 * 60
+let MAXSESSIONINACTIVEAGESECONDS = 15 * 60
 
 private var rumSessionId = generateNewSessionId()
 private var sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
-private var sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_INACTIVE_AGE_SECONDS))
+private var sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
 private let sessionIdLock = NSLock()
 private var sessionIdCallbacks: [(() -> Void)] = []
 
@@ -56,15 +56,15 @@ func getRumSessionId() -> String {
     }
     if Date() > sessionIdExpiration { // expire in 4 hours
         sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_INACTIVE_AGE_SECONDS))
+        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
         rumSessionId = generateNewSessionId()
         callbacks = sessionIdCallbacks
     } else if Date() > sessionIdInActivityExpiration { // expire 15 min
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_INACTIVE_AGE_SECONDS))
+        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
         rumSessionId = generateNewSessionId()
         callbacks = sessionIdCallbacks
     } else { // no timer expire but activity done on screen
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_INACTIVE_AGE_SECONDS))
+        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
     }
     sessionIdLock.unlock()
     unlocked = true
@@ -73,4 +73,3 @@ func getRumSessionId() -> String {
     }
     return rumSessionId
 }
-

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
@@ -62,7 +62,5 @@ func getRumSessionId() -> String {
     for callback in callbacks {
         callback()
     }
-
     return rumSessionId
 }
-

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
@@ -18,11 +18,9 @@ limitations under the License.
 import Foundation
 
 let MAX_SESSION_AGE_SECONDS = 4 * 60 * 60
-let MAXSESSIONINACTIVEAGESECONDS = 15 * 60
 
-private var rumSessionId = generateNewSessionId()
+var rumSessionId = generateNewSessionId()
 private var sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
-private var sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
 private let sessionIdLock = NSLock()
 private var sessionIdCallbacks: [(() -> Void)] = []
 
@@ -54,22 +52,17 @@ func getRumSessionId() -> String {
             sessionIdLock.unlock()
         }
     }
-    if Date() > sessionIdExpiration { // expire in 4 hours
+    if Date() > sessionIdExpiration {
         sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
         rumSessionId = generateNewSessionId()
         callbacks = sessionIdCallbacks
-    } else if Date() > sessionIdInActivityExpiration { // expire 15 min
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
-        rumSessionId = generateNewSessionId()
-        callbacks = sessionIdCallbacks
-    } else { // no timer expire but activity done on screen
-        sessionIdInActivityExpiration = Date().addingTimeInterval(TimeInterval(MAXSESSIONINACTIVEAGESECONDS))
     }
     sessionIdLock.unlock()
     unlocked = true
     for callback in callbacks {
         callback()
     }
+
     return rumSessionId
 }
+

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/Session.swift
@@ -19,7 +19,7 @@ import Foundation
 
 let MAX_SESSION_AGE_SECONDS = 4 * 60 * 60
 
-var rumSessionId = generateNewSessionId()
+private var rumSessionId = generateNewSessionId()
 private var sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
 private let sessionIdLock = NSLock()
 private var sessionIdCallbacks: [(() -> Void)] = []
@@ -56,6 +56,10 @@ func getRumSessionId() -> String {
         sessionIdExpiration = Date().addingTimeInterval(TimeInterval(MAX_SESSION_AGE_SECONDS))
         rumSessionId = generateNewSessionId()
         callbacks = sessionIdCallbacks
+    }
+    if Is_New_SessionID_For_In_Activity {
+        rumSessionId = generateNewSessionId()
+        Is_New_SessionID_For_In_Activity = false
     }
     sessionIdLock.unlock()
     unlocked = true

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampling.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampling.swift
@@ -1,0 +1,78 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetrySdk
+import OpenTelemetryApi
+
+class SessionBasedSampling {
+    static var probability: Double = 1.0
+    static var sessionCount: Int = 0
+    static var timer: Timer?
+    init(ratio: Double) {
+        SessionBasedSampling.probability = ratio
+    }
+    /**check that session will be sampled or not**/
+    public class func sessionshouldSample() {
+        let sampling_percentage = SessionBasedSampling.probability
+        let step = Double(1/sampling_percentage)
+
+        let roundedStepValue = round(step * 10) / 10.0
+        var result = false
+        switch SessionBasedSampling.probability {
+        case 0.0:
+            result = false
+        case 1.0:
+            result = true
+
+        default:
+            if floor(Double(SessionBasedSampling.sessionCount).truncatingRemainder(dividingBy: roundedStepValue)) == 0 {  // if SessionBasedSampling.sessionCount % Int(step) == 0 {
+                result = true
+            } else {
+                result = false
+            }
+        }
+
+        var psampler: Sampler
+        if result {
+                psampler = OpenTelemetrySdk.Samplers.parentBased(root: Samplers.alwaysOn, remoteParentSampled: Samplers.alwaysOn, remoteParentNotSampled: Samplers.alwaysOn, localParentSampled: Samplers.alwaysOn, localParentNotSampled: Samplers.alwaysOn)
+        } else {
+              psampler = OpenTelemetrySdk.Samplers.parentBased(root: Samplers.alwaysOff, remoteParentSampled: Samplers.alwaysOff, remoteParentNotSampled: Samplers.alwaysOff, localParentSampled: Samplers.alwaysOff, localParentNotSampled: Samplers.alwaysOff)
+        }
+        OpenTelemetrySDK.instance.tracerProvider.updateActiveSampler(psampler)
+        if SessionBasedSampling.probability != 0.0 && SessionBasedSampling.probability != 1.0 {
+            SessionBasedSampling.sessionCount += 1
+            SessionBasedSampling.startTimer()
+        }
+
+     }
+    /**start timer**/
+    public class func startTimer() {
+        SessionBasedSampling.stopTimer()
+        guard self.timer == nil else { return }
+        self.timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(MAX_SESSION_AGE_SECONDS), repeats: true) { _ in
+            SessionBasedSampling.sessionshouldSample()
+         }
+
+    }
+    /** stop timer*/
+    public class func stopTimer() {
+        guard timer != nil else { return }
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -140,7 +140,12 @@ var splunkRumInitializeCalledTime = Date()
                 - Parameter options: Non-required configuration toggles for various features.  See SplunkRumOptions struct for details.
      
      */
-    @objc public class func initialize(beaconUrl: String, rumAuth: String, options: SplunkRumOptions? = nil) {
+    @objc public class func initialize(beaconUrl: String, rumAuth: String, options: SplunkRumOptions? = nil, sessionBaseSamplingRatio: Double = 1.0) {
+        if sessionBaseSamplingRatio >= 0.0 && sessionBaseSamplingRatio <= 1.0 {
+          _ = SessionBasedSampling(ratio: sessionBaseSamplingRatio)
+           SessionBasedSampling.sessionshouldSample()
+
+        }
         if !Thread.isMainThread {
             print("SplunkRum: Please call SplunkRum.initialize only on the main thread")
             return

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
@@ -205,5 +205,11 @@ class UtilsTests: XCTestCase {
         localSpans.removeAll()
 
     }
+    
+    func testSessionBasedSampling() throws {
+        SplunkRum.initialize(beaconUrl: "http://127.0.0.1:8989/", rumAuth: "FAKE_RUM_AUTH", options: SplunkRumOptions(allowInsecureBeacon: true, debug: true, globalAttributes: [:], environment: nil, ignoreURLs: nil),sessionBaseSamplingRatio: 0.2)
+        XCTAssertTrue(SessionBasedSampling.probability >= 0.0 && SessionBasedSampling.probability <= 1.0)
+        XCTAssertEqual(SessionBasedSampling.probability, 0.2)
+    }
 
 }


### PR DESCRIPTION
Implemented code.

Overview:

We have to pass `sessionBaseSamplingRatio` value between 0.0 to 1.0 when initialise splunkrum from app delegate.
It’s default value is 1.0. In `initialize` method  of `SplunkRum` class , We checked that if value is with in above range than pass this value to `SessionBasedSampling` class. Call `sessionshouldSample` method of it. In this method we developed algorithm to check that current session will be sampled or not, and set value of result variable accordingly.
If result is true means session will be sampled and false means session will not be sampled.

At the end set the value of active sampler. We use timer to call `sessionshouldSample` method  whenever new session will be generated.

In order to handle 15 min inactivity session time out ,call `sessionshouldSample` from `invalidateSession` method of AppLifeCycle class. I had created branch from APMI-2307 (session time out after 15 min user in activity) than raised PR. 