### PR TITLE
upgrade to OTel 1.1.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "SplunkOtel", targets: ["SplunkOtel"])
     ],
     dependencies: [
-        .package(name: "opentelemetry-swift", url:"https://github.com/open-telemetry/opentelemetry-swift", from: "1.1.0"),
+        .package(name: "opentelemetry-swift", url:"https://github.com/open-telemetry/opentelemetry-swift", from: "1.1.4"),
 	.package(url: "https://github.com/devicekit/DeviceKit.git", from: "4.0.0"),
     ],
     targets: [

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -774,7 +774,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.1.4;
 			};
 		};
 		865A5CA425DC34D8003A1E5A /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/open-telemetry/opentelemetry-swift",
         "state": {
           "branch": null,
-          "revision": "3f9d9d7b754f750bb8a1655796064a39e54b311b",
-          "version": "1.1.0"
+          "revision": "2133b500597eb18685925dc71ac892695c9112a2",
+          "version": "1.1.4"
         }
       },
       {


### PR DESCRIPTION
Mainly due to https://github.com/open-telemetry/opentelemetry-swift/pull/306, but there are additional fixes: https://github.com/open-telemetry/opentelemetry-swift/releases