### PR TITLE
feat: make span disk cache size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ or
 | showVCInstrumentation | Bool | Enable span creation for ViewController Show events (not applicable to all UI frameworks/apps) | true |
 | screenNameSpans | Bool | Enable span creation for changes to the screen name | true |
 | networkInstrumentation | Bool | Enable span creation for network activities | true |
-| enableDiskCache | Bool | Enable disk caching of exported spans. All spans will be written to disk and deleted on a successful export. The storage is capped at 64 MB. | false |
+| enableDiskCache | Bool | Enable disk caching of exported spans. All spans will be written to disk and deleted on a successful export. | false |
+| spanDiskCacheMaxSize | Int64 | Threshold in bytes from which spans will start to be dropped from the disk cache (oldest first). Only applicable when disk caching is enabled. | 25 MB |
 
 ## Crash Reporting
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SpanToDiskExporter.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SpanToDiskExporter.swift
@@ -27,7 +27,7 @@ class SpanToDiskExporter: SpanExporter {
     private var totalSpansInserted: Int64 = 0
     private var checkpointCounter: Int64 = 0
 
-    init(spanDb: SpanDb, maxFileSizeBytes: Int64 = 64 * 1024 * 1024, truncationCheckpoint: Int64 = 2048) {
+    init(spanDb: SpanDb, maxFileSizeBytes: Int64 = 25 * 1024 * 1024, truncationCheckpoint: Int64 = 512) {
         self.db = spanDb
         self.maxFileSizeBytes = maxFileSizeBytes
         self.truncationCheckpoint = truncationCheckpoint

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -23,6 +23,9 @@ import WebKit
 
 let SplunkRumVersionString = "0.7.1"
 
+/**
+ Default maximum size of the disk cache in bytes.
+ */
 public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
 
 /**

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportCommon.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportCommon.swift
@@ -27,7 +27,7 @@ struct TestZipkinSpan: Decodable {
     var tags: [String: String]
 }
 
-enum SpanReceiverError : Error {
+enum SpanReceiverError: Error {
     case timeout(String)
 }
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
@@ -33,7 +33,7 @@ fileprivate var started = false
 class DiskExportPipelineTest: XCTestCase {
 
     override func setUpWithError() throws {
-        super.setUpWithError()
+        try super.setUpWithError()
         if started {
             receiver.reset()
             return

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
@@ -23,25 +23,46 @@ func rumOptions() -> SplunkRumOptions {
     options.debug = true
     options.allowInsecureBeacon = true
     options.enableDiskCache = true
+    options.spanDiskCacheMaxSize = 4096 * 4
     return options
 }
 
+fileprivate let receiver = TestSpanReceiver()
+fileprivate var started = false
+
+
 class DiskExportPipelineTest: XCTestCase {
-    func testExportPipeline() throws {
-        let receiver = TestSpanReceiver()
+
+    override func setUpWithError() throws {
+        if started {
+            receiver.reset()
+            return
+        }
         try receiver.start(9733)
+
+        SpanDb.deleteAtDefaultLocation()
+
         XCTAssertTrue(
             SplunkRum.initialize(beaconUrl: "http://localhost:9733/v1/traces", rumAuth: "FAKE", options: rumOptions())
         )
 
-        buildTracer().spanBuilder(spanName: "test").startSpan().end()
+        started = true
+    }
+    
+    func testExportPipeline() throws {
+        for _ in 1...32 {
+            let span = buildTracer().spanBuilder(spanName: "large-span").startSpan()
+            span.setAttribute(key: "large-attribute", value: String(repeating: "abcd", count: 256))
+            span.setAttribute(key: "large-attribute-2", value: String(repeating: "abcd", count: 256))
+            span.end()
+        }
 
-        sleep(11)
-
-        let spans = receiver.spans()
+        let spans = try receiver.waitForSpans().filter { $0.name == "large-span" }
+        // Assert all spans were either exported or dropped from disk.
+        XCTAssertEqual(SpanDb().fetch(count: 32).count, 0)
+        // The exported size is less than we sent, this means remaining spans were dropped.
+        XCTAssertLessThan(spans.count, 32)
+        // And make sure we didn't receive an empty array
         XCTAssertGreaterThan(spans.count, 0)
-        XCTAssertTrue(spans.contains(where: { s in
-            s.name == "test"
-        }))
     }
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/DiskExportPipelineTest.swift
@@ -30,10 +30,10 @@ func rumOptions() -> SplunkRumOptions {
 fileprivate let receiver = TestSpanReceiver()
 fileprivate var started = false
 
-
 class DiskExportPipelineTest: XCTestCase {
 
     override func setUpWithError() throws {
+        super.setUpWithError()
         if started {
             receiver.reset()
             return
@@ -48,7 +48,7 @@ class DiskExportPipelineTest: XCTestCase {
 
         started = true
     }
-    
+
     func testExportPipeline() throws {
         for _ in 1...32 {
             let span = buildTracer().spanBuilder(spanName: "large-span").startSpan()

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/SpanFromDiskExporterTest.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumDiskExportTests/SpanFromDiskExporterTest.swift
@@ -69,18 +69,7 @@ class SpanFromDiskExporterTest: XCTestCase {
             stop()
         }
 
-        var secondsWaited = 0
-        while !receiver.receivedRequest {
-            sleep(1)
-            secondsWaited += 1
-
-            if secondsWaited >= 10 {
-                XCTFail("Timed out waiting for spans")
-                return
-            }
-        }
-
-        let spans = receiver.spans()
+        let spans = try receiver.waitForSpans()
         XCTAssertEqual(spans.count, 0)
         XCTAssertEqual(db.fetch(count: 10).count, 2)
     }


### PR DESCRIPTION
* Expose setting the span disk cache size to users.
* Set the default disk cache size to 25 MB to be in line with the Android SDK.
* Reduce truncation checkpoint (the count of inserted spans after which a check for database size is done) from 2048 to 512.