### PR TITLE
APMI-2306 slow and frozen frame detection

### DIFF
--- a/SplunkRumWorkspace/SmokeTest/SmokeTest/Base.lproj/Main.storyboard
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTest/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,6 +23,22 @@
                                 <state key="normal" title="CLICK ME"/>
                                 <connections>
                                     <action selector="clickMe" destination="BYZ-38-t0r" eventType="touchUpInside" id="07Q-eK-HdY"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UJh-qh-YJg">
+                                <rect key="frame" x="116" y="112" width="97" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="SMALL SLEEP"/>
+                                <connections>
+                                    <action selector="smallSleep" destination="BYZ-38-t0r" eventType="touchUpInside" id="XhA-zZ-sYq"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c0m-DN-6WC">
+                                <rect key="frame" x="117" y="145" width="96" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="LARGE SLEEP"/>
+                                <connections>
+                                    <action selector="largeSleep" destination="BYZ-38-t0r" eventType="touchUpInside" id="VSR-FB-Add"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/SplunkRumWorkspace/SmokeTest/SmokeTest/ViewController.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTest/ViewController.swift
@@ -40,4 +40,14 @@ class ViewController: UIViewController, WKUIDelegate {
         webview.load(req)
     }
 
+    @IBAction
+    func smallSleep() {
+        usleep(100 * 1000) // 100 ms
+    }
+
+    @IBAction
+    func largeSleep() {
+        usleep(1000 * 1000) // 1000 ms
+    }
+
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		86AAAD4725CEC374001D1195 /* NetworkInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */; };
 		86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39C25E82278004DD939 /* UIInstrumentation.swift */; };
 		86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */; };
+		88734FE628A55FB60035960F /* SlowFrameDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88734FE528A55FB60035960F /* SlowFrameDetector.swift */; };
 		E2ACB216283E3483006A1475 /* SpanToDiskExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB215283E3483006A1475 /* SpanToDiskExporter.swift */; };
 		E2ACB21B283F852E006A1475 /* SpanFromDiskExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB21A283F852E006A1475 /* SpanFromDiskExporter.swift */; };
 		E2ACB21D283F855C006A1475 /* SpanDb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB21C283F855C006A1475 /* SpanDb.swift */; };
@@ -105,6 +106,7 @@
 		86AAAD4625CEC374001D1195 /* NetworkInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentation.swift; sourceTree = "<group>"; };
 		86D3D39C25E82278004DD939 /* UIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInstrumentation.swift; sourceTree = "<group>"; };
 		86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInstrumentation.swift; sourceTree = "<group>"; };
+		88734FE528A55FB60035960F /* SlowFrameDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetector.swift; sourceTree = "<group>"; };
 		E2ACB215283E3483006A1475 /* SpanToDiskExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanToDiskExporter.swift; sourceTree = "<group>"; };
 		E2ACB21A283F852E006A1475 /* SpanFromDiskExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFromDiskExporter.swift; sourceTree = "<group>"; };
 		E2ACB21C283F855C006A1475 /* SpanDb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanDb.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				86043B7B25F93E3400A29788 /* Log.swift */,
 				8634EDC325FA86D20082819A /* LimitingExporter.swift */,
 				8616CD5E266E673F0048980B /* ScreenName.swift */,
+				88734FE528A55FB60035960F /* SlowFrameDetector.swift */,
 				865DBDD82677AA7B00EFE8D5 /* RetryExporter.swift */,
 				8607AD4A267B9032004FAFFD /* AppLifecycle.swift */,
 				8624DAB4269CAE61005D65DE /* NetworkType.swift */,
@@ -396,6 +399,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88734FE628A55FB60035960F /* SlowFrameDetector.swift in Sources */,
 				8654BCEC25E423170013F7F6 /* InstrumentationUtils.swift in Sources */,
 				8616CD5F266E673F0048980B /* ScreenName.swift in Sources */,
 				86260F0F25CDC407009F3CB1 /* SplunkRum.swift in Sources */,

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SlowFrameDetector.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SlowFrameDetector.swift
@@ -1,0 +1,129 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import QuartzCore
+import UIKit
+
+fileprivate var detector: SlowFrameDetector = SlowFrameDetector()
+
+class SlowFrameDetector: NSObject {
+
+    private var displayLink: CADisplayLink?
+    private var slowFrames: [String: Int] = [:]
+    private var frozenFrames: [String: Int] = [:]
+
+    fileprivate var slowFrameThreshold: CFTimeInterval = 16.7
+    fileprivate var frozenFrameThreshold: CFTimeInterval = 700
+
+    private var previousTimestamp: CFTimeInterval = 0.0
+    private var currentScreenName = getScreenName()
+    private var timer = Timer()
+
+    func start() {
+        if self.displayLink != nil {
+            return
+        }
+
+        SplunkRum.addScreenNameChangeCallback { name in
+            self.currentScreenName = name
+        }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(self.appWillResignActive(notification:)), name: UIApplication.willResignActiveNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(self.appDidBecomeActive(notification:)), name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        let displayLink = CADisplayLink(target: self, selector: #selector(displayLinkCallback))
+        displayLink.add(to: .main, forMode: .common)
+        self.displayLink = displayLink
+
+        self.timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { _ in
+            self.dumpFrames()
+        })
+    }
+
+    @objc func appWillResignActive(notification: Notification) {
+        self.displayLink?.isPaused = true
+        dumpFrames()
+    }
+
+    @objc func appDidBecomeActive(notification: Notification) {
+        previousTimestamp = 0.0
+        self.displayLink?.isPaused = false
+    }
+
+    @objc func displayLinkCallback(_ displayLink: CADisplayLink) {
+        if previousTimestamp == 0.0 {
+            previousTimestamp = displayLink.timestamp
+            return
+        }
+
+        let duration = displayLink.timestamp - previousTimestamp
+        previousTimestamp = displayLink.timestamp
+
+        let frozenThresholdSeconds = frozenFrameThreshold / 1e3
+        let slowThresholdSeconds = slowFrameThreshold / 1e3
+        if duration >= frozenThresholdSeconds {
+            if let count = self.frozenFrames[currentScreenName] {
+                self.frozenFrames[currentScreenName] = count + 1
+            } else {
+                self.frozenFrames[currentScreenName] = 1
+             }
+         } else if duration >= slowThresholdSeconds {
+             if let count = self.slowFrames[currentScreenName] {
+                 self.slowFrames[currentScreenName] = count + 1
+             } else {
+                 self.slowFrames[currentScreenName] = 1
+             }
+         }
+     }
+
+    func dumpFrames() {
+        for (screenName, count) in self.slowFrames {
+            reportFrame("slowRenders", screenName, count)
+        }
+
+        for (screenName, count) in self.frozenFrames {
+            reportFrame("frozenRenders", screenName, count)
+        }
+
+        self.slowFrames.removeAll()
+        self.frozenFrames.removeAll()
+    }
+
+    func reportFrame(_ type: String, _ screenName: String, _ count: Int) {
+        let tracer = buildTracer()
+        let now = Date()
+        let span = tracer.spanBuilder(spanName: type).setStartTime(time: now).startSpan()
+        span.setAttribute(key: "component", value: "ui")
+        span.setAttribute(key: "count", value: count)
+        span.setAttribute(key: "screen.name", value: screenName)
+        span.end(time: now)
+    }
+}
+
+func startSlowFrameDetector(slowFrameDetectionThresholdMs: Double?, frozenFrameDetectionThresholdMs: Double?) {
+    if slowFrameDetectionThresholdMs != nil {
+        detector.slowFrameThreshold = slowFrameDetectionThresholdMs!
+    }
+
+    if frozenFrameDetectionThresholdMs != nil {
+        detector.frozenFrameThreshold = frozenFrameDetectionThresholdMs!
+    }
+
+    detector.start()
+}

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// swiftlint:disable file_length
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -407,5 +408,4 @@ var splunkRumInitializeCalledTime = Date()
     @objc public class func isInitialized() -> Bool {
         return initialized
     }
-
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -38,7 +38,6 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
      */
     @objc public override init() {
     }
-
     /**
         Memberwise initializer
      */


### PR DESCRIPTION
Changes: with signed commits.

Pause CADisplayLink when on app will resign and resume it on app activation. Simplifies the code somewhat and avoids issues with counting the frame duration when the app is moved to background.
Group slow and frozen frames per screen names. This is necessary so when 2 different screens have a slow frame in a second interval, they are both reported.
Use screen name callbacks to store the screen name locally to avoid the locking in getScreenName()
Use a 1 second timer to periodically dump the detected frames.