### PR TITLE
APMI 2360: Session Based Sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 xcuserdata/
 .build
 Package.resolved
+SplunkRumWorkspace/.idea

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ or
 | networkInstrumentation | Bool | Enable span creation for network activities | true |
 | enableDiskCache | Bool | Enable disk caching of exported spans. All spans will be written to disk and deleted on a successful export. | false |
 | spanDiskCacheMaxSize | Int64 | Threshold in bytes from which spans will start to be dropped from the disk cache (oldest first). Only applicable when disk caching is enabled. | 25 MB |
+| sessionBaseSamplingRatio | Double | Percentage of sessions to sample.  Expressed as 0.0 - 1.0. | 1.0 |
 
 ## Crash Reporting
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		86D3D39D25E82278004DD939 /* UIInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D3D39C25E82278004DD939 /* UIInstrumentation.swift */; };
 		86F2A5CF2702476000641068 /* WebViewInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */; };
 		88734FE628A55FB60035960F /* SlowFrameDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88734FE528A55FB60035960F /* SlowFrameDetector.swift */; };
+		D77058D428D36E350047D880 /* SessionBasedSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77058D328D36E350047D880 /* SessionBasedSampler.swift */; };
 		E2ACB216283E3483006A1475 /* SpanToDiskExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB215283E3483006A1475 /* SpanToDiskExporter.swift */; };
 		E2ACB21B283F852E006A1475 /* SpanFromDiskExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB21A283F852E006A1475 /* SpanFromDiskExporter.swift */; };
 		E2ACB21D283F855C006A1475 /* SpanDb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ACB21C283F855C006A1475 /* SpanDb.swift */; };
@@ -107,6 +108,7 @@
 		86D3D39C25E82278004DD939 /* UIInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInstrumentation.swift; sourceTree = "<group>"; };
 		86F2A5CE2702476000641068 /* WebViewInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInstrumentation.swift; sourceTree = "<group>"; };
 		88734FE528A55FB60035960F /* SlowFrameDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetector.swift; sourceTree = "<group>"; };
+		D77058D328D36E350047D880 /* SessionBasedSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionBasedSampler.swift; sourceTree = "<group>"; };
 		E2ACB215283E3483006A1475 /* SpanToDiskExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanToDiskExporter.swift; sourceTree = "<group>"; };
 		E2ACB21A283F852E006A1475 /* SpanFromDiskExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFromDiskExporter.swift; sourceTree = "<group>"; };
 		E2ACB21C283F855C006A1475 /* SpanDb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanDb.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				E2ACB21C283F855C006A1475 /* SpanDb.swift */,
 				E2ACB21E283F871D006A1475 /* ZipkinTransform.swift */,
 				E2AFD9E62846919C000F53BF /* BandwidthTracker.swift */,
+				D77058D328D36E350047D880 /* SessionBasedSampler.swift */,
 			);
 			path = SplunkRum;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				E2ACB21D283F855C006A1475 /* SpanDb.swift in Sources */,
 				86043B7C25F93E3400A29788 /* Log.swift in Sources */,
 				E2AFD9E72846919C000F53BF /* BandwidthTracker.swift in Sources */,
+				D77058D428D36E350047D880 /* SessionBasedSampler.swift in Sources */,
 				865DBDD92677AA7B00EFE8D5 /* RetryExporter.swift in Sources */,
 				E2ACB216283E3483006A1475 /* SpanToDiskExporter.swift in Sources */,
 				863A2F4225ED7BB100F3ECE0 /* AppStart.swift in Sources */,

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetrySdk
+import OpenTelemetryApi
+
+class SessionBasedSampler {
+    static var probability: Double = 1.0
+    static var sessionCount: Int = 0
+    static var timer: Timer?
+
+    init(ratio: Double) {
+        SessionBasedSampler.probability = ratio
+    }
+
+    /**Check if session will be sampled or not.**/
+    @discardableResult public class func sessionShouldSample() -> Bool {
+        let samplingPercentage = SessionBasedSampler.probability
+        let step = Double(1/samplingPercentage)
+        let roundedStepValue = round(step * 10) / 10.0
+
+        var result = false
+        switch SessionBasedSampler.probability {
+        case 0.0:
+            result = false
+        case 1.0:
+            result = true
+        default:
+            if floor(Double(SessionBasedSampler.sessionCount).truncatingRemainder(dividingBy: roundedStepValue)) == 0 {
+                result = true
+            } else {
+                result = false
+            }
+        }
+
+        var parentSampler: Sampler
+        if result {
+            parentSampler = OpenTelemetrySdk.Samplers.parentBased(root: Samplers.alwaysOn, remoteParentSampled: Samplers.alwaysOn, remoteParentNotSampled: Samplers.alwaysOn, localParentSampled: Samplers.alwaysOn, localParentNotSampled: Samplers.alwaysOn)
+        } else {
+            parentSampler = OpenTelemetrySdk.Samplers.parentBased(root: Samplers.alwaysOff, remoteParentSampled: Samplers.alwaysOff, remoteParentNotSampled: Samplers.alwaysOff, localParentSampled: Samplers.alwaysOff, localParentNotSampled: Samplers.alwaysOff)
+        }
+
+        OpenTelemetrySDK.instance.tracerProvider.updateActiveSampler(parentSampler)
+        if SessionBasedSampler.probability != 0.0 && SessionBasedSampler.probability != 1.0 {
+            SessionBasedSampler.sessionCount += 1
+            SessionBasedSampler.startTimer()
+        }
+        return result
+    }
+
+    /**start timer**/
+    public class func startTimer() {
+        SessionBasedSampler.stopTimer()
+        guard self.timer == nil else { return }
+        self.timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(MAX_SESSION_AGE_SECONDS), repeats: true) { _ in
+            SessionBasedSampler.sessionShouldSample()
+        }
+    }
+
+    /** stop timer*/
+    public class func stopTimer() {
+        guard timer != nil else { return }
+        timer?.invalidate()
+        timer = nil
+    }
+
+}

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -48,7 +48,8 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
                       enableDiskCache: Bool = false,
                       spanDiskCacheMaxSize: Int64 = DEFAULT_DISK_CACHE_MAX_SIZE_BYTES,
                       slowFrameDetectionThresholdMs: Double = 16.7,
-                      frozenFrameDetectionThresholdMs: Double = 700
+                      frozenFrameDetectionThresholdMs: Double = 700,
+                      sessionBaseSamplingRatio: Double = 1.0
     ) {
         // rejectionFilter not specified to make it possible to call from objc
         self.allowInsecureBeacon = allowInsecureBeacon
@@ -62,6 +63,7 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
         self.spanDiskCacheMaxSize = spanDiskCacheMaxSize
         self.slowFrameDetectionThresholdMs = slowFrameDetectionThresholdMs
         self.frozenFrameDetectionThresholdMs = frozenFrameDetectionThresholdMs
+        self.sessionBaseSamplingRatio = sessionBaseSamplingRatio
     }
     /**
         Copy constructor
@@ -81,6 +83,7 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
         self.networkInstrumentation = opts.networkInstrumentation
         self.enableDiskCache = opts.enableDiskCache
         self.spanDiskCacheMaxSize = opts.spanDiskCacheMaxSize
+        self.sessionBaseSamplingRatio = opts.sessionBaseSamplingRatio
     }
 
     /**
@@ -146,6 +149,11 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
      Only applicable when disk caching is enabled.
      */
     @objc public var spanDiskCacheMaxSize: Int64 = DEFAULT_DISK_CACHE_MAX_SIZE_BYTES
+    
+    /**
+    Percentage of sessions to send spans / data.
+     */
+    @objc public var sessionBaseSamplingRatio: Double = 1.0
 
     func toAttributeValue() -> String {
         var answer = "debug: "+debug.description
@@ -212,6 +220,13 @@ var splunkRumInitializeCalledTime = Date()
         }
         if options?.environment != nil {
             setGlobalAttributes(["environment": options!.environment!])
+        }
+        if options?.sessionBaseSamplingRatio != nil {
+            let samplingRatio = options!.sessionBaseSamplingRatio
+            if samplingRatio >= 0.0 && samplingRatio <= 1.0 {
+                _ = SessionBasedSampler(ratio: samplingRatio)
+                SessionBasedSampler.sessionShouldSample()
+            }
         }
         if !beaconUrl.starts(with: "https:") && options?.allowInsecureBeacon != true {
             print("SplunkRum: beaconUrl must be https or options: allowInsecureBeacon must be true")

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/UtilsTests.swift
@@ -206,4 +206,55 @@ class UtilsTests: XCTestCase {
 
     }
 
+    /**Test Initialization of SessionBasedSampler**/
+    func testSessionBasedSamplingInitialization() throws {
+        // Forces RUM to reinitialze for testing
+        SplunkRum.initialized = false
+        _ = SplunkRum.initialize(beaconUrl: "http://127.0.0.1:8989/",
+                                 rumAuth: "FAKE_RUM_AUTH",
+                                 options: SplunkRumOptions(allowInsecureBeacon: true,
+                                                           debug: true,
+                                                           globalAttributes: [:],
+                                                           environment: nil,
+                                                           ignoreURLs: nil,
+                                                           sessionBaseSamplingRatio: 0.2)
+        )
+        XCTAssertTrue(SessionBasedSampler.probability >= 0.0 && SessionBasedSampler.probability <= 1.0)
+        XCTAssertEqual(SessionBasedSampler.probability, 0.2)
+    }
+
+    /**Test Sending All Spans**/
+    func testSessionBasedSampling100Pct() throws {
+        // Forces RUM to reinitialze for testing
+        SplunkRum.initialized = false
+        _ = SplunkRum.initialize(beaconUrl: "http://127.0.0.1:8989/",
+                                 rumAuth: "FAKE_RUM_AUTH",
+                                 options: SplunkRumOptions(allowInsecureBeacon: true,
+                                                           debug: true,
+                                                           globalAttributes: [:],
+                                                           environment: nil,
+                                                           ignoreURLs: nil,
+                                                           sessionBaseSamplingRatio: 1.0)
+        )
+        let shouldSample = SessionBasedSampler.sessionShouldSample()
+        XCTAssertTrue(shouldSample)
+    }
+
+    /**Tests Sending 0 Spans**/
+    func testSessionBasedSampling0Pct() throws {
+        // Forces RUM to reinitialze for testing
+        SplunkRum.initialized = false
+        _ = SplunkRum.initialize(beaconUrl: "http://127.0.0.1:8989/",
+                                 rumAuth: "FAKE_RUM_AUTH",
+                                 options: SplunkRumOptions(allowInsecureBeacon: true,
+                                                           debug: true,
+                                                           globalAttributes: [:],
+                                                           environment: nil,
+                                                           ignoreURLs: nil,
+                                                           sessionBaseSamplingRatio: 0.0)
+        )
+        let shouldSample = SessionBasedSampler.sessionShouldSample()
+        XCTAssertFalse(shouldSample)
+    }
+
 }


### PR DESCRIPTION
This is a refactor/clean up of this MR. https://github.com/signalfx/splunk-otel-ios/pull/73.

Moves the sampling percentage to the options set.
Adds several extra tests.
Cleans up variable and class names.
Updates ReadMe to add some details about the available options.
Additional Changes

Adds .idea folder to gitignore for users of AppCode.