### PR TITLE
fix: clear carrier info on non-cell connection types

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
@@ -148,6 +148,8 @@ func initializeNetworkTypeMonitoring() {
                 } else {
                     setConnectionType(nil)
                 }
+            } else {
+                setConnectionType(nil)
             }
         }
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
@@ -44,7 +44,7 @@ private func setConnectionType(_ type: String?) {
     }
     currentNetInfo.hostConnectionType = type
 
-    if type != "wifi" {
+    if type != "cell" {
         currentNetInfo.hostConnectionSubType = nil
         currentNetInfo.carrierCountryCode = nil
         currentNetInfo.carrierNetworkCode = nil

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
@@ -43,6 +43,13 @@ private func setConnectionType(_ type: String?) {
         pthread_rwlock_unlock(&netInfoLock)
     }
     currentNetInfo.hostConnectionType = type
+
+    if type != "wifi" {
+        currentNetInfo.hostConnectionSubType = nil
+        currentNetInfo.carrierCountryCode = nil
+        currentNetInfo.carrierNetworkCode = nil
+        currentNetInfo.carrierIsoCountryCode = nil
+    }
 }
 
 private func setCarrierInfo(name: String?, technology: String?, countryCode: String?, networkCode: String?, isoCountryCode: String?) {


### PR DESCRIPTION
Switching from cellular to wifi did not clear carrier information.