### PR TITLE
chore: disable cyclomatic_complexity lint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ disabled_rules:
  - function_body_length
  - force_cast
  - private_over_fileprivate
+ - cyclomatic_complexity
 # Not really sure about a bunch of these, just turning most stuff in the 'performance' and 'lint' categories
 opt_in_rules:
  - missing_docs

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// swiftlint:disable cyclomatic_complexity
 import Foundation
 import OpenTelemetryApi
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkType.swift
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// swiftlint:disable cyclomatic_complexity
 import Foundation
 import SystemConfiguration
 import Network

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -196,7 +196,6 @@ var splunkRumInitializeCalledTime = Date()
                 - Parameter options: Non-required configuration toggles for various features.  See SplunkRumOptions struct for details.
      
      */
-    // swiftlint:disable:next cyclomatic_complexity
     @objc public class func initialize(beaconUrl: String, rumAuth: String, options: SplunkRumOptions? = nil) -> Bool {
         if !Thread.isMainThread {
             print("SplunkRum: Please call SplunkRum.initialize only on the main thread")


### PR DESCRIPTION
CI had it's swiftlint upgraded, which started failing on the current codebase due to `orphaned_doc_comment` rule (https://github.com/signalfx/splunk-otel-ios/actions/runs/3477866164/jobs/6009506623#step:3:40).

This rule was triggered when there was a doc comment before a function that had a `swiftlint:disable:next` clause for a different rule. E.g. `SplunkRum.initialize` had `//swiftlint:disable:next cyclomatic_complexity`.

Added `cyclomatic_complexity` to ignored rules, don't think it's useful anyway.