### PR TITLE
SplunkRum.initialize discardable result

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -196,6 +196,7 @@ var splunkRumInitializeCalledTime = Date()
                 - Parameter options: Non-required configuration toggles for various features.  See SplunkRumOptions struct for details.
      
      */
+    @discardableResult
     @objc public class func initialize(beaconUrl: String, rumAuth: String, options: SplunkRumOptions? = nil) -> Bool {
         if !Thread.isMainThread {
             print("SplunkRum: Please call SplunkRum.initialize only on the main thread")


### PR DESCRIPTION
Adds the @ discardableResult annotation to the SplunkRum.initialize call. 

This gets rid of the warning seen here for those library consumers that do not want to /need to pay attention to the result of the initialize call (including the sample apps).

<img width="1415" alt="Screen Shot 2022-11-29 at 7 42 35 AM" src="https://user-images.githubusercontent.com/113932712/204560004-7c0c6454-8722-4503-b39e-18cdc7e77128.png">

Some projects are also setup to have warnings be errors which means you have to handle the result value which means you end with code like: 

```swift
_ = SplunkRum.initialize(...)
```
