### PR TITLE
POR-14136 RUM instrumentation is causing crashes because of forceFlush

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/AppLifecycle.swift
@@ -103,7 +103,9 @@ func lifecycleEvent(_ event: String) {
     // these two attempt to send to the beacon
     if event == UI_APPLICATION_WILL_TERMINATE_NOTIFICATION ||
             event == UI_APPLICATION_DID_ENTER_BACKGROUND_NOTIFICATION {
-        OpenTelemetrySDK.instance.tracerProvider.forceFlush()
+        DispatchQueue.global(qos: .background).async {
+            OpenTelemetrySDK.instance.tracerProvider.forceFlush(timeout: 2)
+        }
 
     }
 }


### PR DESCRIPTION
RUM doing a “forceFlush” in the main thread and that is taking longer than what iOS/Apple allows