### PR TITLE
fix: unhandled promise rejection in webview instrumentation

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/WebViewInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/WebViewInstrumentation.swift
@@ -39,7 +39,7 @@ class WebViewInstrumentation: NSObject, WKScriptMessageHandler {
                     cachedSessionId: '\(lastSetSessionId)',
                     getNativeSessionId: function() {
                         try {
-                            window.webkit.messageHandlers.SplunkRumNativeUpdate.postMessage();
+                            window.webkit.messageHandlers.SplunkRumNativeUpdate.postMessage('').catch(function() {});
                         } catch (e) {
                             // ignored
                         }


### PR DESCRIPTION
It seems `postMessage` required at least 1 argument (https://developer.apple.com/documentation/webkit/wkscriptmessagehandler).

Calling it without arguments returned a rejecting promise, which was picked up by the Web instrumentation and reported as an error.

Added the extra promise catch just in case, even though adding the single parameter fixed the issue.