### PR TITLE
Draft: MOB-3105: Adds podspec file

### DIFF
--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -1,0 +1,33 @@
+#
+# NOTE: Be sure to run
+#
+# `pod lib lint SplunkOtel.podspec`
+#
+#  to ensure this is a valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'SplunkOtel'  
+  s.version          = '0.1.0'  
+  s.summary          = 'Splunk Open Telemetry pod for iOS' 
+  s.description      = <<-DESC
+The Splunk RUM agent for iOS provides a Swift package that captures:
+HTTP requests, using URLSession instrumentation
+Application startup information
+UI activity - screen name (typically ViewController name), actions, and PresentationTransitions
+Crashes/unhandled exceptions using SplunkRumCrashReporting
+🚧 This project is currently in BETA. It is officially supported by Splunk. However, breaking changes MAY be introduced.
+DESC
+
+  s.swift_version    = '5.1'
+
+  s.homepage         = 'https://github.com/signalfx/splunk-otel-ios.git'
+  s.license          = { :type => "Apache", :file => 'LICENSE' }
+  s.author           = { 'Splunk' => 'www.splunk.com' }
+  s.source           = { :git => 'https://github.com/signalfx/splunk-otel-ios.git', :tag => s.version.to_s }
+  s.ios.deployment_target = '11.0'
+  s.source_files = 'SplunkRumWorkspace/SplunkRum/SplunkRum/**/*.swift'
+end


### PR DESCRIPTION
Adds the podspec file to support cocoapods distribution. As the readme states that we're still in beta, I started the versioning at 0.1.0, but we can start at 1.0.0 if we prefer. Once the podspec is merged into the main branch, I will finish the publish process so the pod can be used by customers.