### PR TITLE
MOB-3105 adds podspec file

### DIFF
--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -12,7 +12,7 @@
 Pod::Spec.new do |s|
   s.name             = 'SplunkOtel'  
   s.version          = '0.10.0'  
-  s.summary          = 'Splunk Open Telemetry pod for iOS' 
+  s.summary          = 'Splunk OpenTelemetry pod for iOS' 
   s.description      = <<-DESC
 The Splunk RUM agent for iOS provides a Swift package that captures:
 HTTP requests, using URLSession instrumentation

--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -1,0 +1,33 @@
+#
+# NOTE: Be sure to run
+#
+# `pod lib lint SplunkOtel.podspec`
+#
+#  to ensure this is a valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'SplunkOtel'  
+  s.version          = '0.1.0'  
+  s.summary          = 'Splunk Open Telemetry pod for iOS' 
+  s.description      = <<-DESC
+The Splunk RUM agent for iOS provides a Swift package that captures:
+HTTP requests, using URLSession instrumentation
+Application startup information
+UI activity - screen name (typically ViewController name), actions, and PresentationTransitions
+Crashes/unhandled exceptions using SplunkRumCrashReporting
+🚧 This project is currently in BETA. It is officially supported by Splunk. However, breaking changes MAY be introduced.
+DESC
+
+  s.swift_version    = '5.1'
+
+  s.homepage         = 'https://github.com/signalfx/splunk-otel-ios.git'
+  s.license          = { :type => "Apache", :file => 'LICENSE' }
+  s.author           = { 'Splunk' => 'www.splunk.com' }
+  s.source           = { :git => 'https://github.com/signalfx/splunk-otel-ios.git', :tag => s.version.to_s }
+  s.ios.deployment_target = '11.0'
+  s.source_files = 'SplunkRumWorkspace/SplunkRum/SplunkRum/**/*.swift'
+end

--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -11,7 +11,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplunkOtel'  
-  s.version          = '0.1.0'  
+  s.version          = '0.10.0'  
   s.summary          = 'Splunk Open Telemetry pod for iOS' 
   s.description      = <<-DESC
 The Splunk RUM agent for iOS provides a Swift package that captures:
@@ -28,6 +28,7 @@ DESC
   s.license          = { :type => "Apache", :file => 'LICENSE' }
   s.author           = { 'Splunk' => 'www.splunk.com' }
   s.source           = { :git => 'https://github.com/signalfx/splunk-otel-ios.git', :tag => s.version.to_s }
+# Make sure the deployment target matches with Package.swift
   s.ios.deployment_target = '11.0'
   s.source_files = 'SplunkRumWorkspace/SplunkRum/SplunkRum/**/*.swift'
 end

--- a/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -34,7 +34,6 @@ var lastTimestamp: CFTimeInterval = CACurrentMediaTime()
 
 class SmokeTestUITests: XCTestCase {
 
-    // swiftlint:disable overridden_super_call
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
@@ -43,7 +42,6 @@ class SmokeTestUITests: XCTestCase {
 
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-    // swiftlint:enable overridden_super_call
 
     let SLEEP_TIME: UInt32 = 30 // batch is currently every 5 so this should be plenty
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -18,6 +18,7 @@ limitations under the License.
 import Foundation
 import WebKit
 
+// Make sure the version numbers on the podspec and SplunkRum.swift match
 let SplunkRumVersionString = "0.10.0"
 
 /**

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -ex
 swiftlint --strict
+
+# Make sure the version numbers on the podspec and SplunkRum.swift match
+echo "Check 3"
+rumVer="$(grep SplunkRumVersionString SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+podVer="$(grep s.version SplunkOtel.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+if [ $podVer != $rumVer ]; then
+    echo "Error: The version numbers in SplunkOtel.podspec and SplunkRum.swift do not match"
+    exit 1
+fi
+
+# Check the podspec is valid
+pod lib lint SplunkOtel.podspec
+
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Debug build
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Debug test
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Release build


### PR DESCRIPTION
Adds the podspec file to support cocoapod distribution. As our readme states we're still in beta, I started versioning at 0.1.0, but can start at 1.0.0 if that's preferred. Once the podspec is merged into main, I'll publish the pod for use.