### PR TITLE
MOB-3105 Creates Podspec File for Cocoapods Support

### DIFF
--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -1,0 +1,34 @@
+#
+# NOTE: Be sure to run
+#
+# `pod lib lint SplunkOtel.podspec`
+#
+#  to ensure this is a valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'SplunkOtel'  
+  s.version          = '0.10.0'  
+  s.summary          = 'Splunk OpenTelemetry pod for iOS' 
+  s.description      = <<-DESC
+The Splunk RUM agent for iOS provides a Swift package that captures:
+HTTP requests, using URLSession instrumentation
+Application startup information
+UI activity - screen name (typically ViewController name), actions, and PresentationTransitions
+Crashes/unhandled exceptions using SplunkRumCrashReporting
+🚧 This project is currently in BETA. It is officially supported by Splunk. However, breaking changes MAY be introduced.
+DESC
+
+  s.swift_version    = '5.1'
+
+  s.homepage         = 'https://github.com/signalfx/splunk-otel-ios.git'
+  s.license          = { :type => "Apache", :file => 'LICENSE' }
+  s.author           = { 'Splunk' => 'www.splunk.com' }
+  s.source           = { :git => 'https://github.com/signalfx/splunk-otel-ios.git', :tag => s.version.to_s }
+# Make sure the deployment target matches with Package.swift
+  s.ios.deployment_target = '11.0'
+  s.source_files = 'SplunkRumWorkspace/SplunkRum/SplunkRum/**/*.swift'
+end

--- a/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -34,7 +34,6 @@ var lastTimestamp: CFTimeInterval = CACurrentMediaTime()
 
 class SmokeTestUITests: XCTestCase {
 
-    // swiftlint:disable overridden_super_call
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
@@ -43,7 +42,6 @@ class SmokeTestUITests: XCTestCase {
 
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-    // swiftlint:enable overridden_super_call
 
     let SLEEP_TIME: UInt32 = 30 // batch is currently every 5 so this should be plenty
 

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -18,6 +18,7 @@ limitations under the License.
 import Foundation
 import WebKit
 
+// Make sure the version numbers on the podspec and SplunkRum.swift match
 let SplunkRumVersionString = "0.10.0"
 
 /**

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -3,7 +3,7 @@ set -ex
 swiftlint --strict
 
 # Make sure the version numbers on the podspec and SplunkRum.swift match
-echo "Check 3"
+echo "Checking that version numbers match"
 rumVer="$(grep SplunkRumVersionString SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
 podVer="$(grep s.version SplunkOtel.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
 if [ $podVer != $rumVer ]; then

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -ex
 swiftlint --strict
+
+# Make sure the version numbers on the podspec and SplunkRum.swift match
+echo "Check 3"
+rumVer="$(grep SplunkRumVersionString SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+podVer="$(grep s.version SplunkOtel.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+if [ $podVer != $rumVer ]; then
+    echo "Error: The version numbers in SplunkOtel.podspec and SplunkRum.swift do not match"
+    exit 1
+fi
+
+# Check the podspec is valid
+pod lib lint SplunkOtel.podspec
+
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Debug build
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Debug test
 xcodebuild -workspace SplunkRumWorkspace/SplunkRumWorkspace.xcworkspace -scheme SplunkOtel -configuration Release build


### PR DESCRIPTION
Same as https://github.com/signalfx/splunk-otel-ios/pull/142 but remade as I had to mess with my SSH keys and it unverified my commits.

Creates the podspec file for cocoapods support.
Adds a version check in the fullbuild script to ensure the version number on the Swift Package and Cocoapod is the same. 
Removes a broken lint check in the UI test that was preventing the build from completing.