### PR TITLE
Adding Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @johnbley
+* @johnbley @dvernon-splunk @seemk
 
 #####################################################
 #
@@ -6,7 +6,7 @@
 #
 #####################################################
 
-*.md @signalfx/gdi-docs @johnbley
-*.rst @signalfx/gdi-docs @johnbley
-docs/ @signalfx/gdi-docs @johnbley
-README* @signalfx/gdi-docs @johnbley
+*.md @signalfx/gdi-docs @johnbley @dvernon-splunk @seemk
+*.rst @signalfx/gdi-docs @johnbley @dvernon-splunk @seemk
+docs/ @signalfx/gdi-docs @johnbley @dvernon-splunk @seemk
+README* @signalfx/gdi-docs @johnbley @dvernon-splunk @seemk


### PR DESCRIPTION
Adding myself and @seemk as Codeowners. Once we turn on the Require Code Owners branch protection, a code owner will need to approve all PRs before it gets merged.

Siim, let me know if you don't actually want to be a codeowner and I can take you off. Having 3 seemed like a good idea so one of us can take an extended vacation without holding up the other codeowner's PRs