### PR TITLE
Dvernon: MOB-3260/MOB-3261 - New Options

### DIFF
--- a/SplunkOtel.podspec
+++ b/SplunkOtel.podspec
@@ -11,7 +11,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SplunkOtel'  
-  s.version          = '0.11.0'  
+  s.version          = '0.11.1'
   s.summary          = 'Splunk OpenTelemetry pod for iOS' 
   s.description      = <<-DESC
 The Splunk RUM agent for iOS provides a Swift package that captures:

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -19,7 +19,7 @@ import Foundation
 import WebKit
 
 // Make sure the version numbers on the podspec and SplunkRum.swift match
-let SplunkRumVersionString = "0.11.0"
+let SplunkRumVersionString = "0.11.1"
 
 /**
  Default maximum size of the disk cache in bytes.
@@ -48,6 +48,7 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
                       networkInstrumentation: Bool = true,
                       enableDiskCache: Bool = false,
                       spanDiskCacheMaxSize: Int64 = DEFAULT_DISK_CACHE_MAX_SIZE_BYTES,
+                      slowRenderingDetectionEnabled: Bool = true,
                       slowFrameDetectionThresholdMs: Double = 16.7,
                       frozenFrameDetectionThresholdMs: Double = 700,
                       sessionSamplingRatio: Double = 1.0
@@ -62,6 +63,7 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
         self.networkInstrumentation = networkInstrumentation
         self.enableDiskCache = enableDiskCache
         self.spanDiskCacheMaxSize = spanDiskCacheMaxSize
+        self.slowRenderingDetectionEnabled = slowRenderingDetectionEnabled
         self.slowFrameDetectionThresholdMs = slowFrameDetectionThresholdMs
         self.frozenFrameDetectionThresholdMs = frozenFrameDetectionThresholdMs
         self.sessionSamplingRatio = sessionSamplingRatio
@@ -79,6 +81,7 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
         self.spanFilter = opts.spanFilter
         self.showVCInstrumentation = opts.showVCInstrumentation
         self.screenNameSpans = opts.screenNameSpans
+        self.slowRenderingDetectionEnabled = opts.slowRenderingDetectionEnabled
         self.slowFrameDetectionThresholdMs = opts.slowFrameDetectionThresholdMs
         self.frozenFrameDetectionThresholdMs = opts.frozenFrameDetectionThresholdMs
         self.networkInstrumentation = opts.networkInstrumentation
@@ -129,6 +132,11 @@ public let DEFAULT_DISK_CACHE_MAX_SIZE_BYTES: Int64 = 25 * 1024 * 1024
      Enable NetworkInstrumentation span creation for https calls.
      */
     @objc public var networkInstrumentation: Bool = true
+
+    /**
+     Enable slow rendering detection. Slow rendering detection generates spans whenever it detects a slow or frozen frame render.
+     */
+    @objc public var slowRenderingDetectionEnabled: Bool = true
 
     /**
      Threshold, in milliseconds, from which to count a rendered frame as slow.
@@ -288,10 +296,12 @@ var splunkRumInitializeCalledTime = Date()
         }
         initializeNetworkTypeMonitoring()
         initalizeUIInstrumentation()
-        startSlowFrameDetector(
-                    slowFrameDetectionThresholdMs: options?.slowFrameDetectionThresholdMs,
-                    frozenFrameDetectionThresholdMs: options?.frozenFrameDetectionThresholdMs
-                )
+        if options?.slowRenderingDetectionEnabled ?? true {
+            startSlowFrameDetector(
+                slowFrameDetectionThresholdMs: options?.slowFrameDetectionThresholdMs,
+                frozenFrameDetectionThresholdMs: options?.frozenFrameDetectionThresholdMs
+            )
+        }
         // not initializeAppLifecycleInstrumentation, done at end of AppStart
         srInit.end()
         initialized = true
@@ -378,10 +388,12 @@ var splunkRumInitializeCalledTime = Date()
         }
         initializeNetworkTypeMonitoring()
         initalizeUIInstrumentation()
-        startSlowFrameDetector(
-                    slowFrameDetectionThresholdMs: options.slowFrameDetectionThresholdMs,
-                    frozenFrameDetectionThresholdMs: options.frozenFrameDetectionThresholdMs
-                )
+        if options.slowRenderingDetectionEnabled {
+            startSlowFrameDetector(
+                slowFrameDetectionThresholdMs: options.slowFrameDetectionThresholdMs,
+                frozenFrameDetectionThresholdMs: options.frozenFrameDetectionThresholdMs
+            )
+        }
         // not initializeAppLifecycleInstrumentation, done at end of AppStart
         srInit.end()
         initialized = true

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRumBuilder.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRumBuilder.swift
@@ -30,6 +30,7 @@ import Foundation
     private var networkInstrumentation: Bool = true
     private var enableDiskCache: Bool = false
     private var spanDiskCacheMaxSize: Int64 = DEFAULT_DISK_CACHE_MAX_SIZE_BYTES
+    private var slowRenderingDetectionEnabled: Bool = true
     private var slowFrameDetectionThresholdMs: Double = 16.7
     private var frozenFrameDetectionThresholdMs: Double = 700
     private var sessionSamplingRatio: Double = 1.0
@@ -110,6 +111,13 @@ import Foundation
 
     @discardableResult
     @objc
+    public func slowRenderingDetectionEnabled(_ enabled: Bool) -> SplunkRumBuilder {
+        self.slowRenderingDetectionEnabled = enabled
+        return self
+    }
+
+    @discardableResult
+    @objc
     public func slowFrameDetectionThresholdMs(thresholdMs: Double) -> SplunkRumBuilder {
         self.slowFrameDetectionThresholdMs = thresholdMs
         return self
@@ -151,6 +159,7 @@ import Foundation
                                                networkInstrumentation: self.networkInstrumentation,
                                                enableDiskCache: self.enableDiskCache,
                                                spanDiskCacheMaxSize: self.spanDiskCacheMaxSize,
+                                               slowRenderingDetectionEnabled: self.slowRenderingDetectionEnabled,
                                                slowFrameDetectionThresholdMs: self.slowFrameDetectionThresholdMs,
                                                frozenFrameDetectionThresholdMs: self.frozenFrameDetectionThresholdMs,
                                                sessionSamplingRatio: self.sessionSamplingRatio))

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRumBuilder.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRumBuilder.swift
@@ -35,6 +35,7 @@ import Foundation
     private var frozenFrameDetectionThresholdMs: Double = 700
     private var sessionSamplingRatio: Double = 1.0
     private var appName: String?
+    private var spanSchedulingDelay: TimeInterval = 5.0
 
     @objc public init(beaconUrl: String, rumAuth: String) {
         self.beaconUrl = beaconUrl
@@ -146,6 +147,13 @@ import Foundation
 
     @discardableResult
     @objc
+    public func setSpanSchedulingDelay(seconds: TimeInterval) -> SplunkRumBuilder {
+        self.spanSchedulingDelay = seconds
+        return self
+    }
+
+    @discardableResult
+    @objc
     public func build() -> Bool {
         return SplunkRum.create(beaconUrl: self.beaconUrl,
                                 rumAuth: self.rumAuth,
@@ -162,6 +170,7 @@ import Foundation
                                                slowRenderingDetectionEnabled: self.slowRenderingDetectionEnabled,
                                                slowFrameDetectionThresholdMs: self.slowFrameDetectionThresholdMs,
                                                frozenFrameDetectionThresholdMs: self.frozenFrameDetectionThresholdMs,
-                                               sessionSamplingRatio: self.sessionSamplingRatio))
+                                               sessionSamplingRatio: self.sessionSamplingRatio,
+                                               spanSchedulingDelay: self.spanSchedulingDelay))
     }
 }


### PR DESCRIPTION
Creates new options for:
* slowRenderingDetectionEnabled - allows user ability to disable slowRenderingDetection
* spanScheduleDelay - allows user to set their own schedule delay time interval for the BatchSpanProcessor

@theletterf the slowRenderingDetectionEnabled is already mentioned in the docs, but it claims that the default value is false. The default value should be changed to true, as that was the previous default behavior (the customer didn't have a way to turn it off) and it's Android's default behavior as well.