### PR TITLE
Implement Sampler protocol for SessionBasedSampler

### DIFF
--- a/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -35,6 +35,8 @@ var lastTimestamp: CFTimeInterval = CACurrentMediaTime()
 class SmokeTestUITests: XCTestCase {
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
+
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
         // In UI tests it is usually best to stop immediately when a failure occurs.

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
@@ -16,40 +16,66 @@ limitations under the License.
 
 import Foundation
 
-class SessionBasedSampler {
-    static var probability: Double = 1.0
-    private let sessionIdCallback: (() -> Void) = {
-        sessionShouldSample()
-    }
-
+class SessionBasedSampler: Sampler {
+    
+    var probability: Double = 1.0
+    var currentlySampled: Bool?
+    var lock: Lock = Lock()
+    
     init(ratio: Double) {
-        SessionBasedSampler.probability = ratio
-        addSessionIdCallback(sessionIdCallback)
+        probability = ratio
+        observeSessionIdChange()
     }
-
+    
+    func shouldSample(parentContext: SpanContext?, traceId: TraceId, name: String, kind: SpanKind, attributes: [String : AttributeValue], parentLinks: [SpanData.Link]) -> Decision {
+        return lock.withLock({
+            return self.getDecision()
+        })
+        
+    }
+    
+    var description: String {
+        return "SessionBasedSampler, Ratio: \(probability)"
+    }
+    
+    private func observeSessionIdChange() {
+        addSessionIdCallback { [weak self] in
+            self?.lock.withLockVoid {
+                self?.currentlySampled = self?.shouldSampleNewSession()
+            }
+        }
+    }
+    
+    private func getDecision() -> Decision {
+        
+        if let currentlySampled = self.currentlySampled {
+            return self.getDecision(shouldSample: currentlySampled)
+        }
+        
+        let newShouldSample = self.shouldSampleNewSession()
+        self.currentlySampled = newShouldSample
+        return self.getDecision(shouldSample: newShouldSample)
+    }
+    
+    private func getDecision(shouldSample: Bool) -> Decision {
+        return shouldSample ? Samplers.alwaysOnDecision : Samplers.alwaysOffDecision
+    }
+    
     /**Check if session will be sampled or not.**/
-    @discardableResult public class func sessionShouldSample() -> Bool {
-
+    private func shouldSampleNewSession() -> Bool {
+        
         var result = false
-        switch SessionBasedSampler.probability {
+        
+        switch probability {
         case 0.0:
             result = false
         case 1.0:
             result = true
         default:
-            result = Double.random(in: 0.0...1.0) <= SessionBasedSampler.probability
+            result = Double.random(in: 0.0...1.0) <= probability
         }
-
-        var parentSampler: Sampler
-        if result {
-            parentSampler = Samplers.parentBased(root: Samplers.alwaysOn, remoteParentSampled: Samplers.alwaysOn, remoteParentNotSampled: Samplers.alwaysOn, localParentSampled: Samplers.alwaysOn, localParentNotSampled: Samplers.alwaysOn)
-        } else {
-            parentSampler = Samplers.parentBased(root: Samplers.alwaysOff, remoteParentSampled: Samplers.alwaysOff, remoteParentNotSampled: Samplers.alwaysOff, localParentSampled: Samplers.alwaysOff, localParentNotSampled: Samplers.alwaysOff)
-        }
-
-        let tracerProvider = OpenTelemetry.instance.tracerProvider as! TracerProviderSdk
-        tracerProvider.updateActiveSampler(parentSampler)
+        
         return result
     }
-
+    
 }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
@@ -16,6 +16,11 @@ limitations under the License.
 
 import Foundation
 
+struct BoolDecision: Decision {
+    var isSampled: Bool
+    var attributes: [String : AttributeValue] = [:]
+}
+
 class SessionBasedSampler: Sampler {
     
     var probability: Double = 1.0
@@ -49,16 +54,16 @@ class SessionBasedSampler: Sampler {
     private func getDecision() -> Decision {
         
         if let currentlySampled = self.currentlySampled {
-            return self.getDecision(shouldSample: currentlySampled)
+            return self.getDecision(isSampled: currentlySampled)
         }
         
-        let newShouldSample = self.shouldSampleNewSession()
-        self.currentlySampled = newShouldSample
-        return self.getDecision(shouldSample: newShouldSample)
+        let isSampled = self.shouldSampleNewSession()
+        self.currentlySampled = isSampled
+        return self.getDecision(isSampled: isSampled)
     }
     
-    private func getDecision(shouldSample: Bool) -> Decision {
-        return shouldSample ? Samplers.alwaysOnDecision : Samplers.alwaysOffDecision
+    private func getDecision(isSampled: Bool) -> Decision {
+        return BoolDecision(isSampled: isSampled)
     }
     
     /**Check if session will be sampled or not.**/

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SessionBasedSampler.swift
@@ -54,15 +54,11 @@ class SessionBasedSampler: Sampler {
     private func getDecision() -> Decision {
         
         if let currentlySampled = self.currentlySampled {
-            return self.getDecision(isSampled: currentlySampled)
+            return BoolDecision(isSampled: currentlySampled)
         }
         
         let isSampled = self.shouldSampleNewSession()
         self.currentlySampled = isSampled
-        return self.getDecision(isSampled: isSampled)
-    }
-    
-    private func getDecision(isSampled: Bool) -> Decision {
         return BoolDecision(isSampled: isSampled)
     }
     

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -243,7 +243,7 @@ var splunkRumInitializeCalledTime = Date()
             .add(spanProcessor: GlobalAttributesProcessor())
             .with(sampler: SessionBasedSampler(ratio: options?.sessionSamplingRatio ?? 1.0))
             .build()
-        
+
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
 
         if options != nil {
@@ -341,7 +341,7 @@ var splunkRumInitializeCalledTime = Date()
             .add(spanProcessor: GlobalAttributesProcessor(appName: appName))
             .with(sampler: SessionBasedSampler(ratio: options.sessionSamplingRatio))
             .build()
-        
+
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
 
         configuredOptions = SplunkRumOptions(opts: options)

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/SplunkRum.swift
@@ -241,7 +241,9 @@ var splunkRumInitializeCalledTime = Date()
 
         let tracerProvider = TracerProviderBuilder()
             .add(spanProcessor: GlobalAttributesProcessor())
+            .with(sampler: SessionBasedSampler(ratio: options?.sessionSamplingRatio ?? 1.0))
             .build()
+        
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
 
         if options != nil {
@@ -252,13 +254,6 @@ var splunkRumInitializeCalledTime = Date()
         }
         if options?.environment != nil {
             setGlobalAttributes(["environment": options!.environment!])
-        }
-        if options?.sessionSamplingRatio != nil {
-            let samplingRatio = options!.sessionSamplingRatio
-            if samplingRatio >= 0.0 && samplingRatio <= 1.0 {
-                _ = SessionBasedSampler(ratio: samplingRatio)
-                SessionBasedSampler.sessionShouldSample()
-            }
         }
 
         if rumAuth.isEmpty {
@@ -344,19 +339,15 @@ var splunkRumInitializeCalledTime = Date()
 
         let tracerProvider = TracerProviderBuilder()
             .add(spanProcessor: GlobalAttributesProcessor(appName: appName))
+            .with(sampler: SessionBasedSampler(ratio: options.sessionSamplingRatio))
             .build()
+        
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
 
         configuredOptions = SplunkRumOptions(opts: options)
         setGlobalAttributes(options.globalAttributes)
         if let environment = options.environment {
             setGlobalAttributes(["environment": environment])
-        }
-
-        let samplingRatio = options.sessionSamplingRatio
-        if samplingRatio >= 0.0 && samplingRatio <= 1.0 {
-            _ = SessionBasedSampler(ratio: samplingRatio)
-            SessionBasedSampler.sessionShouldSample()
         }
 
         if rumAuth.isEmpty {

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/SessionSamplingTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/SessionSamplingTests.swift
@@ -29,10 +29,10 @@ class SessionSamplingTests: XCTestCase {
             .globalAttributes(globalAttributes: [:])
             .sessionSamplingRatio(samplingRatio: 0.2)
             .build()
-        
+
         let provider = OpenTelemetry.instance.tracerProvider as! TracerProviderSdk
         let sampler = provider.getActiveSampler() as! SessionBasedSampler
-        
+
         XCTAssertTrue(sampler.probability >= 0.0 && sampler.probability <= 1.0)
         XCTAssertEqual(sampler.probability, 0.2)
         resetRUM()
@@ -48,11 +48,11 @@ class SessionSamplingTests: XCTestCase {
             .globalAttributes(globalAttributes: [:])
             .sessionSamplingRatio(samplingRatio: 1.0)
             .build()
-        
+
         let provider = OpenTelemetry.instance.tracerProvider as! TracerProviderSdk
         let sampler = provider.getActiveSampler() as! SessionBasedSampler
         let shouldSample = sampler.shouldSample(parentContext: nil, traceId: .random(), name: "Span Example", kind: .client, attributes: [:], parentLinks: [])
-        
+
         XCTAssertTrue(shouldSample.isSampled)
         resetRUM()
     }
@@ -67,11 +67,11 @@ class SessionSamplingTests: XCTestCase {
             .globalAttributes(globalAttributes: [:])
             .sessionSamplingRatio(samplingRatio: 0.0)
             .build()
-        
+
         let provider = OpenTelemetry.instance.tracerProvider as! TracerProviderSdk
         let sampler = provider.getActiveSampler() as! SessionBasedSampler
         let shouldSample = sampler.shouldSample(parentContext: nil, traceId: .random(), name: "Span Example", kind: .client, attributes: [:], parentLinks: [])
-        
+
         XCTAssertFalse(shouldSample.isSampled)
         resetRUM()
     }
@@ -86,16 +86,16 @@ class SessionSamplingTests: XCTestCase {
             .globalAttributes(globalAttributes: [:])
             .sessionSamplingRatio(samplingRatio: 0.5)
             .build()
-        
+
         let provider = OpenTelemetry.instance.tracerProvider as! TracerProviderSdk
         let sampler = provider.getActiveSampler() as! SessionBasedSampler
-        
+
         func testSampling() -> Bool {
             _ = getRumSessionId(forceNewSessionId: true)
             let shouldSample = sampler.shouldSample(parentContext: nil, traceId: .random(), name: "Span Example", kind: .client, attributes: [:], parentLinks: [])
             return shouldSample.isSampled
         }
-        
+
         var countSpans = 0
         for _ in 1...100 where testSampling() {
             countSpans += 1


### PR DESCRIPTION
We are having some crashes that are being tracked on Crashlytics. Based on the stack trace, it appears that Splunk is attempting to change the sampler during session changes. I suspect that there are spans that are referencing the old sampler while Splunk is replacing them.

This pull request eliminates the constant need to replace samplers, as everything is now handled within the SessionBasedSampler class.

**Crash stack trace:**
```
Crashed: scheduler-thread
0  libsystem_kernel.dylib         0x7578 __pthread_kill + 8
1  libsystem_pthread.dylib        0x7118 pthread_kill + 268
2  libsystem_c.dylib              0x1d178 abort + 180
3  libswiftCore.dylib             0x3b8b98 swift::fatalError(unsigned int, char const*, ...) + 134
4  libswiftCore.dylib             0x3b8bb8 swift::warningv(unsigned int, char const*, char*) + 30
5  libswiftCore.dylib             0x3bd7c8 swift_deallocPartialClassInstance + 190
6  libswiftCore.dylib             0x3bd618 _swift_release_dealloc + 56
7  libswiftCore.dylib             0x3be43c bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 132
8  ******                      0x14ee5b4 specialized static SessionBasedSampler.sessionShouldSample() + 75 (TracerSharedState.swift:75)
9  ******                      0x14ea8e0 getRumSessionId(forceNewSessionId:) + 64 (Session.swift:64)
10 ******                      0x152c3bc GlobalAttributesProcessor.onStart(parentContext:span:) + 68 (InstrumentationUtils.swift:68)
11 ******                      0x152c2e8 protocol witness for SpanProcessor.onStart(parentContext:span:) in conformance GlobalAttributesProcessor + 15150240 (<compiler-generated>:15150240)
12 ******                      0x1500ee8 MultiSpanProcessor.onStart(parentContext:span:) + 37 (MultiSpanProcessor.swift:37)
13 ******                      0x15229a8 specialized static RecordEventsReadableSpan.startSpan(context:name:instrumentationScopeInfo:kind:parentContext:hasRemoteParent:spanLimits:spanProcessor:clock:resource:attributes:links:totalRecordedLinks:startTime:) + 189 (RecordEventsReadableSpan.swift:189)
14 ******                      0x1521e54 SpanBuilderSdk.startSpan() + 152 (SpanBuilderSdk.swift:152)
15 ******                      0x26e4508 startHttpSpan(request:) + 91 (NetworkInstrumentation.swift:91)
16 ******                      0x26e3754 NSURLSessionTask.splunk_swizzled_resume() + 156 (NetworkInstrumentation.swift:156)
17 ******                      0x26e3528 @objc NSURLSessionTask.splunk_swizzled_resume() + 33726176 (<compiler-generated>:33726176)
// ... private API call
29 libdispatch.dylib              0x2320 _dispatch_call_block_and_release + 32
30 libdispatch.dylib              0x3eac _dispatch_client_callout + 20
31 libdispatch.dylib              0xb534 _dispatch_lane_serial_drain + 668
32 libdispatch.dylib              0xc0a4 _dispatch_lane_invoke + 384
33 libdispatch.dylib              0x16cdc _dispatch_workloop_worker_thread + 648
34 libsystem_pthread.dylib        0xddc _pthread_wqthread + 288
35 libsystem_pthread.dylib        0xb7c start_wqthread + 8
```