### PR TITLE
MOB-3278 Lychee and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: ./fullbuild.sh
       - name: Smoke Test
         run: ./smoketest.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.2.1
   xcframework:
     runs-on: macos-11
     steps:
@@ -37,8 +39,3 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.1
         with:
           fail: true
-  codecov:
-    runs-on: macos-latest
-    steps:
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,16 @@ jobs:
         with:
           name: SplunkOtel.xcframework
           path: ./SplunkRumWorkspace/SplunkRum/xcframeworks/SplunkOtel.xcframework
+    check_links:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Link Checker
+          uses: lycheeverse/lychee-action@v1.5.1
+          with:
+            fail: true
+    codecov:
+      runs-on: macos-latest
+      steps:
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v1.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
         with:
           name: SplunkOtel.xcframework
           path: ./SplunkRumWorkspace/SplunkRum/xcframeworks/SplunkOtel.xcframework
-    check_links:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-        - name: Link Checker
-          uses: lycheeverse/lychee-action@v1.5.1
-          with:
-            fail: true
-    codecov:
-      runs-on: macos-latest
-      steps:
-        - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v1.2.1
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.1
+        with:
+          fail: true
+  codecov:
+    runs-on: macos-latest
+    steps:
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.2.1


### PR DESCRIPTION
Adds Lychee link checker and Codecov to the repo to be run with each build. GDI spec recommends these two apps on its repos.