### PR TITLE
Increasing sleep time on smokeUI startup test

### DIFF
--- a/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/SplunkRumWorkspace/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -43,7 +43,7 @@ class SmokeTestUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
-    let SLEEP_TIME: UInt32 = 30 // batch is currently every 5 so this should be plenty
+    let SLEEP_TIME: UInt32 = 60 // batch is currently every 5 so this should be plenty
 
     func testStartup() throws {
         // UI tests must launch the application that they test.


### PR DESCRIPTION
Increases the sleep time in the smokeUI test. Kind of a bandaid fix but hopefully should help the test fail less.