### PR TITLE
Dvernon/MOB-3294 Parsing traceparent

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
@@ -37,16 +37,11 @@ func endHttpSpan(span: Span, task: URLSessionTask) {
         span.setAttribute(key: Constants.AttributeNames.HTTP_STATUS_CODE, value: hr!.statusCode)
         // Blerg, looks like an iteration here since it is case sensitive and the case insensitive search assumes single value
         for (key, val) in hr!.allHeaderFields {
-            let keyStr = key as? String
-            if keyStr != nil {
-                if keyStr?.caseInsensitiveCompare("server-timing") == .orderedSame {
-                    let valStr = val as? String
-                    if valStr != nil {
-                        if valStr!.starts(with: "traceparent") {
-                            addLinkToSpan(span: span, valStr: valStr!)
-                        }
-                    }
-                }
+            if let keyStr = key as? String,
+               let valStr = val as? String,
+               keyStr.caseInsensitiveCompare("server-timing") == .orderedSame,
+               valStr.contains("traceparent") {
+                addLinkToSpan(span: span, valStr: valStr!)
             }
         }
     }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/NetworkInstrumentation.swift
@@ -41,7 +41,7 @@ func endHttpSpan(span: Span, task: URLSessionTask) {
                let valStr = val as? String,
                keyStr.caseInsensitiveCompare("server-timing") == .orderedSame,
                valStr.contains("traceparent") {
-                addLinkToSpan(span: span, valStr: valStr!)
+                addLinkToSpan(span: span, valStr: valStr)
             }
         }
     }

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/ServerTimingTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/ServerTimingTests.swift
@@ -89,7 +89,7 @@ class ServerTimingTests: XCTestCase {
         addLinkToSpan(span: span, valStr: "foo; bar=42, traceparent;desc=\"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\"")
         XCTAssertEqual(span.attrs["link.spanId"], "b7ad6b7169203331")
         XCTAssertEqual(span.attrs["link.traceId"], "0af7651916cd43dd8448eb211c80319c")
-        
+
         let span2 = TestSpan()
         addLinkToSpan(span: span2, valStr: "foo; bar=42, traceparent;desc=\"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\", origin; dur=1002")
         XCTAssertEqual(span2.attrs["link.spanId"], "b7ad6b7169203331")

--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/ServerTimingTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/ServerTimingTests.swift
@@ -84,6 +84,17 @@ class ServerTimingTests: XCTestCase {
         XCTAssertEqual(span.attrs["link.traceId"], "0af7651916cd43dd8448eb211c80319c")
 
     }
+    func testStringOrder() throws {
+        let span = TestSpan()
+        addLinkToSpan(span: span, valStr: "foo; bar=42, traceparent;desc=\"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\"")
+        XCTAssertEqual(span.attrs["link.spanId"], "b7ad6b7169203331")
+        XCTAssertEqual(span.attrs["link.traceId"], "0af7651916cd43dd8448eb211c80319c")
+        
+        let span2 = TestSpan()
+        addLinkToSpan(span: span2, valStr: "foo; bar=42, traceparent;desc=\"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\", origin; dur=1002")
+        XCTAssertEqual(span2.attrs["link.spanId"], "b7ad6b7169203331")
+        XCTAssertEqual(span2.attrs["link.traceId"], "0af7651916cd43dd8448eb211c80319c")
+    }
     func testDoesNotThrow() throws {
         let span = TestSpan()
         let tests = [


### PR DESCRIPTION
Fixes the parse on reading the traceparent so it will work even if "traceparent" isn't the first pattern in the string. Also cleaned up the syntax to make it a bit more "swifty" and remove some nested ifs.