### PR TITLE
Disable swiftlint unneeded_override as default auto-generated code has it

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,6 +13,7 @@ disabled_rules:
  - cyclomatic_complexity
  - missing_docs
  - switch_case_alignment
+ - unneeded_override
 # Not really sure about a bunch of these, just turning most stuff in the 'performance' and 'lint' categories
 opt_in_rules:
  - unowned_variable_capture


### PR DESCRIPTION
... we can always turn it back on later if desired.  This is a new behavior with a new version of swiftlint and it is causing builds to fail.