### PR TITLE
sampling: use session id for source of randomness

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRumTests/SessionSamplingTests.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRumTests/SessionSamplingTests.swift
@@ -38,6 +38,12 @@ class SessionSamplingTests: XCTestCase {
         resetRUM()
     }
 
+    func testSessionIdValue() throws {
+        // The result value is taken from the JS RUM SDK for the given input
+        let value = sessionIdValue(sessionId: "c06947ed1f53b1a69be3c6899bc11a3e")
+        XCTAssertEqual(value, 3742903036)
+    }
+
     /**Test Sending All Spans**/
     func testSessionBasedSampling100Pct() throws {
         // Forces RUM to reinitialze for testing


### PR DESCRIPTION
Use the session ID bytes for the source of randomness when making a sampling decision.

The algorithm for the session ID value calculation is the same as is in the [JS RUM SDK](https://github.com/signalfx/splunk-otel-js-web/blob/main/packages/web/src/SessionBasedSampler.ts#L88). This fixes the issue where, if sampling is used with the iOS SDK and inside a WebView, the SDKs come to a different sampling decision due to differing algorithms.


Note: session ID callbacks should have the session ID as a parameter, but this would be a breaking change in the public API, so I decided to keep the plain callbacks for now.