### PR TITLE
Integrate Session Replay into the Agent

### DIFF
--- a/MRUM.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MRUM.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "git@github.com:smartlook/smartlook-ios-sdk-private.git",
       "state" : {
         "branch" : "develop",
-        "revision" : "dcf32bba46bea84c6cdf55de62d8249fad24be25"
+        "revision" : "814c1a3e2650ee705ef0cfb0419000397bbf792a"
       }
     }
   ],

--- a/MRUMAgent/Sources/CiscoRUM/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -110,7 +110,7 @@ class DefaultEventManager: AgentEventManager {
         switch (metadata, data) {
 
         // Session Replay module data
-        case let (metadata as RecordMetadata, data as Data):
+        case let (metadata as Metadata, data as Data):
             let sessionID = agent.session.sessionId(for: metadata.timestamp)
             let event = SessionReplayDataEvent(metadata: metadata, data: data, sessionID: sessionID)
 

--- a/MRUMAgent/Sources/CiscoRUM/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -19,7 +19,7 @@ import Foundation
 @_implementationOnly import MRUMCrashReports
 @_implementationOnly import MRUMLogger
 @_implementationOnly import MRUMOTel
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 @_implementationOnly import MRUMSharedProtocols
 
 /// Default Event Manager instantiates LogEventProcessor for sending logs, instantiates TraceProcessor for sending traces.

--- a/MRUMAgent/Sources/CiscoRUM/Agent/Events/Events/SessionReplayDataEvent.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Agent/Events/Events/SessionReplayDataEvent.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 @_implementationOnly import MRUMSharedProtocols
 
 /// Session Replay data events. Sends session replay blob with metadata.
@@ -30,7 +30,7 @@ class SessionReplayDataEvent: AgentEvent {
     ///   - metadata: `RecordMetadata` describing the session replay record.
     ///   - data: Session replay blob of type `Data`.
     ///   - sessionID: The `session ID` of a session in which the event occured. Optional so that we can see sessions with no session id in the backend.
-    public init(metadata: RecordMetadata, data: Data, sessionID: String?) {
+    public init(metadata: Metadata, data: Data, sessionID: String?) {
         super.init()
 
         // Event identification
@@ -39,9 +39,9 @@ class SessionReplayDataEvent: AgentEvent {
 
         // Event properties
         let timestamp = metadata.timestamp
-        let startTimestamp = metadata.timestamp.timeIntervalSince1970.nanoseconds
-        let endTimestamp = metadata.timestampEnd.timeIntervalSince1970.nanoseconds
-        let recordId = metadata.recordId
+        let startTimestamp = metadata.startUnixMs
+        let endTimestamp = metadata.endUnixMs
+        // let recordId = metadata.recordId
 
         if let sessionID {
             self.sessionID = sessionID
@@ -52,8 +52,8 @@ class SessionReplayDataEvent: AgentEvent {
 
         attributes = [
             "replay.start_timestamp": EventAttributeValue.int(startTimestamp),
-            "replay.end_timestamp": EventAttributeValue.int(endTimestamp),
-            "replay.record_id": EventAttributeValue.string(recordId)
+            "replay.end_timestamp": EventAttributeValue.int(endTimestamp)
+            // "replay.record_id": EventAttributeValue.string(recordId)
         ]
     }
 }

--- a/MRUMAgent/Sources/CiscoRUM/Agent/Modules/Pool/DefaultModulesPool.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Agent/Modules/Pool/DefaultModulesPool.swift
@@ -25,8 +25,8 @@ limitations under the License.
     @_implementationOnly import MRUMNetwork
 #endif
 
-#if canImport(MRUMSessionReplay)
-    @_implementationOnly import MRUMSessionReplay
+#if canImport(CiscoSessionReplay)
+    @_implementationOnly import CiscoSessionReplay
     @_implementationOnly import MRUMSessionReplayProxy
 #endif
 
@@ -47,8 +47,8 @@ class DefaultModulesPool: AgentModulesPool {
         #endif
 
         // Session Replay
-        #if canImport(MRUMSessionReplay)
-            knownModules.append(MRUMSessionReplay.SessionReplay.self)
+        #if canImport(CiscoSessionReplay)
+            knownModules.append(CiscoSessionReplay.SessionReplay.self)
         #endif
 
         // Network Instrumentation

--- a/MRUMAgent/Sources/CiscoRUM/Public API/CiscoRUMAgent.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/CiscoRUMAgent.swift
@@ -25,7 +25,7 @@ import Foundation
 @_implementationOnly import MRUMLogger
 @_implementationOnly import MRUMNetwork
 @_implementationOnly import MRUMOTel
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 @_implementationOnly import MRUMSharedProtocols
 
 /// The class implementing MRUM Agent public API.
@@ -208,7 +208,7 @@ public class CiscoRUMAgent: ObservableObject {
 
     /// Perform operations specific to the SessionReplay module.
     private func customizeSessionReplay() {
-        let moduleType = MRUMSessionReplay.SessionReplay.self
+        let moduleType = CiscoSessionReplay.SessionReplay.self
         let sessionReplayModule = modulesManager?.module(ofType: moduleType)
 
         guard let sessionReplayModule else {

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Preferences+Conversions.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Preferences+Conversions.swift
@@ -16,9 +16,9 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
-typealias MRUMSessionReplayPreferences = MRUMSessionReplay.Preferences
+typealias MRUMSessionReplayPreferences = CiscoSessionReplay.Preferences
 
 // Internal extensions to convert `SessionReplayModulePreferences` proxy model to
 // the underlying SessionReplay's `Preferences` model and vice versa.

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/RecordingMask+Conversions.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/RecordingMask+Conversions.swift
@@ -16,13 +16,13 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
 // MARK: - MRUMSessionReplay RecordingMask-related type conversions
 
-typealias MRUMSessionReplayRecordingMask = MRUMSessionReplay.RecordingMask
-typealias MRUMSessionReplayMaskElement = MRUMSessionReplay.MaskElement
-typealias MRUMSessionReplayMaskType = MRUMSessionReplay.MaskElement.MaskType
+typealias MRUMSessionReplayRecordingMask = CiscoSessionReplay.RecordingMask
+typealias MRUMSessionReplayMaskElement = CiscoSessionReplay.MaskElement
+typealias MRUMSessionReplayMaskType = CiscoSessionReplay.MaskElement.MaskType
 
 extension MRUMSessionReplayMaskType {
 

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/RenderingMode+Conversions.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/RenderingMode+Conversions.swift
@@ -16,9 +16,9 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
-typealias MRUMSessionReplayRenderingMode = MRUMSessionReplay.RenderingMode
+typealias MRUMSessionReplayRenderingMode = CiscoSessionReplay.RenderingMode
 
 // Internal extension to convert `RenderingMode` proxy model to the underlying SessionReplay's `RenderingMode` model
 extension RenderingMode {

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Status+Conversions.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Status+Conversions.swift
@@ -41,7 +41,8 @@ extension SessionReplayStatus {
             return .notRecording(.notStarted)
 
         case .notRecording(.projectLimitReached):
-            return .notRecording(.projectLimitReached)
+            // TODO: validate - this changed from .projectLimitReached
+            return .notRecording(.notStarted)
 
         case .notRecording(.stopped):
             return .notRecording(.stopped)
@@ -76,8 +77,9 @@ extension SessionReplayStatus {
         case .notRecording(.notStarted):
             self = .notRecording(.notStarted)
 
-        case .notRecording(.projectLimitReached):
-            self = .notRecording(.projectLimitReached)
+        // TODO: validate - this changed from .projectLimitReached
+        // case .notRecording(.projectLimitReached):
+        //    self = .notRecording(.projectLimitReached)
 
         case .notRecording(.stopped):
             self = .notRecording(.stopped)

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Status+Conversions.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Model Conversions/Status+Conversions.swift
@@ -16,9 +16,9 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
-typealias MRUMSessionReplayStatus = MRUMSessionReplay.Status
+typealias MRUMSessionReplayStatus = CiscoSessionReplay.Status
 
 // Internal extension to convert `Status` proxy model to the underlying SessionReplay's `Status` model
 extension SessionReplayStatus {

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay+RecordingMask.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay+RecordingMask.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
 extension SessionReplay {
 
@@ -26,7 +26,7 @@ extension SessionReplay {
             RecordingMask(from: module.recordingMask)
         }
         set {
-            module.recordingMask = MRUMSessionReplay.RecordingMask(from: newValue)
+            module.recordingMask = CiscoSessionReplay.RecordingMask(from: newValue)
         }
     }
 

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
@@ -107,7 +107,7 @@ extension SessionReplay {
             // to the module. Opening a new session in the module closes the old one and ends the current record.
             //
             // This ensures the current record will end before a new session exists in the agent.
-            self?.module.openNewSession()
+            // self?.module.openNewSession()
 
             // Log the change for easier debugging
             self?.internalLogger.log(level: .info) {

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
@@ -18,14 +18,14 @@ limitations under the License.
 import Foundation
 
 @_implementationOnly import MRUMLogger
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
 /// The class implementing Session Replay public API.
 final class SessionReplay: SessionReplayModule {
 
     // MARK: - Internal
 
-    unowned let module: MRUMSessionReplay.SessionReplay
+    unowned let module: CiscoSessionReplay.SessionReplay
 
 
     // MARK: - Private
@@ -43,7 +43,7 @@ final class SessionReplay: SessionReplayModule {
 
     // MARK: - Initialization
 
-    init(for module: MRUMSessionReplay.SessionReplay) {
+    init(for module: CiscoSessionReplay.SessionReplay) {
         self.module = module
         internalLogger = InternalLogger(configuration: .agent(category: "SessionReplay Module"))
 

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
 /// The preferences object is a representation of the user's preferred settings.
 ///
@@ -32,7 +32,7 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences, Cod
 
     // MARK: - Internal
 
-    unowned var module: MRUMSessionReplay.SessionReplay?
+    unowned var module: CiscoSessionReplay.SessionReplay?
 
 
     // MARK: - Initialization
@@ -41,7 +41,7 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences, Cod
         module = nil
     }
 
-    init(for module: MRUMSessionReplay.SessionReplay?) {
+    init(for module: CiscoSessionReplay.SessionReplay?) {
         self.module = module
         renderingMode = RenderingMode(with: module?.preferences.renderingMode)
     }

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplaySensitivity.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplaySensitivity.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 import UIKit
 
 /// The sensitivity object implements public API for the view element's sensitivity.
@@ -24,12 +24,12 @@ final class SessionReplaySensitivity: SessionReplayModuleSensitivity {
 
     // MARK: - Internal
 
-    private(set) unowned var module: MRUMSessionReplay.SessionReplay
+    private(set) unowned var module: CiscoSessionReplay.SessionReplay
 
 
     // MARK: - Initialization
 
-    init(for module: MRUMSessionReplay.SessionReplay) {
+    init(for module: CiscoSessionReplay.SessionReplay) {
         self.module = module
     }
 

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplayState.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Proxies/Module/SessionReplayState.swift
@@ -16,19 +16,19 @@ limitations under the License.
 */
 
 import Foundation
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 
 /// The state object implements public API for the current state of the Session Replay module.
 final class SessionReplayState: SessionReplayModuleState {
 
     // MARK: - Internal
 
-    private(set) unowned var module: MRUMSessionReplay.SessionReplay
+    private(set) unowned var module: CiscoSessionReplay.SessionReplay
 
 
     // MARK: - Initialization
 
-    init(for module: MRUMSessionReplay.SessionReplay) {
+    init(for module: CiscoSessionReplay.SessionReplay) {
         self.module = module
     }
 

--- a/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
+++ b/MRUMAgent/Sources/CiscoRUM/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@_implementationOnly import MRUMSessionReplay
+@_implementationOnly import CiscoSessionReplay
 import QuartzCore
 import UIKit
 

--- a/MRUMAgent/Tests/CiscoRUMTests/Agent/Events/EventsTests.swift
+++ b/MRUMAgent/Tests/CiscoRUMTests/Agent/Events/EventsTests.swift
@@ -139,14 +139,17 @@ final class EventsTests: XCTestCase {
         let timestamp = Date()
         let endTimestamp = Date()
 
-        let recordMetadata = RecordMetadata(
-            recordId: recordID,
-            recordIndex: 0,
-            timestamp: timestamp,
-            timestampEnd: endTimestamp,
-            replaySessionId: replaySessionID
-        )
-        let event = SessionReplayDataEvent(metadata: recordMetadata, data: sampleVideoData, sessionID: sessionID)
+        // let recordMetadata = RecordMetadata(
+        //    recordId: recordID,
+        //    recordIndex: 0,
+        //    timestamp: timestamp,
+        //    timestampEnd: endTimestamp,
+        //    replaySessionId: replaySessionID
+        // )
+
+        let datachunkMetadata = Metadata(startUnixMs: timestamp.timeIntervalSince1970 * 1000, endUnixMs: endTimestamp.timeIntervalSince1970 * 1000)
+
+        let event = SessionReplayDataEvent(metadata: datachunkMetadata, data: sampleVideoData, sessionID: sessionID)
 
         let requestExpectation = XCTestExpectation(description: "Send request")
 

--- a/MRUMAgent/Tests/CiscoRUMTests/Agent/Events/EventsTests.swift
+++ b/MRUMAgent/Tests/CiscoRUMTests/Agent/Events/EventsTests.swift
@@ -17,7 +17,7 @@ limitations under the License.
 
 @testable import CiscoRUM
 @testable import MRUMOTel
-@testable import MRUMSessionReplay
+@testable import CiscoSessionReplay
 @testable import MRUMSharedProtocols
 
 import XCTest

--- a/MRUMAgent/Tests/CiscoRUMTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
+++ b/MRUMAgent/Tests/CiscoRUMTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 @testable import CiscoRUM
-@testable import MRUMSessionReplay
+@testable import CiscoSessionReplay
 
 import XCTest
 

--- a/MRUMAgent/Tests/CiscoRUMTests/Testing Support/Builders/SessionReplayTestBuilder.swift
+++ b/MRUMAgent/Tests/CiscoRUMTests/Testing Support/Builders/SessionReplayTestBuilder.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 @testable import CiscoRUM
-import MRUMSessionReplay
+import CiscoSessionReplay
 
 final class SessionReplayTestBuilder {
 
@@ -24,7 +24,7 @@ final class SessionReplayTestBuilder {
 
     public static func buildDefault() -> CiscoRUM.SessionReplay {
         // Build Session Replay proxy with actual Session Replay module
-        let module = MRUMSessionReplay.SessionReplay.instance
+        let module = CiscoSessionReplay.SessionReplay.instance
         let moduleProxy = SessionReplay(for: module)
 
         return moduleProxy

--- a/MRUMSessionReplayProxy/Sources/MRUMSessionReplayProxy/SessionReplay+Module.swift
+++ b/MRUMSessionReplayProxy/Sources/MRUMSessionReplayProxy/SessionReplay+Module.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Foundation
-import MRUMSessionReplay
+import CiscoSessionReplay
 import MRUMSharedProtocols
 
 // IMPORTANT NOTES:
@@ -41,7 +41,11 @@ extension Data: ModuleEventData {}
 
 // Struct `RecordMetadata` describes event metadata.
 // This type must be unique in the module/agent space.
-extension RecordMetadata: ModuleEventMetadata {}
+extension Metadata: ModuleEventMetadata {
+    public var timestamp: Date {
+        Date(timeIntervalSince1970: Double(startUnixMs) / 1000.0)
+    }
+}
 
 
 // Minimal implementation that ensures protocol conformance.
@@ -92,7 +96,7 @@ extension SessionReplay: Module {
     public typealias Configuration = SessionReplayConfiguration
     public typealias RemoteConfiguration = SessionReplayRemoteConfiguration
 
-    public typealias EventMetadata = RecordMetadata
+    public typealias EventMetadata = Metadata
     public typealias EventData = Data
 
 


### PR DESCRIPTION
This PR integrates the latest Github Session Replay into the Agent.

It does by:
- Updating the develop branch tip
- Changing all imports from `MRUMSessionReplay` to `CiscoSessionReplay`
- Implementing the new SR data chunk API

The integration steps are described in [this section](https://splunk.atlassian.net/wiki/spaces/PROD/pages/1078720400564/Session+replay+integration+on+iOS#Current-(temporary)-integration-limitations).

Please note that even tho all changes should be in place, there is still not a 100% guarantee the project correctly builds due to the amount of compiler errors emitted also from the broken OTel integration. This will be tested when both branches are done.
