### PR TITLE
DEMRUM-1181 Integrate opentelemetry-swift upstream

### DIFF
--- a/MRUM.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MRUM.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,156 @@
 {
   "pins" : [
     {
+      "identity" : "grpc-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift.git",
+      "state" : {
+        "revision" : "8c5e99d0255c373e0330730d191a3423c57373fb",
+        "version" : "1.24.2"
+      }
+    },
+    {
+      "identity" : "opentelemetry-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift",
+      "state" : {
+        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
+        "version" : "1.12.1"
+      }
+    },
+    {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
       "identity" : "smartlook-ios-sdk-private",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:smartlook/smartlook-ios-sdk-private.git",
       "state" : {
         "branch" : "develop",
         "revision" : "dcf32bba46bea84c6cdf55de62d8249fad24be25"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+        "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "e0165b53d49b413dd987526b641e05e246782685",
+        "version" : "2.5.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
+        "version" : "2.77.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
+        "version" : "1.35.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
+        "version" : "2.29.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "bbd5e63cf949b7db0c9edaf7a21e141c52afe214",
+        "version" : "1.23.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version" : "1.28.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/MRUMAgent/Tests/CiscoRUMTests/Agent/Resources/ResourcesTests.swift
+++ b/MRUMAgent/Tests/CiscoRUMTests/Agent/Resources/ResourcesTests.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@testable import AppDOpenTelemetrySdk
+@testable import OpenTelemetrySdk
 @testable import CiscoRUM
 @testable import MRUMOTel
 @testable import MRUMSharedProtocols

--- a/MRUMNetwork/Sources/MRUMNetwork/NetworkInstrumentation.swift
+++ b/MRUMNetwork/Sources/MRUMNetwork/NetworkInstrumentation.swift
@@ -19,12 +19,11 @@ limitations under the License.
 import Foundation
 import MRUMSharedProtocols
 import MRUMLogger
-import AppDOpenTelemetryApi
-import AppDURLSessionInstrumentation
-import AppDOpenTelemetryProtocolExporterHttp
-import AppDOpenTelemetrySdk
-import AppDResourceExtension
-import AppDSignPostIntegration
+import OpenTelemetryApi
+import URLSessionInstrumentation
+import OpenTelemetrySdk
+import ResourceExtension
+import SignPostIntegration
 
 public class NetworkInstrumentation {
     

--- a/MRUMOTel/Package.swift
+++ b/MRUMOTel/Package.swift
@@ -20,7 +20,11 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "MRUMOTelBackgroundExporter", path: "../MRUMOTelBackgroundExporter"),
-        .package(name: "MRUMLogger", path: "../MRUMLogger")
+        .package(name: "MRUMLogger", path: "../MRUMLogger"),
+        .package(
+            url: "https://github.com/open-telemetry/opentelemetry-swift",
+            exact: "1.12.1"
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -29,7 +33,11 @@ let package = Package(
             name: "MRUMOTel",
             dependencies: [
                 "MRUMOTelBackgroundExporter",
-                "MRUMLogger"
+                "MRUMLogger",
+                .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
+                .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
+                .product(name: "ResourceExtension", package: "opentelemetry-swift"),
+                .product(name: "SignPostIntegration", package: "opentelemetry-swift")
             ]),
 
         .testTarget(

--- a/MRUMOTel/Sources/MRUMOTel/Log Event Processor/OTLPLogEventProcessor+AgentEvent.swift
+++ b/MRUMOTel/Sources/MRUMOTel/Log Event Processor/OTLPLogEventProcessor+AgentEvent.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import AppDOpenTelemetryApi
+import OpenTelemetryApi
 import MRUMSharedProtocols
 
 extension OTLPLogEventProcessor {

--- a/MRUMOTel/Sources/MRUMOTel/Log Event Processor/OTLPLogEventProcessor.swift
+++ b/MRUMOTel/Sources/MRUMOTel/Log Event Processor/OTLPLogEventProcessor.swift
@@ -3,9 +3,9 @@
 //
 
 import Foundation
-import AppDOpenTelemetryApi
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDOpenTelemetrySdk
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
 import MRUMSharedProtocols
 import MRUMOTelBackgroundExporter
 import MRUMLogger

--- a/MRUMOTel/Sources/MRUMOTel/Resources/Resource+AgentResources.swift
+++ b/MRUMOTel/Sources/MRUMOTel/Resources/Resource+AgentResources.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 import MRUMSharedProtocols
-import AppDOpenTelemetryApi
-import AppDOpenTelemetrySdk
+import OpenTelemetryApi
+import OpenTelemetrySdk
 
 /// Builds OTel Resource object from AgentResources.
 extension Resource {

--- a/MRUMOTel/Sources/MRUMOTel/Trace Processor/OTLPTraceProcessor.swift
+++ b/MRUMOTel/Sources/MRUMOTel/Trace Processor/OTLPTraceProcessor.swift
@@ -3,9 +3,9 @@
 //
 
 import Foundation
-import AppDOpenTelemetryApi
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDOpenTelemetrySdk
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
 import MRUMSharedProtocols
 import MRUMOTelBackgroundExporter
 

--- a/MRUMOTel/Sources/MRUMOTel/Utils/AttributeValue+MrumEventAttributeValue.swift
+++ b/MRUMOTel/Sources/MRUMOTel/Utils/AttributeValue+MrumEventAttributeValue.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import MRUMSharedProtocols
-import AppDOpenTelemetryApi
+import OpenTelemetryApi
 
 extension AttributeValue {
     public init(_ eventAttributeValue: EventAttributeValue) {
@@ -19,7 +19,8 @@ extension AttributeValue {
             self = .double(eventAttributeValue)
 
         case let .data(eventAttributeValue):
-            self = .data(eventAttributeValue)
+            // ‼️ Placeholder solution
+            self = .string(eventAttributeValue.base64EncodedString())
         }
     }
 }

--- a/MRUMOTelBackgroundExporter/Package.swift
+++ b/MRUMOTelBackgroundExporter/Package.swift
@@ -19,7 +19,11 @@ let package = Package(
             ])
     ],
     dependencies: [
-        .package(name: "MRUMLogger", path: "../MRUMLogger")
+        .package(name: "MRUMLogger", path: "../MRUMLogger"),
+        .package(
+            url: "https://github.com/open-telemetry/opentelemetry-swift",
+            exact: "1.12.1"
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -27,7 +31,9 @@ let package = Package(
         .target(
             name: "MRUMOTelBackgroundExporter",
             dependencies: [
-                "MRUMLogger"
+                "MRUMLogger",
+                .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
+                .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift")
             ]),
 
         .testTarget(

--- a/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/logs/OTLPBackgroundHTTPLogExporter.swift
+++ b/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/logs/OTLPBackgroundHTTPLogExporter.swift
@@ -15,15 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDOpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
 import Foundation
 
 public class OTLPBackgroundHTTPLogExporter: OTLPBackgroundHTTPBaseExporter, LogRecordExporter {
 
     // MARK: - Implementation LogRecordExporter protocol
 
-    public func export(logRecords: [AppDOpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> AppDOpenTelemetrySdk.ExportResult {
+    public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
         let body = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
             request.resourceLogs = LogRecordAdapter.toProtoResourceRecordLog(logRecordList: logRecords)
         }
@@ -59,7 +59,7 @@ public class OTLPBackgroundHTTPLogExporter: OTLPBackgroundHTTPBaseExporter, LogR
         return .success
     }
 
-    public func forceFlush(explicitTimeout: TimeInterval?) -> AppDOpenTelemetrySdk.ExportResult {
+    public func forceFlush(explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
         let semaphore = DispatchSemaphore(value: 0)
 
         httpClient.flush {

--- a/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/metric/OTLPBackgroundHTTPMetricExporter.swift
+++ b/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/metric/OTLPBackgroundHTTPMetricExporter.swift
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDOpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
 import Foundation
 
 public class OTLPBackgroundHTTPMetricExporter: OTLPBackgroundHTTPBaseExporter, MetricExporter {
@@ -57,7 +57,7 @@ public class OTLPBackgroundHTTPMetricExporter: OTLPBackgroundHTTPBaseExporter, M
         return .success
     }
 
-    public func forceFlush(explicitTimeout: TimeInterval?) -> AppDOpenTelemetrySdk.ExportResult {
+    public func forceFlush(explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
         let semaphore = DispatchSemaphore(value: 0)
 
         httpClient.flush {

--- a/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
+++ b/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDOpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
 import Foundation
 
 public class OTLPBackgroundHTTPTraceExporter: OTLPBackgroundHTTPBaseExporter, SpanExporter {

--- a/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Models/RequestDescriptor.swift
+++ b/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/Models/RequestDescriptor.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import AppDOpenTelemetryProtocolExporterCommon
+import OpenTelemetryProtocolExporterCommon
 import Foundation
 
 /// Defines description of request used to upload exported file

--- a/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
+++ b/MRUMOTelBackgroundExporter/Sources/MRUMOTelBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import AppDOpenTelemetryProtocolExporterCommon
-import AppDSwiftProtobuf
+import OpenTelemetryProtocolExporterCommon
+import SwiftProtobuf
 import Foundation
 
 /// Basic implementation of exporters

--- a/MRUMSlowFrameDetector/Sources/MRUMSlowFrameDetector/ScreenName/ScreenManager.swift
+++ b/MRUMSlowFrameDetector/Sources/MRUMSlowFrameDetector/ScreenName/ScreenManager.swift
@@ -16,9 +16,8 @@ limitations under the License.
 */
 
 import Foundation
-import AppDOpenTelemetryApi
-import AppDOpenTelemetryProtocolExporterHttp
-import AppDOpenTelemetrySdk
+import OpenTelemetryApi
+import OpenTelemetrySdk
 
 
 // Global convenience functions to maintain compatibility with legacy code
@@ -133,7 +132,7 @@ public class ScreenManager: NSObject {
 
     // TODO: Hook this up with the real OTEL code
     private func emitScreenNameChangedSpan(oldName: String, newName: String) {
-        //AppDOpenTelemetrySdk.emitScreenNameChangedSpan(oldName: oldName, newName: newName)
+        //OpenTelemetrySdk.emitScreenNameChangedSpan(oldName: oldName, newName: newName)
         print("calling emitScreenNameChangedSpan")
     }
 


### PR DESCRIPTION
This PR replaces old adhoc created opentelemetry-swift files by integrating the upstream opentelemetry-swift instead.