### PR TITLE
fix: Make arguments of Span's '==' of type ‘Self’

### DIFF
--- a/SplunkRumWorkspace/SplunkRum/SplunkRum/OpenTelemetry/OpenTelemetryApi/Trace/Span.swift
+++ b/SplunkRumWorkspace/SplunkRum/SplunkRum/OpenTelemetry/OpenTelemetryApi/Trace/Span.swift
@@ -74,7 +74,7 @@ public extension Span {
         hasher.combine(context.spanId)
     }
 
-    static func == (lhs: Span, rhs: Span) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.context.spanId == rhs.context.spanId
     }
 }


### PR DESCRIPTION
Resolves a compilation failure in the upcoming Xcode 15.3