### PR TITLE
DEMRUM-1226: Update Crash Report data model

### DIFF
--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		4BB680F62B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */; };
 		4BB680FF2B7A7A53000A54D4 /* API-1.0-ModuleProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */; };
 		52286CB52CD5404A001F8A31 /* ScreenName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52286CB42CD54045001F8A31 /* ScreenName.swift */; };
+		BABAA26A2DADE0FF00F925E5 /* CrashReportDeviceStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */; };
 		C703FAAF2BA9D417000CC11B /* AgentAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */; };
 		C703FAB12BA9D41E000CC11B /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAB02BA9D41E000CC11B /* AppStateManager.swift */; };
 		C703FAB32BA9D424000CC11B /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAB22BA9D424000CC11B /* AppState.swift */; };
@@ -691,6 +692,7 @@
 		4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionReplayModule.swift"; sourceTree = "<group>"; };
 		4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-ModuleProxyTests.swift"; sourceTree = "<group>"; };
 		52286CB42CD54045001F8A31 /* ScreenName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenName.swift; sourceTree = "<group>"; };
+		BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportDeviceStats.swift; sourceTree = "<group>"; };
 		C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAppStateManager.swift; sourceTree = "<group>"; };
 		C703FAB02BA9D41E000CC11B /* AppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
 		C703FAB22BA9D424000CC11B /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -1848,6 +1850,7 @@
 		4B5A5C8C2D5E5686009DA0D5 /* SplunkCrashReports */ = {
 			isa = PBXGroup;
 			children = (
+				BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */,
 				4B5A5C862D5E5686009DA0D5 /* Extensions */,
 				4B5A5C872D5E5686009DA0D5 /* CrashReportConfig.swift */,
 				4B5A5C882D5E5686009DA0D5 /* CrashReportJSON.swift */,
@@ -3898,6 +3901,7 @@
 				4B96410A2D60FE8E009A2E7F /* CrashReports.swift in Sources */,
 				4B96410B2D60FE8E009A2E7F /* CrashReportKeys.swift in Sources */,
 				4B96410C2D60FE8E009A2E7F /* CrashReportJSON.swift in Sources */,
+				BABAA26A2DADE0FF00F925E5 /* CrashReportDeviceStats.swift in Sources */,
 				4B96410D2D60FE8E009A2E7F /* CrashReportConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportConfig.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportConfig.swift
@@ -40,7 +40,6 @@ public struct CrashReportsRemoteConfiguration: RemoteModuleConfiguration {
         let configuration: Configuration
     }
 
-
     // MARK: - Protocol compliance
 
     public var enabled: Bool
@@ -53,4 +52,3 @@ public struct CrashReportsRemoteConfiguration: RemoteModuleConfiguration {
         enabled = root.configuration.mrum.crashReporting.enabled
     }
 }
-

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportDeviceStats.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportDeviceStats.swift
@@ -40,8 +40,7 @@ public class CrashReportDeviceStats {
             return "Unknown"
         }
     }
-    
-    // https://stackoverflow.com/questions/5012886/determining-the-available-amount-of-ram-on-an-ios-device/8540665#8540665
+
     class var freeMemory: String {
         var usedBytes: Float = 0
         let totalBytes = Float(ProcessInfo.processInfo.physicalMemory)
@@ -50,10 +49,10 @@ public class CrashReportDeviceStats {
         let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
             $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
                 task_info(
-                        mach_task_self_,
-                        task_flavor_t(MACH_TASK_BASIC_INFO),
-                        $0,
-                        &count
+                    mach_task_self_,
+                    task_flavor_t(MACH_TASK_BASIC_INFO),
+                    $0,
+                    &count
                 )
             }
         }
@@ -65,5 +64,4 @@ public class CrashReportDeviceStats {
         let freeBytes = totalBytes - usedBytes
         return ByteCountFormatter.string(fromByteCount: Int64(freeBytes), countStyle: .memory)
     }
-
 }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportDeviceStats.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportDeviceStats.swift
@@ -1,0 +1,69 @@
+//
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import System
+import UIKit
+
+public class CrashReportDeviceStats {
+    class var batteryLevel: String {
+
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        let level = abs(UIDevice.current.batteryLevel * 100)
+        return "\(level)%"
+    }
+
+    class var freeDiskSpace: String {
+
+        do {
+            let systemAttributes = try FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory() as String)
+            let maybeFreeSpace = (systemAttributes[FileAttributeKey.systemFreeSize] as? NSNumber)?.int64Value
+            guard let freeSpace = maybeFreeSpace else {
+                return "Unknown"
+            }
+            return ByteCountFormatter.string(fromByteCount: freeSpace, countStyle: .file)
+        } catch {
+            return "Unknown"
+        }
+    }
+    
+    // https://stackoverflow.com/questions/5012886/determining-the-available-amount-of-ram-on-an-ios-device/8540665#8540665
+    class var freeMemory: String {
+        var usedBytes: Float = 0
+        let totalBytes = Float(ProcessInfo.processInfo.physicalMemory)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                task_info(
+                        mach_task_self_,
+                        task_flavor_t(MACH_TASK_BASIC_INFO),
+                        $0,
+                        &count
+                )
+            }
+        }
+        if kerr == KERN_SUCCESS {
+            usedBytes = Float(info.resident_size)
+        } else {
+            return "Unknown"
+        }
+        let freeBytes = totalBytes - usedBytes
+        return ByteCountFormatter.string(fromByteCount: Int64(freeBytes), countStyle: .memory)
+    }
+
+}

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportJSON.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportJSON.swift
@@ -20,24 +20,18 @@ import Foundation
 // JSON Support for Crash Reports.
 
 public class CrashReportJSON {
-    
+
     public static func convertDictionaryToJSONData(_ dictionary: [String: Any]) -> Data? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted) else {
-            
             return nil
         }
         return jsonData
     }
-    
+
     public static func convertDictionaryToJSONString(_ dictionary: [String: Any]) -> String? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted) else {
-            
             return nil
         }
-        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-            
-            return nil
-        }
-        return jsonString
+        return String(data: jsonData, encoding: .utf8)
     }
 }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportJSON.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportJSON.swift
@@ -21,14 +21,14 @@ import Foundation
 
 public class CrashReportJSON {
 
-    public static func convertDictionaryToJSONData(_ dictionary: [String: Any]) -> Data? {
+    public static func convertDictionaryToJSONData(_ dictionary: [CrashReportKeys: Any]) -> Data? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted) else {
             return nil
         }
         return jsonData
     }
 
-    public static func convertDictionaryToJSONString(_ dictionary: [String: Any]) -> String? {
+    public static func convertDictionaryToJSONString(_ dictionary: [CrashReportKeys: Any]) -> String? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted) else {
             return nil
         }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
@@ -23,8 +23,8 @@ public class CrashReportKeys {
     static let previousAppState = "ios.state"
     static let eventName = "device.app.crash"
 
-    static let timestamp = "crash.timestamp"
-    static let actualTimestamp = "crash.observedTimestamp"
+    static let crashTimestamp = "crash.timestamp"
+    static let currentTimestamp = "crash.observedTimestamp"
     static let freeDiskSpace = "crash.freeDiskSpace"
     static let batteryLevel = "crash.batteryLevel"
     static let freeMemory = "crash.freeMemory"
@@ -36,15 +36,14 @@ public class CrashReportKeys {
     static let signalName = "signalName"
     static let faultAddress = "crash.address"
 
-    static let exceptionName = "exceptionName"
-    static let exceptionReason = "exceptionReason"
-    static let exceptionStackFrames = "exceptionStackFrames"
+    static let exceptionName = "exception.type"
+    static let exceptionReason = "exception.message"
 
     static let threads = "exception.threads"
     static let images = "exception.images"
     static let details = "details"
     static let component = "component"
-    static let errortag = "error"
+    static let status = "status"
 
     // Stack Frame
     static let instructionPointer = "instructionPointer"
@@ -57,7 +56,6 @@ public class CrashReportKeys {
     static let isCrashedThread = "crashed"
 
     // Binary Image
-    static let codeType = "codeType"
     static let baseAddress = "baseAddress"
     static let offset = "offset"
     static let imageSize = "imageSize"

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
@@ -21,85 +21,49 @@ import Foundation
 
 public class CrashReportKeys {
     static let previousAppState = "ios.state"
+    static let eventName = "device.app.crash"
 
-    static let operatingSystem = "operatingSystem"
-    static let architecture = "architecture"
-    static let osVersion = "osVersion"
-    static let osBuild = "osBuild"
-    static let timestamp = "timestamp"
-    static let actualTimestamp = "actualTimestamp"
-    
-    static let hardwareModel = "hardwareModel"
-    static let cpuType = "cpuType"
-    static let cpuCount = "cpuCount"
-    static let cpuLogicalCount = "cpuLogicalCount"
-    
-    static let appBundleId = "appBundleId"
+    static let timestamp = "crash.timestamp"
+    static let actualTimestamp = "crash.observedTimestamp"
+    static let freeDiskSpace = "crash.freeDiskSpace"
+    static let batteryLevel = "crash.batteryLevel"
+    static let freeMemory = "crash.freeMemory"
     static let appVersion = "appVersion"
-    
-    static let processName = "processName"
-    static let processId = "processId"
-    static let processPath = "processPath"
-    static let parentProcessName = "parentProcessName"
-    static let parentProcessId = "parentProcessId"
-    static let isNative = "isNative"
-    
+
+    static let processPath = "crash.processPath"
+    static let isNative = "crash.isNative"
+
     static let signalName = "signalName"
-    static let signalCode = "signalCode"
-    static let faultAddress = "faultAddress"
-    
+    static let faultAddress = "crash.address"
+
     static let exceptionName = "exceptionName"
     static let exceptionReason = "exceptionReason"
     static let exceptionStackFrames = "exceptionStackFrames"
-    
-    static let threads = "threads"
-    static let images = "images"
+
+    static let threads = "exception.threads"
+    static let images = "exception.images"
     static let details = "details"
-    
-    // Register
-    static let registerName = "registerName"
-    static let registerValue = "registerValue"
-    
+    static let component = "component"
+    static let errortag = "error"
+
     // Stack Frame
     static let instructionPointer = "instructionPointer"
     static let imageName = "imageName"
     static let symbolName = "symbolName"
-    static let symbolOffset = "symbolOffset"
-    static let nearestSymbolOffset = "nearestSymbolOffset"
 
     // Thread
     static let threadNumber = "threadNumber"
     static let stackFrames = "stackFrames"
-    static let isCrashedThread = "isIssueThread"
-    static let isErrorThread = "isIssueThread"
-    static let isANRThread = "isIssueThread"
-    static let registers = "registers"
-    
-    // CPU Type
-    static let cType = "cpuType"
-    static let cSubType = "subType"
-    
+    static let isCrashedThread = "crashed"
+
     // Binary Image
     static let codeType = "codeType"
     static let baseAddress = "baseAddress"
+    static let offset = "offset"
     static let imageSize = "imageSize"
     static let imagePath = "imagePath"
     static let imageUUID = "imageUUID"
 
-    // Prior run holdover keys
-    static let majorVersionAtCrash = "appMajorVersionAtCrash"
-    static let minorVersionAtCrash = "appMinorVersionAtCrash"
-    static let systemVersionAtCrash = "osVersionAtCrash"
-
     // Primary group key
     static let crashReportMessageName = "ios.crash_report"
-    
-    // Logging keys
-    static let scopeName = "ios-mrum"
-    static let versionKey = "appdynamics.agent.version"
-    static let eventDomainKey = "event.domain"
-    static let eventNameKey = "event.name"
-    static let eventDomain = "mrum"
-    // TODO: MRUM_AC-985 - Change event.name value to device.app.crash
-    static let eventName = "device.app.crash"
 }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReportKeys.swift
@@ -19,49 +19,48 @@ import Foundation
 
 // Static strings for crash report keys
 
-public class CrashReportKeys {
-    static let previousAppState = "ios.state"
-    static let eventName = "device.app.crash"
+public enum CrashReportKeys: String {
+    case previousAppState = "ios.state"
 
-    static let crashTimestamp = "crash.timestamp"
-    static let currentTimestamp = "crash.observedTimestamp"
-    static let freeDiskSpace = "crash.freeDiskSpace"
-    static let batteryLevel = "crash.batteryLevel"
-    static let freeMemory = "crash.freeMemory"
-    static let appVersion = "appVersion"
+    case crashTimestamp = "crash.timestamp"
+    case currentTimestamp = "crash.observedTimestamp"
+    case freeDiskSpace = "crash.freeDiskSpace"
+    case batteryLevel = "crash.batteryLevel"
+    case freeMemory = "crash.freeMemory"
+    case appVersion = "appVersion"
 
-    static let processPath = "crash.processPath"
-    static let isNative = "crash.isNative"
+    case processPath = "crash.processPath"
+    case isNative = "crash.isNative"
 
-    static let signalName = "signalName"
-    static let faultAddress = "crash.address"
+    case signalName = "signalName"
+    case faultAddress = "crash.address"
 
-    static let exceptionName = "exception.type"
-    static let exceptionReason = "exception.message"
+    case exceptionName = "exception.type"
+    case exceptionReason = "exception.message"
 
-    static let threads = "exception.threads"
-    static let images = "exception.images"
-    static let details = "details"
-    static let component = "component"
-    static let status = "status"
+    case threads = "exception.threads"
+    case images = "exception.images"
+    case details = "details"
+    case component = "component"
+    case error = "error"
 
     // Stack Frame
-    static let instructionPointer = "instructionPointer"
-    static let imageName = "imageName"
-    static let symbolName = "symbolName"
+    case instructionPointer = "instructionPointer"
+    case imageName = "imageName"
+    case symbolName = "symbolName"
 
     // Thread
-    static let threadNumber = "threadNumber"
-    static let stackFrames = "stackFrames"
-    static let isCrashedThread = "crashed"
+    case threadNumber = "threadNumber"
+    case stackFrames = "stackFrames"
+    case isCrashedThread = "crashed"
 
     // Binary Image
-    static let baseAddress = "baseAddress"
-    static let offset = "offset"
-    static let imageSize = "imageSize"
-    static let imagePath = "imagePath"
-    static let imageUUID = "imageUUID"
+    case baseAddress = "baseAddress"
+    case offset = "offset"
+    case imageSize = "imageSize"
+    case imagePath = "imagePath"
+    case imageUUID = "imageUUID"
 
     // Primary group key
-    static let crashReportMessageName = "ios.crash_report"
+    case crashReportMessageName = "ios.crash_report"
 }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Module.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Module.swift
@@ -26,7 +26,7 @@ extension String: ModuleEventData {}
 /// Describes the Crash Report event metadata.
 public struct CrashReportsMetadata: ModuleEventMetadata {
     public var timestamp: Date = Date()
-    public var eventName: String = CrashReportKeys.eventName
+    public var eventName: String = "device.app.crash"
 }
 
 extension CrashReports : Module {

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Module.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Module.swift
@@ -25,12 +25,12 @@ extension String: ModuleEventData {}
 
 /// Describes the Crash Report event metadata.
 public struct CrashReportsMetadata: ModuleEventMetadata {
-    public var timestamp: Date = Date()
+    public var timestamp = Date()
     public var eventName: String = "device.app.crash"
 }
 
-extension CrashReports : Module {
-    
+extension CrashReports: Module {
+
     // MARK: - Module types
 
     public typealias Configuration = CrashReportsConfiguration
@@ -38,7 +38,6 @@ extension CrashReports : Module {
 
     public typealias EventMetadata = CrashReportsMetadata
     public typealias EventData = String
-
 
     // MARK: - Module event data publishing
 

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -221,7 +221,6 @@ public class CrashReports {
         }
     }
 
-
     // Report formatting
 
     private func stackFramesFromCrashReport(report: SPLKPLCrashReport) -> [CrashReportKeys: Any] {
@@ -253,26 +252,21 @@ public class CrashReports {
             formatter.dateFormat = "yyyy-MM-dd HH:mm:ss ZZZZZ"
             reportDict[.currentTimestamp] = formatter.string(from: Date())
         }
-
         if report.applicationInfo != nil {
             reportDict[.appVersion] = report.applicationInfo.applicationMarketingVersion
         }
-
         if report.hasProcessInfo {
             reportDict[.processPath] = report.processInfo.processPath
             reportDict[.isNative] = report.processInfo.native ? "1" : "0"
         }
-
         if report.signalInfo != nil {
             reportDict[.signalName] = report.signalInfo.name
             reportDict[.faultAddress] = String(report.signalInfo.address)
         }
-
         if report.hasExceptionInfo {
             reportDict[.exceptionName] = report.exceptionInfo.exceptionName ?? ""
             reportDict[.exceptionReason] = report.exceptionInfo.exceptionReason ?? ""
         }
-
         if report.customData != nil {
             let customData = NSKeyedUnarchiver.unarchiveObject(with: report.customData) as? [CrashReportKeys: String]
             if customData != nil {
@@ -305,13 +299,10 @@ public class CrashReports {
             switch appState {
             case "active":
                 crashPayload[.previousAppState] = "foreground"
-
             case "inactive":
                 crashPayload[.previousAppState] = "background"
-
             case "terminate":
                 crashPayload[.previousAppState] = "background"
-
             default:
                 crashPayload[.previousAppState] = appState
             }
@@ -326,7 +317,6 @@ public class CrashReports {
         var isFirstTime = true
 
         guard let frames = frames as? [SPLKPLCrashReportStackFrameInfo] else {
-            // TODO: - Check the correctness of the return value.
             internalLogger.log(level: .error) {
                 "CrashReporter received incorrect stackFrame type."
             }

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -91,7 +91,7 @@ public class CrashReports {
             let stackFrames = stackFramesFromCrashReport(report: report)
 
             // At this point we should send the report to the collector
-            let reportPayload =  formatCrashReport(report: report, stackFrames: stackFrames)
+            let reportPayload = formatCrashReport(report: report, stackFrames: stackFrames)
             let jsonPayload = CrashReportJSON.convertDictionaryToJSONString(reportPayload)
 
             guard let jsonPayload else {
@@ -136,7 +136,7 @@ public class CrashReports {
 
     // Starts up crash reporter if enable is true and no debugger attached
     private func initializeCrashReporter() -> Bool {
-        
+
         guard crashReporter != nil else {
             self.internalLogger.log(level: .warn) {
                 "Could not enable crash reporter: Not Installed"
@@ -161,7 +161,7 @@ public class CrashReports {
         }
         return true
     }
-    
+
     // Returns true if debugger is attached
     private func isDebuggerAttached() -> Bool {
         var debuggerIsAttached = false

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -81,6 +81,7 @@ public class CrashReports {
         }
 
         do {
+            allUsedImageNames.removeAll()
             let data = try crashReporter?.loadPendingCrashReportDataAndReturnError()
 
             // Retrieving crash reporter data.


### PR DESCRIPTION
- Modified the Crash Report payload to match the new Splunk Crash Reporting data model
- Cleaned up unused names CrashReportKeys
- Added support for collecting device stats, from original splunk agent
