### PR TITLE
DEMRUM-1683: Implement SessionState and related logic

### DIFF
--- a/Applications/DevelApp/DevelApp/ContentView.swift
+++ b/Applications/DevelApp/DevelApp/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
 
     // MARK: - Identifiers
 
-    @State private var sessionId = SplunkRum.instance?.session.currentSessionId ?? "nil"
+    @State private var sessionId = SplunkRum.instance?.session.state.id ?? "nil"
     @State private var userTrackingMode = SplunkRum.instance?.user.state.trackingMode ?? .default
     @State private var agentStatus = SplunkRum.instance?.state.status ?? .notRunning(.notInstalled)
 

--- a/Splunk.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Splunk.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3eb9999c68975bd1cc59f9b5d725dd6b3d40dee008aa9ee04c4b4fbde03c3c1f",
+  "originHash" : "086cbf8ba05fee02327b46721643451f4c667c178e559c7a6787221339f1d7b4",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -31,7 +31,7 @@
     {
       "identity" : "smartlook-ios-sdk-private",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/smartlook/smartlook-ios-sdk-private",
+      "location" : "git@github.com:smartlook/smartlook-ios-sdk-private.git",
       "state" : {
         "branch" : "develop",
         "revision" : "814c1a3e2650ee705ef0cfb0419000397bbf792a"

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
@@ -27,7 +27,9 @@ public final class Session {
 
     // MARK: - State
 
-    public private(set) lazy var state: SessionState = SessionState(for: owner)
+    /// An object that reflects the current session's state.
+    public private(set) lazy var state = SessionState(for: owner)
+
 
     // MARK: - Initialization
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-SessionState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-SessionState.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2024 Splunk Inc.
+Copyright 2025 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,19 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Foundation
-
-/// A session object is a representation of the current user session.
-public final class Session {
+/// A state object that reflects the current session's state.
+public final class SessionState {
 
     // MARK: - Internal
 
     private unowned let owner: SplunkRum
 
-
-    // MARK: - State
-
-    public private(set) lazy var state: SessionState = SessionState(for: owner)
 
     // MARK: - Initialization
 
@@ -36,18 +30,19 @@ public final class Session {
     }
 }
 
+public extension SessionState {
 
-public extension Session {
+    // MARK: - Public properties
 
-    // MARK: - Identifier
-
-    /// Identification of recorded session in given time.
+    /// Identification of recorded session.
     ///
-    /// Some events can be tracked with a delay caused by, e.g., its asynchronous pre-processing
-    /// or an application crash.
-    ///
-    /// This method returns the respective session ID for the timestamp the event originates.
-    func sessionId(for timestamp: Date) -> String? {
-        owner.currentSession.sessionId(for: timestamp)
+    /// When the agent is initialized, there is always some session ID.
+    var id: String {
+        owner.currentSession.currentSessionId
+    }
+
+    /// Value of the currently used session sampling rate.
+    var samplingRate: Double {
+        owner.agentConfiguration.sessionSamplingRate
     }
 }

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -181,16 +181,17 @@
 		4BB680F52B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680E12B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift */; };
 		4BB680F62B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */; };
 		4BB680FF2B7A7A53000A54D4 /* API-1.0-ModuleProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */; };
-		520067082DAED31F00444346 /* SlowFrameDetectorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520067072DAED2F600444346 /* SlowFrameDetectorConfiguration.swift */; };
-		520067092DAED31F00444346 /* SlowFrameDetector+Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520067062DAED2F600444346 /* SlowFrameDetector+Module.swift */; };
-		5200670B2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5200670A2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift */; };
 		4BF895742DAD7C2100E171A4 /* SplunkConfigurationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF895732DAD7C2100E171A4 /* SplunkConfigurationHandler.swift */; };
 		4BF8957F2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF8957D2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift */; };
 		4BF895812DAD987D00E171A4 /* RemoteConfigurationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF895802DAD987D00E171A4 /* RemoteConfigurationModel.swift */; };
+		4BF895AD2DB3CC7D00E171A4 /* API-1.0-SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF895AC2DB3CC7D00E171A4 /* API-1.0-SessionState.swift */; };
+		520067082DAED31F00444346 /* SlowFrameDetectorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520067072DAED2F600444346 /* SlowFrameDetectorConfiguration.swift */; };
+		520067092DAED31F00444346 /* SlowFrameDetector+Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520067062DAED2F600444346 /* SlowFrameDetector+Module.swift */; };
+		5200670B2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5200670A2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift */; };
 		52286CB52CD5404A001F8A31 /* ScreenName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52286CB42CD54045001F8A31 /* ScreenName.swift */; };
-		BABAA26A2DADE0FF00F925E5 /* CrashReportDeviceStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */; };
 		522A70B92DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522A70B82DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift */; };
 		522A70BB2DAD9F23008A2479 /* OTelDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522A70BA2DAD9F23008A2479 /* OTelDestination.swift */; };
+		BABAA26A2DADE0FF00F925E5 /* CrashReportDeviceStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */; };
 		C703FAAF2BA9D417000CC11B /* AgentAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */; };
 		C703FAB12BA9D41E000CC11B /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAB02BA9D41E000CC11B /* AppStateManager.swift */; };
 		C703FAB32BA9D424000CC11B /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAB22BA9D424000CC11B /* AppState.swift */; };
@@ -749,16 +750,17 @@
 		4BB680E12B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionReplayStatus.swift"; sourceTree = "<group>"; };
 		4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionReplayModule.swift"; sourceTree = "<group>"; };
 		4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-ModuleProxyTests.swift"; sourceTree = "<group>"; };
-		520067062DAED2F600444346 /* SlowFrameDetector+Module.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SlowFrameDetector+Module.swift"; sourceTree = "<group>"; };
-		520067072DAED2F600444346 /* SlowFrameDetectorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetectorConfiguration.swift; sourceTree = "<group>"; };
-		5200670A2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMetadataSlowFrameDetector.swift; sourceTree = "<group>"; };
 		4BF895732DAD7C2100E171A4 /* SplunkConfigurationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkConfigurationHandler.swift; sourceTree = "<group>"; };
 		4BF8957D2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkConfigurationHandlerTests.swift; sourceTree = "<group>"; };
 		4BF895802DAD987D00E171A4 /* RemoteConfigurationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationModel.swift; sourceTree = "<group>"; };
+		4BF895AC2DB3CC7D00E171A4 /* API-1.0-SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionState.swift"; sourceTree = "<group>"; };
+		520067062DAED2F600444346 /* SlowFrameDetector+Module.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SlowFrameDetector+Module.swift"; sourceTree = "<group>"; };
+		520067072DAED2F600444346 /* SlowFrameDetectorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetectorConfiguration.swift; sourceTree = "<group>"; };
+		5200670A2DAEE2A900444346 /* EventMetadataSlowFrameDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMetadataSlowFrameDetector.swift; sourceTree = "<group>"; };
 		52286CB42CD54045001F8A31 /* ScreenName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenName.swift; sourceTree = "<group>"; };
-		BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportDeviceStats.swift; sourceTree = "<group>"; };
 		522A70B82DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetectorDestination.swift; sourceTree = "<group>"; };
 		522A70BA2DAD9F23008A2479 /* OTelDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTelDestination.swift; sourceTree = "<group>"; };
+		BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportDeviceStats.swift; sourceTree = "<group>"; };
 		C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAppStateManager.swift; sourceTree = "<group>"; };
 		C703FAB02BA9D41E000CC11B /* AppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
 		C703FAB22BA9D424000CC11B /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -2907,6 +2909,7 @@
 				2A03CF5A2D9C311800CF3BC9 /* API-1.0-EndpointConfiguration.swift */,
 				2AC68DA62D9E77970086EEF7 /* API-1.0-RuntimeState.swift */,
 				E4F2E50F2B1737F2006EBA69 /* API-1.0-Session.swift */,
+				4BF895AC2DB3CC7D00E171A4 /* API-1.0-SessionState.swift */,
 				E4F2E4FF2B172A64006EBA69 /* API-1.0-User.swift */,
 				E4F3ACB52DA7B7C2007EFC0A /* API-1.0-UserPreferences.swift */,
 				E4F3ACB72DA7B7F3007EFC0A /* API-1.0-UserState.swift */,
@@ -3907,6 +3910,7 @@
 				2AB51E992B7A670600307B77 /* DeviceInfo.swift in Sources */,
 				E4EE9ED02BA330AE0000D594 /* SessionReplayNonOperational+RecordingMask.swift in Sources */,
 				E4134BAB2BC6AC5400F0D2FC /* API-1.0-Status.swift in Sources */,
+				4BF895AD2DB3CC7D00E171A4 /* API-1.0-SessionState.swift in Sources */,
 				4BB680F52B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift in Sources */,
 				E4F3ACB82DA7B800007EFC0A /* API-1.0-UserState.swift in Sources */,
 				E4E4B1122BA19A5B001CB6B3 /* SessionReplay.swift in Sources */,

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
@@ -61,7 +61,7 @@ final class EventsTests: XCTestCase {
     // MARK: - Testing Event manual events
 
     func testSessionStartEvent() throws {
-        let sessionID = try XCTUnwrap(agent?.session.currentSessionId)
+        let sessionID = try XCTUnwrap(agent?.session.state.id)
         let timestamp = Date()
         let userID = try XCTUnwrap(agent?.currentUser.userIdentifier)
 
@@ -139,7 +139,7 @@ final class EventsTests: XCTestCase {
     // MARK: - Testing immediate and background processing
 
     func testImmediateProcessing() throws {
-        let sessionID = try XCTUnwrap(agent?.session.currentSessionId)
+        let sessionID = try XCTUnwrap(agent?.session.state.id)
         let userID = try XCTUnwrap(agent?.user.identifier)
         let timestamp = Date()
 
@@ -163,7 +163,7 @@ final class EventsTests: XCTestCase {
     }
 
     func testBackgroundProcessing() throws {
-        let sessionID = try XCTUnwrap(agent?.session.currentSessionId)
+        let sessionID = try XCTUnwrap(agent?.session.state.id)
         let userID = try XCTUnwrap(agent?.user.identifier)
         let timestamp = Date()
 
@@ -188,7 +188,7 @@ final class EventsTests: XCTestCase {
 
     func testDuplicateSessionStartEvents() throws {
         let agent = try XCTUnwrap(agent)
-        let sessionID = try XCTUnwrap(agent.session.currentSessionId)
+        let sessionID = try XCTUnwrap(agent.session.state.id)
         let eventManager = try XCTUnwrap(agent.eventManager as? DefaultEventManager)
 
         let eventsModel = eventManager.eventsModel

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-SessionTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-SessionTests.swift
@@ -28,9 +28,12 @@ final class API10SessionTests: XCTestCase {
         let session = agent.session
         XCTAssertNotNil(session)
 
-        // Properties (READ)
-        let currentSessionId = session.currentSessionId
+        // State properties (READ)
+        let currentSessionId = session.state.id
         XCTAssertNotNil(currentSessionId)
+
+        let currentSamplingRate = session.state.samplingRate
+        XCTAssertNotNil(currentSamplingRate)
 
         // Methods
         let sessionId = session.sessionId(for: Date())


### PR DESCRIPTION
This PR implements new `SessionState` container as per [these docs](https://splunk.atlassian.net/wiki/spaces/PROD/pages/1078750096708/iOS+agent+API#State) (the links in related ticket are wrong). Note that it does not implement the proposed constructor as it doesn't make contextual sense.

One thing to consider is the unification of docc of the `samplingRate` properties in `SessionState` and `AgentConfiguration`.