### PR TITLE
DEMRUM-772 Add IgnoreURLs support to Network Instrumentation

### DIFF
--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -12,8 +12,6 @@
 		2A03CF5D2D9C315C00CF3BC9 /* API-1.0-AgentConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03CF5C2D9C315000CF3BC9 /* API-1.0-AgentConfigurationError.swift */; };
 		2A03CF5F2D9C31C100CF3BC9 /* API-1.0-AgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03CF5E2D9C317D00CF3BC9 /* API-1.0-AgentConfiguration.swift */; };
 		2A1673CD2BA1F52600F85698 /* EventsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1673CC2BA1F52600F85698 /* EventsModel.swift */; };
-		2A2926352DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */; };
-		2A2926372DAD11C800AB6F03 /* AttributeCheckerLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */; };
 		2A1789B72DA3CDA900EC548B /* AppStartSimulations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789B52DA3CDA900EC548B /* AppStartSimulations.swift */; };
 		2A1789BB2DA3CDD300EC548B /* AppStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789B92DA3CDD300EC548B /* AppStartTests.swift */; };
 		2A1789C02DA3CDEB00EC548B /* InitializeTests+Checks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789BE2DA3CDEB00EC548B /* InitializeTests+Checks.swift */; };
@@ -22,6 +20,8 @@
 		2A1789C82DA3D62100EC548B /* AgentInitializeSpanData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789C42DA3D62100EC548B /* AgentInitializeSpanData.swift */; };
 		2A1789C92DA3D62100EC548B /* AppStartEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789C52DA3D62100EC548B /* AppStartEvent.swift */; };
 		2A1789CA2DA3D62100EC548B /* AppStartSpanData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789C62DA3D62100EC548B /* AppStartSpanData.swift */; };
+		2A2926352DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */; };
+		2A2926372DAD11C800AB6F03 /* AttributeCheckerLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */; };
 		2A30EE1C2BD7AEDD008557DD /* NOTICES in Resources */ = {isa = PBXBuildFile; fileRef = 2A30EE1B2BD7AECE008557DD /* NOTICES */; };
 		2A5949DB2DA3FC2100F2E857 /* SplunkStdoutSpanExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5949D92DA3FC2100F2E857 /* SplunkStdoutSpanExporter.swift */; };
 		2A5949DC2DA3FC2100F2E857 /* SplunkStdoutLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5949D82DA3FC2100F2E857 /* SplunkStdoutLogExporter.swift */; };
@@ -188,6 +188,8 @@
 		52286CB52CD5404A001F8A31 /* ScreenName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52286CB42CD54045001F8A31 /* ScreenName.swift */; };
 		522A70B92DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522A70B82DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift */; };
 		522A70BB2DAD9F23008A2479 /* OTelDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522A70BA2DAD9F23008A2479 /* OTelDestination.swift */; };
+		BAAC20C22DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC20C12DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift */; };
+		BAAC20C42DB9BB5E00BC8B60 /* IgnoreURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC20C32DB9BB5E00BC8B60 /* IgnoreURLsTests.swift */; };
 		BABAA26A2DADE0FF00F925E5 /* CrashReportDeviceStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */; };
 		C703FAAF2BA9D417000CC11B /* AgentAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */; };
 		C703FAB12BA9D41E000CC11B /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C703FAB02BA9D41E000CC11B /* AppStateManager.swift */; };
@@ -574,8 +576,6 @@
 		2A03CF5C2D9C315000CF3BC9 /* API-1.0-AgentConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-AgentConfigurationError.swift"; sourceTree = "<group>"; };
 		2A03CF5E2D9C317D00CF3BC9 /* API-1.0-AgentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-AgentConfiguration.swift"; sourceTree = "<group>"; };
 		2A1673CC2BA1F52600F85698 /* EventsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsModel.swift; sourceTree = "<group>"; };
-		2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeCheckerSpanExporter.swift; sourceTree = "<group>"; };
-		2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeCheckerLogExporter.swift; sourceTree = "<group>"; };
 		2A1789B52DA3CDA900EC548B /* AppStartSimulations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartSimulations.swift; sourceTree = "<group>"; };
 		2A1789B92DA3CDD300EC548B /* AppStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartTests.swift; sourceTree = "<group>"; };
 		2A1789BD2DA3CDEB00EC548B /* InitializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializeTests.swift; sourceTree = "<group>"; };
@@ -584,6 +584,8 @@
 		2A1789C42DA3D62100EC548B /* AgentInitializeSpanData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInitializeSpanData.swift; sourceTree = "<group>"; };
 		2A1789C52DA3D62100EC548B /* AppStartEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartEvent.swift; sourceTree = "<group>"; };
 		2A1789C62DA3D62100EC548B /* AppStartSpanData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartSpanData.swift; sourceTree = "<group>"; };
+		2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeCheckerSpanExporter.swift; sourceTree = "<group>"; };
+		2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeCheckerLogExporter.swift; sourceTree = "<group>"; };
 		2A30EE1B2BD7AECE008557DD /* NOTICES */ = {isa = PBXFileReference; lastKnownFileType = text; path = NOTICES; sourceTree = "<group>"; };
 		2A5949D82DA3FC2100F2E857 /* SplunkStdoutLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkStdoutLogExporter.swift; sourceTree = "<group>"; };
 		2A5949D92DA3FC2100F2E857 /* SplunkStdoutSpanExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkStdoutSpanExporter.swift; sourceTree = "<group>"; };
@@ -758,6 +760,8 @@
 		52286CB42CD54045001F8A31 /* ScreenName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenName.swift; sourceTree = "<group>"; };
 		522A70B82DAD9EE3008A2479 /* SlowFrameDetectorDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowFrameDetectorDestination.swift; sourceTree = "<group>"; };
 		522A70BA2DAD9F23008A2479 /* OTelDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTelDestination.swift; sourceTree = "<group>"; };
+		BAAC20C12DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentationIgnoreURLs.swift; sourceTree = "<group>"; };
+		BAAC20C32DB9BB5E00BC8B60 /* IgnoreURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreURLsTests.swift; sourceTree = "<group>"; };
 		BABAA2692DADE0FF00F925E5 /* CrashReportDeviceStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportDeviceStats.swift; sourceTree = "<group>"; };
 		C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAppStateManager.swift; sourceTree = "<group>"; };
 		C703FAB02BA9D41E000CC11B /* AppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
@@ -1101,15 +1105,6 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		2A2926342DAD114900AB6F03 /* Attribute Checker Exporters */ = {
-			isa = PBXGroup;
-			children = (
-				2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */,
-				2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */,
-			);
-			path = "Attribute Checker Exporters";
-			sourceTree = "<group>";
-		};
 		2A1789B62DA3CDA900EC548B /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -1144,6 +1139,15 @@
 				2A1789C62DA3D62100EC548B /* AppStartSpanData.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		2A2926342DAD114900AB6F03 /* Attribute Checker Exporters */ = {
+			isa = PBXGroup;
+			children = (
+				2A2926362DAD11C100AB6F03 /* AttributeCheckerLogExporter.swift */,
+				2A2926332DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift */,
+			);
+			path = "Attribute Checker Exporters";
 			sourceTree = "<group>";
 		};
 		2A5949DA2DA3FC2100F2E857 /* Stdout Exporters */ = {
@@ -1743,6 +1747,7 @@
 		4B5A5B8E2D5E4C79009DA0D5 /* SplunkNetwork */ = {
 			isa = PBXGroup;
 			children = (
+				BAAC20C12DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift */,
 				4B5A5B8A2D5E4C79009DA0D5 /* Extensions */,
 				4B5A5B8B2D5E4C79009DA0D5 /* NetworkInstrumentation.swift */,
 				4B5A5B8C2D5E4C79009DA0D5 /* NetworkInstrumentation+Module.swift */,
@@ -1762,6 +1767,7 @@
 		4B5A5B912D5E4C79009DA0D5 /* SplunkNetworkTests */ = {
 			isa = PBXGroup;
 			children = (
+				BAAC20C32DB9BB5E00BC8B60 /* IgnoreURLsTests.swift */,
 				4B5A5B902D5E4C79009DA0D5 /* SplunkNetworkTests.swift */,
 			);
 			path = SplunkNetworkTests;
@@ -4041,6 +4047,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B9640402D60FB4B009A2E7F /* NetworkInstrumentationConfig.swift in Sources */,
+				BAAC20C22DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift in Sources */,
 				4B9640412D60FB4B009A2E7F /* NetworkInstrumentation.swift in Sources */,
 				4B9640422D60FB4B009A2E7F /* NetworkInstrumentation+Module.swift in Sources */,
 				4B9640432D60FB4B009A2E7F /* InternalLoggerConfiguration+Defaults.swift in Sources */,
@@ -4052,6 +4059,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B9640442D60FB66009A2E7F /* SplunkNetworkTests.swift in Sources */,
+				BAAC20C42DB9BB5E00BC8B60 /* IgnoreURLsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -31,6 +31,9 @@ public class NetworkInstrumentation {
     private let internalLogger = InternalLogger(configuration:
             .networkInstrumentation(category: "NetworkInstrumentation"))
 
+    /// Holds regex patterns from IgnoreURLs API
+    private let ignoreURLs = IgnoreURLs()
+
     // MARK: - Public
 
     /// Endpoints excluded from network instrumentation.
@@ -63,8 +66,18 @@ public class NetworkInstrumentation {
             return ((agentConfiguration?.appDCloudShouldInstrument!(URLRequest)) != nil)
         }
         */
-        let requestEndpoint = URLRequest.description
 
+        // Filter using ignoreURLs API
+        if let urlToTest = URLRequest.url {
+            if ignoreURLs.matches(url: urlToTest) {
+                self.internalLogger.log(level: .debug) {
+                    "URL excluded via IgnoreURLs API \(URLRequest.description)"
+                }
+                return false
+            }
+        }
+
+        let requestEndpoint = URLRequest.description
         if let excludedEndpoints {
             for excludedEndpoint in excludedEndpoints where requestEndpoint.contains(excludedEndpoint.absoluteString) {
                 self.internalLogger.log(level: .debug) {

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentationIgnoreURLs.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentationIgnoreURLs.swift
@@ -1,0 +1,70 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+public class IgnoreURLs {
+    private var urlPatterns: [NSRegularExpression]
+    
+    public init() {
+        self.urlPatterns = []
+    }
+    
+    public init(patterns: Set<String>) throws {
+        self.urlPatterns = try patterns.map { pattern in
+            try NSRegularExpression(pattern: pattern, options: [])
+        }
+    }
+    
+    @discardableResult
+    public func clearPatterns() -> Int {
+        let count = urlPatterns.count
+        urlPatterns.removeAll()
+        return count
+    }
+    
+    @discardableResult
+    public func addPatterns(_ patterns: Set<String>) throws -> Int {
+        let newPatterns = try patterns.map { pattern in
+            try NSRegularExpression(pattern: pattern, options: [])
+        }
+        
+        let existingPatternStrings = Set(urlPatterns.map { $0.pattern })
+        let uniqueNewPatterns = newPatterns.filter { !existingPatternStrings.contains($0.pattern) }
+        urlPatterns.append(contentsOf: uniqueNewPatterns)
+        return uniqueNewPatterns.count
+    }
+    
+    public func count() -> Int {
+        return urlPatterns.count
+    }
+    
+    public func getAllPatterns() -> [String] {
+        return urlPatterns.map { $0.pattern }
+    }
+    
+    public func matches(_ urlString: String) -> Bool {
+        return urlPatterns.contains { regex in
+            let range = NSRange(urlString.startIndex..., in: urlString)
+            return regex.firstMatch(in: urlString, options: [], range: range) != nil
+        }
+    }
+    
+    public func matches(url: URL) -> Bool {
+        return matches(url.absoluteString)
+    }
+} 

--- a/SplunkNetwork/Tests/SplunkNetworkTests/IgnoreURLsTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/IgnoreURLsTests.swift
@@ -1,0 +1,186 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import XCTest
+@testable import SplunkNetwork
+
+final class IgnoreURLsTests: XCTestCase {
+    
+    // MARK: - Initialization Tests
+    
+    func testEmptyInitializer() {
+        let ignoreURLs = IgnoreURLs()
+        XCTAssertEqual(ignoreURLs.count(), 0)
+        XCTAssertEqual(ignoreURLs.getAllPatterns().count, 0)
+    }
+    
+    func testInitializerWithValidPatterns() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        XCTAssertEqual(ignoreURLs.count(), 2)
+        XCTAssertEqual(Set(ignoreURLs.getAllPatterns()), patterns)
+    }
+    
+    func testInitializerWithInvalidPatterns() {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            "[A-Z",  // Invalid pattern - missing closing bracket
+            ".*/api/.*"
+        ])
+        
+        XCTAssertThrowsError(try IgnoreURLs(patterns: patterns))
+    }
+    
+    // MARK: - Pattern Management Tests
+    
+    func testAddPatterns() throws {
+        let ignoreURLs = IgnoreURLs()
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let addedCount = try ignoreURLs.addPatterns(patterns)
+        XCTAssertEqual(addedCount, 2)
+        XCTAssertEqual(ignoreURLs.count(), 2)
+        XCTAssertEqual(Set(ignoreURLs.getAllPatterns()), patterns)
+    }
+    
+    func testAddDuplicatePatterns() throws {
+        let initialPatterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: initialPatterns)
+        
+        // Try to add the same patterns again
+        let addedCount = try ignoreURLs.addPatterns(initialPatterns)
+        XCTAssertEqual(addedCount, 0)  // No new patterns added
+        XCTAssertEqual(ignoreURLs.count(), 2)  // Count remains the same
+        XCTAssertEqual(Set(ignoreURLs.getAllPatterns()), initialPatterns)
+    }
+    
+    func testAddInvalidPatterns() throws {
+        let ignoreURLs = IgnoreURLs()
+        let validPatterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        // First add valid patterns
+        _ = try ignoreURLs.addPatterns(validPatterns)
+        XCTAssertEqual(ignoreURLs.count(), 2)
+        
+        // Then try to add invalid patterns
+        let invalidPatterns = Set([
+            ".*\\.(pdf|doc)$",
+            "[A-Z",  // Invalid pattern
+            ".*/downloads/.*"
+        ])
+        
+        XCTAssertThrowsError(try ignoreURLs.addPatterns(invalidPatterns))
+        
+        // Verify that the original patterns are still intact
+        XCTAssertEqual(ignoreURLs.count(), 2)
+        XCTAssertEqual(Set(ignoreURLs.getAllPatterns()), validPatterns)
+    }
+    
+    func testClearPatterns() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        XCTAssertEqual(ignoreURLs.count(), 2)
+        
+        let clearedCount = ignoreURLs.clearPatterns()
+        XCTAssertEqual(clearedCount, 2)
+        XCTAssertEqual(ignoreURLs.count(), 0)
+        XCTAssertEqual(ignoreURLs.getAllPatterns().count, 0)
+    }
+    
+    // MARK: - URL Matching Tests
+    
+    func testMatchesWithStringURLs() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        
+        // Test matching URLs
+        XCTAssertTrue(ignoreURLs.matches("https://example.com/image.jpg"))
+        XCTAssertTrue(ignoreURLs.matches("https://api.example.com/users"))
+        
+        // Test non-matching URLs
+        XCTAssertFalse(ignoreURLs.matches("https://example.com/page.html"))
+        XCTAssertFalse(ignoreURLs.matches("https://example.com/document.pdf"))
+    }
+    
+    func testMatchesWithURLObjects() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        
+        // Test matching URLs
+        XCTAssertTrue(ignoreURLs.matches(url: URL(string: "https://example.com/image.jpg")!))
+        XCTAssertTrue(ignoreURLs.matches(url: URL(string: "https://api.example.com/users")!))
+        
+        // Test non-matching URLs
+        XCTAssertFalse(ignoreURLs.matches(url: URL(string: "https://example.com/page.html")!))
+        XCTAssertFalse(ignoreURLs.matches(url: URL(string: "https://example.com/document.pdf")!))
+    }
+    
+    func testMatchesWithEmptyPatterns() {
+        let ignoreURLs = IgnoreURLs()
+        
+        // No patterns should mean no matches
+        XCTAssertFalse(ignoreURLs.matches("https://example.com/image.jpg"))
+    }
+   
+    // MARK: - Edge Cases
+    
+    func testMatchesWithEmptyURLs() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        XCTAssertFalse(ignoreURLs.matches(""))
+    }
+    
+    func testMatchesWithInvalidURLs() throws {
+        let patterns = Set([
+            ".*\\.(jpg|jpeg|png|gif)$",
+            ".*/api/.*"
+        ])
+        
+        let ignoreURLs = try IgnoreURLs(patterns: patterns)
+        XCTAssertFalse(ignoreURLs.matches("not a url"))
+    }
+}


### PR DESCRIPTION
- Added IgnoreURLs class to manage Regex patterns supplied by users through the ignoreURLs API (The actual API support to be added in another ticket)
- Added code to stop instrumenting a url if it matches the supplied pattern
- Added unit tests 