### PR TITLE
DEMRUM-1635: Implement non operational agent instance

### DIFF
--- a/Applications/DevelApp/DevelApp/AgentDataSource.swift
+++ b/Applications/DevelApp/DevelApp/AgentDataSource.swift
@@ -24,10 +24,10 @@ class AgentDataSource: ObservableObject {
     // MARK: - Published Properties
 
     @Published var agentVersion: String = SplunkRum.version
-    @Published var agentAppVersion: String = SplunkRum.instance?.state.appVersion ?? "nil"
-    @Published var sessionId: String = SplunkRum.instance?.session.state.id ?? "nil"
-    @Published private var userTrackingMode = SplunkRum.instance?.user.state.trackingMode ?? .default
-    @Published var rumEnabled: Bool = SplunkRum.instance?.state.status == .running
+    @Published var agentAppVersion: String = SplunkRum.instance.state.appVersion
+    @Published var sessionId: String = SplunkRum.instance.session.state.id
+    @Published private var userTrackingMode = SplunkRum.instance.user.state.trackingMode
+    @Published var rumEnabled: Bool = SplunkRum.instance.state.status == .running
 
     // MARK: - Session publisher for handling session resets
 
@@ -54,9 +54,9 @@ class AgentDataSource: ObservableObject {
         // Observe changes to agent status (rumEnabled) based on `state.status`
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.rumEnabled = (SplunkRum.instance?.state.status == .running)
-                self?.sessionId = SplunkRum.instance?.session.state.id ?? "nil"
-                self?.userTrackingMode = SplunkRum.instance?.user.state.trackingMode ?? .default
+                self?.rumEnabled = (SplunkRum.instance.state.status == .running)
+                self?.sessionId = SplunkRum.instance.session.state.id
+                self?.userTrackingMode = SplunkRum.instance.user.state.trackingMode
             }
         }
     }

--- a/Applications/DevelApp/DevelApp/SessionReplayDemoView.swift
+++ b/Applications/DevelApp/DevelApp/SessionReplayDemoView.swift
@@ -30,14 +30,14 @@ struct SessionReplayDemoView: View {
     // MARK: - Versions
 
     let agentVersion = SplunkRum.version
-    let agentAppVersion = SplunkRum.instance?.state.appVersion ?? "nil"
+    let agentAppVersion = SplunkRum.instance.state.appVersion
 
 
     // MARK: - Identifiers
 
-    @State private var sessionId = SplunkRum.instance?.session.state.id ?? "nil"
-    @State private var userTrackingMode = SplunkRum.instance?.user.state.trackingMode ?? .default
-    @State private var agentStatus = SplunkRum.instance?.state.status ?? .notRunning(.notInstalled)
+    @State private var sessionId = SplunkRum.instance.session.state.id
+    @State private var userTrackingMode = SplunkRum.instance.user.state.trackingMode
+    @State private var agentStatus = SplunkRum.instance.state.status
 
     let sessionPublisher = NotificationCenter.default
         .publisher(

--- a/SplunkAgent/Sources/SplunkAgent/Agent/AppState/NoOpAppStateManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/AppState/NoOpAppStateManager.swift
@@ -14,24 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+	
 import Foundation
 
-/// A dummy configuration handler. It is used for the non-operational instance, or on a target platform the agent is not fully supporting.
-final class ConfigurationHandlerNonOperational: AgentConfigurationHandler {
+struct NoOpAppStateManager: AgentAppStateManager {
 
-    // MARK: - Configuration
-
-    var configurationData: Data? {
+    func appState(for timestamp: Date) -> AppState? {
         return nil
-    }
-
-    let configuration: any AgentConfigurationProtocol
-
-
-    // MARK: - Intialization
-
-    init(for configuration: any AgentConfigurationProtocol) {
-        self.configuration = configuration
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/AppState/NoOpAppStateManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/AppState/NoOpAppStateManager.swift
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-	
+
 import Foundation
 
+/// This struct implements a non operational variant of the AgentAppStateManager.
 struct NoOpAppStateManager: AgentAppStateManager {
 
     func appState(for timestamp: Date) -> AppState? {

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
@@ -19,13 +19,10 @@ import Foundation
 
 extension AgentConfiguration {
     static var emptyConfiguration: AgentConfiguration {
-
-        // TODO: DEMRUM-1663 remove try! once the DEMRUM-1700 is merged
-        return try! AgentConfiguration(
-            rumAccessToken: "token",
-            endpoint: EndpointConfiguration(realm: "realm"),
-            appName: "app name",
-            deploymentEnvironment: "env"
+        return AgentConfiguration(
+            endpoint: EndpointConfiguration(realm: "", rumAccessToken: ""),
+            appName: "",
+            deploymentEnvironment: ""
         )
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
@@ -17,21 +17,13 @@ limitations under the License.
 
 import Foundation
 
-/// A dummy configuration handler. It is used for the non-operational instance, or on a target platform the agent is not fully supporting.
-final class ConfigurationHandlerNonOperational: AgentConfigurationHandler {
-
-    // MARK: - Configuration
-
-    var configurationData: Data? {
-        return nil
-    }
-
-    let configuration: any AgentConfigurationProtocol
-
-
-    // MARK: - Intialization
-
-    init(for configuration: any AgentConfigurationProtocol) {
-        self.configuration = configuration
+extension AgentConfiguration {
+    static var emptyConfiguration: AgentConfiguration {
+        return try! AgentConfiguration(
+            rumAccessToken: "token",
+            endpoint: EndpointConfiguration(realm: "realm"),
+            appName: "app name",
+            deploymentEnvironment: "env"
+        )
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Configuration/Models/AgentConfiguration+Empty.swift
@@ -19,6 +19,8 @@ import Foundation
 
 extension AgentConfiguration {
     static var emptyConfiguration: AgentConfiguration {
+
+        // TODO: DEMRUM-1663 remove try! once the DEMRUM-1700 is merged
         return try! AgentConfiguration(
             rumAccessToken: "token",
             endpoint: EndpointConfiguration(realm: "realm"),

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+AppStart.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+AppStart.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2024 Splunk Inc.
+Copyright 2025 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2024 Splunk Inc.
+Copyright 2025 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Session/NoOpSession.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Session/NoOpSession.swift
@@ -14,24 +14,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+	
 import Foundation
 
-/// A dummy configuration handler. It is used for the non-operational instance, or on a target platform the agent is not fully supporting.
-final class ConfigurationHandlerNonOperational: AgentConfigurationHandler {
+struct NoOpSession: AgentSession {
+    let currentSessionItem = SessionItem(id: "no-op", start: Date())
 
-    // MARK: - Configuration
-
-    var configurationData: Data? {
-        return nil
+    var currentSessionId: String {
+        currentSessionItem.id
     }
 
-    let configuration: any AgentConfigurationProtocol
-
-
-    // MARK: - Intialization
-
-    init(for configuration: any AgentConfigurationProtocol) {
-        self.configuration = configuration
+    func sessionId(for timestamp: Date) -> String? {
+        return currentSessionItem.id
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Session/NoOpSession.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Session/NoOpSession.swift
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-	
+
 import Foundation
 
+/// This struct implements a non operational variant of the AgentSession.
 struct NoOpSession: AgentSession {
     let currentSessionItem = SessionItem(id: "no-op", start: Date())
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/SplunkRum+AppStart.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/SplunkRum+AppStart.swift
@@ -1,0 +1,56 @@
+//
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+internal import SplunkAppStart
+
+extension SplunkRum {
+
+    /// Reports agent initialization metrics
+    func reportAgentInitialization(start: Date, initializeEvents: [String: Date]) {
+        var initializeEvents = initializeEvents
+
+        // Fetch modules initialization times from the Modules manager
+        modulesManager?.modulesInitializationTimes.forEach { moduleName, time in
+            let moduleName = "\(moduleName)_initialized"
+            initializeEvents[moduleName] = time
+        }
+
+        // Report initialize events to App Start module
+        if let appStartModule = modulesManager?.module(ofType: SplunkAppStart.AppStart.self) {
+            appStartModule.reportAgentInitialize(
+                start: start,
+                end: Date(),
+                events: initializeEvents,
+                configurationSettings: configurationSettings
+            )
+        }
+    }
+
+    private var configurationSettings: [String: String] {
+        var settings = [String: String]()
+
+        settings["enableDebugLogging"] = String(agentConfigurationHandler.configuration.enableDebugLogging)
+        settings["sessionSamplingRate"] = String(agentConfigurationHandler.configuration.sessionSamplingRate)
+
+        if let modulesConfigurations = modulesManager?.modulesConfigurationDescription {
+            settings.merge(modulesConfigurations) { $1 }
+        }
+
+        return settings
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/SplunkRum+Modules.swift
@@ -1,0 +1,130 @@
+//
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+internal import CiscoSessionReplay
+internal import SplunkAppStart
+internal import SplunkNetwork
+
+#if canImport(SplunkCrashReports)
+    internal import SplunkCrashReports
+#endif
+
+internal import SplunkWebView
+internal import SplunkWebViewProxy
+
+extension SplunkRum {
+
+    // MARK: - Modules publish
+
+    func registerModulePublish() {
+        // Send events on data publish
+        modulesManager?.onModulePublish(data: { metadata, data in
+            self.eventManager?.publish(data: data, metadata: metadata) { success in
+                if success {
+                    self.modulesManager?.deleteModuleData(for: metadata)
+                } else {
+                    // TODO: MRUM_AC-1061 (post GA): Handle a case where data is not sent.
+                }
+            }
+        })
+    }
+
+
+    // MARK: - Modules customization
+
+    /// Perform specific pre-defined customizations for some modules.
+    func customizeModules() {
+        customizeCrashReports()
+        customizeSessionReplay()
+        customizeNetwork()
+        customizeAppStart()
+        customizeWebViewInstrumentation()
+    }
+
+    /// Perform operations specific to the SessionReplay module.
+    private func customizeSessionReplay() {
+        let moduleType = CiscoSessionReplay.SessionReplay.self
+        let sessionReplayModule = modulesManager?.module(ofType: moduleType)
+
+        guard let sessionReplayModule else {
+            return
+        }
+
+        // Initialize proxy API for this module
+        sessionReplayProxy = SessionReplay(for: sessionReplayModule)
+    }
+
+    /// Configure Network module with shared state.
+    private func customizeNetwork() {
+        let networkModule = modulesManager?.module(ofType: SplunkNetwork.NetworkInstrumentation.self)
+
+        // Assign an object providing the current state of the agent instance.
+        // We need to do this because we need to read `sessionID` from the agent continuously.
+        networkModule?.sharedState = sharedState
+
+        // We need the endpoint url to manage trace exclusion logic
+        var excludedEndpoints: [URL] = []
+        if let traceUrl = agentConfiguration.endpoint.traceEndpoint {
+            excludedEndpoints.append(traceUrl)
+        }
+
+        if let sessionReplayUrl = agentConfiguration.endpoint.sessionReplayEndpoint {
+            excludedEndpoints.append(sessionReplayUrl)
+        }
+
+        networkModule?.excludedEndpoints = excludedEndpoints
+    }
+
+    /// Configure Crash Reports module with shared state.
+    private func customizeCrashReports() {
+    // swiftformat:disable indent
+    #if canImport(SplunkCrashReports)
+        let crashReportsModule = modulesManager?.module(ofType: SplunkCrashReports.CrashReports.self)
+
+        // Assign an object providing the current state of the agent instance.
+        // We need to do this because we need to read `appState` from the agent in the instance of a crash.
+        crashReportsModule?.sharedState = sharedState
+
+        // Check if a crash ended the previous run of the app
+        crashReportsModule?.reportCrashIfPresent()
+    #endif
+    // swiftformat:enable indent
+    }
+
+    /// Configure App start module
+    private func customizeAppStart() {
+        let appStartModule = modulesManager?.module(ofType: SplunkAppStart.AppStart.self)
+
+        appStartModule?.sharedState = sharedState
+    }
+
+    /// Configure WebView intrumentation module
+    private func customizeWebViewInstrumentation() {
+        // Get WebViewInstrumentation module, set its sharedState
+        if let webViewInstrumentationModule = modulesManager?.module(ofType: SplunkWebView.WebViewInstrumentationInternal.self) {
+            WebViewInstrumentationInternal.instance.sharedState = sharedState
+            logger.log(level: .notice, isPrivate: false) {
+                "WebViewInstrumentation module installed."
+            }
+        } else {
+            logger.log(level: .notice, isPrivate: false) {
+                "WebViewInstrumentation module not installed."
+            }
+        }
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/User/NoOpUser.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/User/NoOpUser.swift
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-	
+
 import Foundation
 
+/// This struct implements a non operational variant of the AgentUser.
 struct NoOpUser: AgentUser {
     let userIdentifier = "noop"
     var trackingMode = UserTrackingMode.noTracking

--- a/SplunkAgent/Sources/SplunkAgent/Agent/User/NoOpUser.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/User/NoOpUser.swift
@@ -14,24 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+	
 import Foundation
 
-/// A dummy configuration handler. It is used for the non-operational instance, or on a target platform the agent is not fully supporting.
-final class ConfigurationHandlerNonOperational: AgentConfigurationHandler {
-
-    // MARK: - Configuration
-
-    var configurationData: Data? {
-        return nil
-    }
-
-    let configuration: any AgentConfigurationProtocol
-
-
-    // MARK: - Intialization
-
-    init(for configuration: any AgentConfigurationProtocol) {
-        self.configuration = configuration
-    }
+struct NoOpUser: AgentUser {
+    let userIdentifier = "noop"
+    var trackingMode = UserTrackingMode.noTracking
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
@@ -26,10 +26,10 @@ public extension UIView {
     /// Assigning `nil` removes previously assigned explicit sensitivity.
     var srSensitive: Bool? {
         get {
-            SplunkRum.instance?.sessionReplay.sensitivity[self]
+            SplunkRum.instance.sessionReplay.sensitivity[self]
         }
         set {
-            SplunkRum.instance?.sessionReplay.sensitivity[self] = newValue
+            SplunkRum.instance.sessionReplay.sensitivity[self] = newValue
         }
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -176,8 +176,6 @@ public class SplunkRum: ObservableObject {
         // Prepare handler for stored configuration and download remote configuration
         let configurationHandler = createConfigurationHandler(for: configuration)
 
-        let session = DefaultSession()
-
         // Preparation for sampling
         let sampledOut = false
         if sampledOut {
@@ -194,7 +192,7 @@ public class SplunkRum: ObservableObject {
         let agent = SplunkRum(
             configurationHandler: configurationHandler,
             user: DefaultUser(),
-            session: session,
+            session: DefaultSession(),
             appStateManager: AppStateManager()
         )
         privateInstance = agent

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -114,6 +114,7 @@ public class SplunkRum: ObservableObject {
     public static func install(with configuration: AgentConfiguration, moduleConfigurations: [Any]? = nil) throws -> SplunkRum {
 
         // Install is allowed only once.
+        //
         // ‼️ This condition check implies that other checks (supported platform check, sampling check) are performed only once,
         // and agent's shared instance can't be reinstalled
         guard shared.currentStatus == .notRunning(.notInstalled) else {
@@ -140,7 +141,7 @@ public class SplunkRum: ObservableObject {
             return shared
         }
 
-        // Initialize the full agent if all checks passed
+        // Initialize the full agent if all checks pass
         let agent = try SplunkRum(
             with: configuration,
             moduleConfigurations: moduleConfigurations
@@ -193,6 +194,7 @@ public class SplunkRum: ObservableObject {
         // Prepare handler for stored configuration and download remote configuration
         let configurationHandler = Self.createConfigurationHandler(for: configuration)
 
+        // Initialize the agent
         self.init(
             configurationHandler: configurationHandler,
             user: DefaultUser(),
@@ -224,6 +226,7 @@ public class SplunkRum: ObservableObject {
 
         initializeEvents["modules_connected"] = Date()
 
+        // Register modules' publish callback
         registerModulePublish()
 
         // Runs module-specific customizations
@@ -231,6 +234,7 @@ public class SplunkRum: ObservableObject {
 
         initializeEvents["modules_customized"] = Date()
 
+        // Report agent's initialization metrics for the app start event
         reportAgentInitialization(start: initializeStart, initializeEvents: initializeEvents)
 
         logger.log(level: .notice, isPrivate: false) {

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -2851,8 +2851,10 @@
 		E4AD34F22B56E031004976CA /* Modules */ = {
 			isa = PBXGroup;
 			children = (
-				E468E7712B6123ED0035BB31 /* Pool */,
 				E468E7722B6124440035BB31 /* Manager */,
+				E468E7712B6123ED0035BB31 /* Pool */,
+				2AF6AABE2DCE099C00BB9DC3 /* SplunkRum+AppStart.swift */,
+				2AF6AABC2DCE081A00BB9DC3 /* SplunkRum+Modules.swift */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -3009,8 +3011,6 @@
 		E4F2E4F82B172911006EBA69 /* Agent */ = {
 			isa = PBXGroup;
 			children = (
-				2AF6AABC2DCE081A00BB9DC3 /* SplunkRum+Modules.swift */,
-				2AF6AABE2DCE099C00BB9DC3 /* SplunkRum+AppStart.swift */,
 				C703FAAD2BA9D3A2000CC11B /* AppState */,
 				E4F2E4F72B172853006EBA69 /* Configuration */,
 				2AE43B3F2B861325002C4A98 /* Events */,

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		2AE43B472B861325002C4A98 /* AgentEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE43B412B861325002C4A98 /* AgentEventManager.swift */; };
 		2AE43B482B861325002C4A98 /* SessionReplayDataEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE43B432B861325002C4A98 /* SessionReplayDataEvent.swift */; };
 		2AE43B4B2B861325002C4A98 /* SessionStartEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE43B462B861325002C4A98 /* SessionStartEvent.swift */; };
+		2AF6AABD2DCE081F00BB9DC3 /* SplunkRum+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF6AABC2DCE081A00BB9DC3 /* SplunkRum+Modules.swift */; };
+		2AF6AABF2DCE09B900BB9DC3 /* SplunkRum+AppStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF6AABE2DCE099C00BB9DC3 /* SplunkRum+AppStart.swift */; };
 		3384F2AD2AC879FD00512D79 /* SplunkRum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384F2AC2AC879FD00512D79 /* SplunkRum.swift */; };
 		4B0F238A2D79F51F00EA575A /* SplunkCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B9640842D60FD04009A2E7F /* SplunkCommon.framework */; };
 		4B0F23952D79F54000EA575A /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0F23942D79F54000EA575A /* OpenTelemetryApi */; };
@@ -631,6 +633,8 @@
 		2AE43B412B861325002C4A98 /* AgentEventManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgentEventManager.swift; sourceTree = "<group>"; };
 		2AE43B432B861325002C4A98 /* SessionReplayDataEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayDataEvent.swift; sourceTree = "<group>"; };
 		2AE43B462B861325002C4A98 /* SessionStartEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionStartEvent.swift; sourceTree = "<group>"; };
+		2AF6AABC2DCE081A00BB9DC3 /* SplunkRum+Modules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SplunkRum+Modules.swift"; sourceTree = "<group>"; };
+		2AF6AABE2DCE099C00BB9DC3 /* SplunkRum+AppStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SplunkRum+AppStart.swift"; sourceTree = "<group>"; };
 		3384F2A22AC879E900512D79 /* SplunkAgent.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SplunkAgent.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3384F2AC2AC879FD00512D79 /* SplunkRum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkRum.swift; sourceTree = "<group>"; };
 		4B2C8BBA2BCBE4A200C6E72F /* CrashReportsDataEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportsDataEvent.swift; sourceTree = "<group>"; };
@@ -2994,6 +2998,8 @@
 		E4F2E4F82B172911006EBA69 /* Agent */ = {
 			isa = PBXGroup;
 			children = (
+				2AF6AABC2DCE081A00BB9DC3 /* SplunkRum+Modules.swift */,
+				2AF6AABE2DCE099C00BB9DC3 /* SplunkRum+AppStart.swift */,
 				C703FAAD2BA9D3A2000CC11B /* AppState */,
 				E4F2E4F72B172853006EBA69 /* Configuration */,
 				2AE43B3F2B861325002C4A98 /* Events */,
@@ -4092,6 +4098,7 @@
 				2A1673CD2BA1F52600F85698 /* EventsModel.swift in Sources */,
 				BAAC20C82DBB0F4800BC8B60 /* ThreadSafeDictionary.swift in Sources */,
 				2AE43B0C2B7FAD9B002C4A98 /* DefaultResources.swift in Sources */,
+				2AF6AABD2DCE081F00BB9DC3 /* SplunkRum+Modules.swift in Sources */,
 				2AE43B4B2B861325002C4A98 /* SessionStartEvent.swift in Sources */,
 				2AB51E992B7A670600307B77 /* DeviceInfo.swift in Sources */,
 				E4EE9ED02BA330AE0000D594 /* SessionReplayNonOperational+RecordingMask.swift in Sources */,
@@ -4132,6 +4139,7 @@
 				E4EE9ED22BA332CD0000D594 /* SessionReplayNonOperationalSensitivity.swift in Sources */,
 				E4EF6E432B18986900206883 /* UserDefaultsStorage.swift in Sources */,
 				E47953C52BA1CF7D0065677D /* SessionReplay+Recording.swift in Sources */,
+				2AF6AABF2DCE09B900BB9DC3 /* SplunkRum+AppStart.swift in Sources */,
 				4BB680E52B7940C0000A54D4 /* SensitivityModifier.swift in Sources */,
 				4B2C8BBB2BCBE4A200C6E72F /* CrashReportsDataEvent.swift in Sources */,
 				C7A2BD1B2BB45363005D4CFB /* AppStateModel.swift in Sources */,

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		2A03CF5B2D9C312200CF3BC9 /* API-1.0-EndpointConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03CF5A2D9C311800CF3BC9 /* API-1.0-EndpointConfiguration.swift */; };
 		2A03CF5D2D9C315C00CF3BC9 /* API-1.0-AgentConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03CF5C2D9C315000CF3BC9 /* API-1.0-AgentConfigurationError.swift */; };
 		2A03CF5F2D9C31C100CF3BC9 /* API-1.0-AgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03CF5E2D9C317D00CF3BC9 /* API-1.0-AgentConfiguration.swift */; };
+		2A0B3FC32DC89B610042FB38 /* NoOpAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0B3FC22DC89B5A0042FB38 /* NoOpAppStateManager.swift */; };
+		2A0B3FC52DC89BB90042FB38 /* AgentConfiguration+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0B3FC42DC89BAD0042FB38 /* AgentConfiguration+Empty.swift */; };
+		2A0B3FC72DC8A4180042FB38 /* NoOpSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0B3FC62DC8A4150042FB38 /* NoOpSession.swift */; };
+		2A0B3FC92DC8A43D0042FB38 /* NoOpUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0B3FC82DC8A43A0042FB38 /* NoOpUser.swift */; };
 		2A1673CD2BA1F52600F85698 /* EventsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1673CC2BA1F52600F85698 /* EventsModel.swift */; };
 		2A1789B72DA3CDA900EC548B /* AppStartSimulations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789B52DA3CDA900EC548B /* AppStartSimulations.swift */; };
 		2A1789BB2DA3CDD300EC548B /* AppStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1789B92DA3CDD300EC548B /* AppStartTests.swift */; };
@@ -587,6 +591,10 @@
 		2A03CF5A2D9C311800CF3BC9 /* API-1.0-EndpointConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-EndpointConfiguration.swift"; sourceTree = "<group>"; };
 		2A03CF5C2D9C315000CF3BC9 /* API-1.0-AgentConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-AgentConfigurationError.swift"; sourceTree = "<group>"; };
 		2A03CF5E2D9C317D00CF3BC9 /* API-1.0-AgentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-AgentConfiguration.swift"; sourceTree = "<group>"; };
+		2A0B3FC22DC89B5A0042FB38 /* NoOpAppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpAppStateManager.swift; sourceTree = "<group>"; };
+		2A0B3FC42DC89BAD0042FB38 /* AgentConfiguration+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentConfiguration+Empty.swift"; sourceTree = "<group>"; };
+		2A0B3FC62DC8A4150042FB38 /* NoOpSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpSession.swift; sourceTree = "<group>"; };
+		2A0B3FC82DC8A43A0042FB38 /* NoOpUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpUser.swift; sourceTree = "<group>"; };
 		2A1673CC2BA1F52600F85698 /* EventsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsModel.swift; sourceTree = "<group>"; };
 		2A1789B52DA3CDA900EC548B /* AppStartSimulations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartSimulations.swift; sourceTree = "<group>"; };
 		2A1789B92DA3CDD300EC548B /* AppStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartTests.swift; sourceTree = "<group>"; };
@@ -2409,6 +2417,7 @@
 				C7A2BD192BB44E1C005D4CFB /* Model */,
 				C703FAAE2BA9D417000CC11B /* AgentAppStateManager.swift */,
 				C703FAB02BA9D41E000CC11B /* AppStateManager.swift */,
+				2A0B3FC22DC89B5A0042FB38 /* NoOpAppStateManager.swift */,
 			);
 			path = AppState;
 			sourceTree = "<group>";
@@ -2588,6 +2597,7 @@
 		E436194D2B87426E009AD3B8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				2A0B3FC42DC89BAD0042FB38 /* AgentConfiguration+Empty.swift */,
 				2AC68DA82D9E77B60086EEF7 /* AgentConfigurationProtocol.swift */,
 				2AC68DA92D9E77B60086EEF7 /* AgentConfigurationProtocol+MergeRemote.swift */,
 				C73FF47F2B6CE749009C53FF /* RemoteConfiguration.swift */,
@@ -2955,6 +2965,7 @@
 				E426CFA72B28C18000094AC0 /* Model */,
 				E4F2E5062B1733C9006EBA69 /* AgentSession.swift */,
 				E4F2E5082B173429006EBA69 /* DefaultSession.swift */,
+				2A0B3FC62DC8A4150042FB38 /* NoOpSession.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -2962,6 +2973,7 @@
 		E4F2E4F62B17281F006EBA69 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				2A0B3FC82DC8A43A0042FB38 /* NoOpUser.swift */,
 				E4F3ACBE2DA7B8E5007EFC0A /* Model */,
 				E4F2E50B2B17350D006EBA69 /* AgentUser.swift */,
 				E4F2E50D2B17351E006EBA69 /* DefaultUser.swift */,
@@ -4112,6 +4124,7 @@
 				4BB680F32B7940C0000A54D4 /* API-1.0-Sensitivity+UIView.swift in Sources */,
 				E4EE9EC72BA30E180000D594 /* SessionReplayState.swift in Sources */,
 				E41FB0932B90D873009F5CA6 /* DefaultSharedState.swift in Sources */,
+				2A0B3FC32DC89B610042FB38 /* NoOpAppStateManager.swift in Sources */,
 				E4F2E5092B173429006EBA69 /* DefaultSession.swift in Sources */,
 				E4EE9EC22BA2E5240000D594 /* SessionReplayNonOperational.swift in Sources */,
 				4BB680F42B7940C0000A54D4 /* API-1.0-Sensitivity+SwiftUI.swift in Sources */,
@@ -4136,6 +4149,7 @@
 				4BF895742DAD7C2100E171A4 /* SplunkConfigurationHandler.swift in Sources */,
 				E426CFAA2B28C18000094AC0 /* SessionsModel.swift in Sources */,
 				E42634832BB44B0F003706A9 /* SplunkAgent.docc in Sources */,
+				2A0B3FC52DC89BB90042FB38 /* AgentConfiguration+Empty.swift in Sources */,
 				C73FF4882B6CE749009C53FF /* ConfigurationHandlerError.swift in Sources */,
 				C703FAB32BA9D424000CC11B /* AppState.swift in Sources */,
 				E4F2E5102B1737F2006EBA69 /* API-1.0-Session.swift in Sources */,
@@ -4153,9 +4167,11 @@
 				C73FF4842B6CE749009C53FF /* AgentConfigurationHandler.swift in Sources */,
 				2A03CF5B2D9C312200CF3BC9 /* API-1.0-EndpointConfiguration.swift in Sources */,
 				C73FF4982B6CE777009C53FF /* APIClientError.swift in Sources */,
+				2A0B3FC92DC8A43D0042FB38 /* NoOpUser.swift in Sources */,
 				2AC68DAA2D9E77B60086EEF7 /* AgentConfigurationProtocol.swift in Sources */,
 				2AC68DAB2D9E77B60086EEF7 /* AgentConfigurationProtocol+MergeRemote.swift in Sources */,
 				C73FF4962B6CE777009C53FF /* APIClient.swift in Sources */,
+				2A0B3FC72DC8A4180042FB38 /* NoOpSession.swift in Sources */,
 				4B985E5B2D94C9F900CB0321 /* String+HexID.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -23,9 +23,6 @@ final class API10AgentTests: XCTestCase {
     // MARK: - API Tests
 
     func testInstall() throws {
-        // Test noop instance
-        XCTAssertTrue(SplunkRum.instance === SplunkRum.noOpInstance)
-
         // Test initial state
         XCTAssertTrue(SplunkRum.instance.state.status == .notRunning(.notInstalled))
 
@@ -35,9 +32,6 @@ final class API10AgentTests: XCTestCase {
         // Agent install
         let configuration = try ConfigurationTestBuilder.buildDefault()
         var agent: SplunkRum? = SplunkRum.install(with: configuration)
-
-        // Test for internal instance
-        XCTAssertFalse(SplunkRum.instance === SplunkRum.noOpInstance)
 
         // The agent should run after install
         let agentStatus = try XCTUnwrap(agent?.state.status)

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -24,7 +24,7 @@ final class API10AgentTests: XCTestCase {
 
     func testInstall() throws {
         // Test initial state
-        XCTAssertTrue(SplunkRum.instance.state.status == .notRunning(.notInstalled))
+        XCTAssertTrue(SplunkRum.shared.state.status == .notRunning(.notInstalled))
 
         // Agent initialization
         _ = try AgentTestBuilder.buildDefault()

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -23,12 +23,21 @@ final class API10AgentTests: XCTestCase {
     // MARK: - API Tests
 
     func testInstall() throws {
+        // Test noop instance
+        XCTAssertTrue(SplunkRum.instance === SplunkRum.noOpInstance)
+
+        // Test initial state
+        XCTAssertTrue(SplunkRum.instance.state.status == .notRunning(.notInstalled))
+
         // Agent initialization
         _ = try AgentTestBuilder.buildDefault()
 
         // Agent install
         let configuration = try ConfigurationTestBuilder.buildDefault()
         var agent: SplunkRum? = SplunkRum.install(with: configuration)
+
+        // Test for internal instance
+        XCTAssertFalse(SplunkRum.instance === SplunkRum.noOpInstance)
 
         // The agent should run after install
         let agentStatus = try XCTUnwrap(agent?.state.status)


### PR DESCRIPTION
This PR implements the non-operational agent instance. 

Initial shared instance is initialized statically with non-operational variants of respective parameters. Install method performs checks, if all pass, full agent instance is created and assigned to the agent's singleton instance. 

This PR also refactors the SplunkRum class a bit as it was becoming too long.