### PR TITLE
DEMRUM-938: Implement span interception internals

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -106,7 +106,8 @@ class DefaultEventManager: AgentEventManager {
             with: traceUrl,
             resources: resources,
             runtimeAttributes: agent.runtimeAttributes,
-            debugEnabled: configuration.enableDebugLogging
+            debugEnabled: configuration.enableDebugLogging,
+            spanInterceptor: configuration.spanInterceptor
         )
 
         logger.log(level: .info, isPrivate: false) {

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		4B385B532D94C594005CF4C9 /* AppStartDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B385B162D94C4EB005CF4C9 /* AppStartDestination.swift */; };
 		4B385B542D94C594005CF4C9 /* AppStart+ProcessStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B385B202D94C4EB005CF4C9 /* AppStart+ProcessStart.swift */; };
 		4B385B552D94C594005CF4C9 /* AppStartRemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B385B1C2D94C4EB005CF4C9 /* AppStartRemoteConfiguration.swift */; };
+		4B3B3FF32DCB616200F1BC5C /* SpanInterceptorExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B3FF22DCB616200F1BC5C /* SpanInterceptorExporter.swift */; };
 		4B6878C12B9F3B420024479A /* ConfigurationHandler+RequestErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6878C02B9F3B420024479A /* ConfigurationHandler+RequestErrorHandling.swift */; };
 		4B963FEF2D60F7E3009A2E7F /* SplunkLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B963FE52D60F7E3009A2E7F /* SplunkLogger.framework */; };
 		4B96402A2D60FB3B009A2E7F /* SplunkNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B9640202D60FB3A009A2E7F /* SplunkNetwork.framework */; };
@@ -656,6 +657,7 @@
 		4B385B202D94C4EB005CF4C9 /* AppStart+ProcessStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppStart+ProcessStart.swift"; sourceTree = "<group>"; };
 		4B385B2F2D94C55A005CF4C9 /* SplunkAppStart.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SplunkAppStart.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B385B362D94C55B005CF4C9 /* SplunkAppStartTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SplunkAppStartTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B3B3FF22DCB616200F1BC5C /* SpanInterceptorExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanInterceptorExporter.swift; sourceTree = "<group>"; };
 		4B536BF22B67FAFE004A6C7C /* Release-staticlib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release-staticlib.xcconfig"; sourceTree = "<group>"; };
 		4B536BF42B67FB2F004A6C7C /* Release-mh_dylib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release-mh_dylib.xcconfig"; sourceTree = "<group>"; };
 		4B536BFF2B693BED004A6C7C /* Debug-mh_dylib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Debug-mh_dylib.xcconfig"; sourceTree = "<group>"; };
@@ -1662,6 +1664,14 @@
 			path = ../SplunkAppStart;
 			sourceTree = SOURCE_ROOT;
 		};
+		4B3B3FF12DCB613C00F1BC5C /* Span Interceptor Exporter */ = {
+			isa = PBXGroup;
+			children = (
+				4B3B3FF22DCB616200F1BC5C /* SpanInterceptorExporter.swift */,
+			);
+			path = "Span Interceptor Exporter";
+			sourceTree = "<group>";
+		};
 		4B536BF12B67FADC004A6C7C /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -1996,6 +2006,7 @@
 		4B5A5CAA2D60ED3D009DA0D5 /* SplunkOpenTelemetry */ = {
 			isa = PBXGroup;
 			children = (
+				4B3B3FF12DCB613C00F1BC5C /* Span Interceptor Exporter */,
 				4B5A5C9F2D60ED3D009DA0D5 /* API */,
 				4B5A5CA62D60ED3D009DA0D5 /* Trace Processor */,
 				4B5A5CA22D60ED3D009DA0D5 /* Log Event Processor */,
@@ -4337,6 +4348,7 @@
 				2A5949DB2DA3FC2100F2E857 /* SplunkStdoutSpanExporter.swift in Sources */,
 				2A5949DC2DA3FC2100F2E857 /* SplunkStdoutLogExporter.swift in Sources */,
 				2A2926352DAD114900AB6F03 /* AttributeCheckerSpanExporter.swift in Sources */,
+				4B3B3FF32DCB616200F1BC5C /* SpanInterceptorExporter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
@@ -1,0 +1,64 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+import Foundation
+import OpenTelemetrySdk
+import SplunkCommon
+
+public typealias SplunkSpanInterceptor = (SpanData) -> SpanData?
+
+class SpanInterceptorExporter: SpanExporter {
+
+    // MARK: - Private
+
+    private let spanInterceptor: SplunkSpanInterceptor?
+
+    private let proxyExporter: SpanExporter
+
+
+    // MARK: - Initialization
+
+    init(with interceptor: SplunkSpanInterceptor?, proxy: SpanExporter) {
+        spanInterceptor = interceptor
+        proxyExporter = proxy
+    }
+
+
+    // MARK: - Span Exporter methods
+
+    func shutdown(explicitTimeout: TimeInterval?) {
+        proxyExporter.shutdown(explicitTimeout: explicitTimeout)
+    }
+
+    func flush(explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.SpanExporterResultCode {
+        proxyExporter.flush(explicitTimeout: explicitTimeout)
+    }
+
+    func export(spans: [OpenTelemetrySdk.SpanData], explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.SpanExporterResultCode {
+
+        // Simply re-export the spans if no interceptor was set.
+        guard let spanInterceptor else {
+            return proxyExporter.export(spans: spans)
+        }
+
+        // Invoke the interceptor and only pass through non-nil spans.
+        let interceptedSpans = spans.compactMap({ span in return spanInterceptor(span)})
+
+        return proxyExporter.export(spans: interceptedSpans)
+    }
+}

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Stdout Exporters/SplunkStdoutSpanExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Stdout Exporters/SplunkStdoutSpanExporter.swift
@@ -25,6 +25,8 @@ class SplunkStdoutSpanExporter: SpanExporter {
 
     // MARK: - Private
 
+    private let proxyExporter: SpanExporter
+
     // Internal Logger
     private let logger = DefaultLogAgent(poolName: PackageIdentifier.instance(), category: "OpenTelemetry")
 
@@ -43,7 +45,9 @@ class SplunkStdoutSpanExporter: SpanExporter {
         return dateFormat
     }()
 
-    init() {}
+    init(with proxy: SpanExporter) {
+        proxyExporter = proxy
+    }
 
     func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
         for span in spans {
@@ -89,12 +93,14 @@ class SplunkStdoutSpanExporter: SpanExporter {
             }
         }
 
-        return .success
+        return proxyExporter.export(spans: spans)
     }
     
     public func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
-        return .success
+        return proxyExporter.flush(explicitTimeout: explicitTimeout)
     }
     
-    public func shutdown(explicitTimeout: TimeInterval?) {}
+    public func shutdown(explicitTimeout: TimeInterval?) {
+        proxyExporter.shutdown(explicitTimeout: explicitTimeout)
+    }
 }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
@@ -39,7 +39,8 @@ public class OTLPTraceProcessor: TraceProcessor {
         with tracesEndpoint: URL,
         resources: AgentResources,
         runtimeAttributes: RuntimeAttributes,
-        debugEnabled: Bool
+        debugEnabled: Bool,
+        spanInterceptor: SplunkSpanInterceptor?
     ) {
 
         let configuration = OtlpConfiguration()
@@ -56,8 +57,11 @@ public class OTLPTraceProcessor: TraceProcessor {
         // Initialize attribute checker proxy exporter
         let attributeCheckerExporter = AttributeCheckerSpanExporter(proxy: backgroundTraceExporter)
 
+        // Initialize span interceptor proxy exporter
+        let spanInterceptorExporter = SpanInterceptorExporter(with: spanInterceptor, proxy: attributeCheckerExporter)
+
         // Initialize processor
-        let spanProcessor = SimpleSpanProcessor(spanExporter: attributeCheckerExporter)
+        let spanProcessor = SimpleSpanProcessor(spanExporter: spanInterceptorExporter)
         let attributesProcessor = OLTPAttributesSpanProcessor(with: runtimeAttributes)
 
         // Build Resources


### PR DESCRIPTION
This PR implements the internals for the already existing public API of the customer-allowed span interception.

It also refactors the `SplunkStdoutSpanExporter` to live in the exporter chain, to correctly log all span data from the whole pipeline.