### PR TITLE
DEMRUM-970 Add PLCrashReporter via github

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -159,47 +159,11 @@ let package = Package(
         ),
         
         
-        // MARK: SplunkCrashReporter
-        
-        .target(
-            name: "SplunkCrashReporter",
-            path: "SplunkCrashReporter",
-            exclude: [
-                "Source/dwarf_opstream.hpp",
-                "Source/dwarf_stack.hpp",
-                "Source/PLCrashAsyncDwarfCFAState.hpp",
-                "Source/PLCrashAsyncDwarfCIE.hpp",
-                "Source/PLCrashAsyncDwarfEncoding.hpp",
-                "Source/PLCrashAsyncDwarfExpression.hpp",
-                "Source/PLCrashAsyncDwarfFDE.hpp",
-                "Source/PLCrashAsyncDwarfPrimitives.hpp",
-                "Source/PLCrashAsyncLinkedList.hpp",
-                "Source/PLCrashReport.proto"
-            ],
-            sources: [
-                "Source",
-                "Dependencies/protobuf-c"
-            ],
-            cSettings: [
-                .define("PLCR_PRIVATE"),
-                .define("PLCF_RELEASE_BUILD"),
-                .define("PLCRASHREPORTER_PREFIX", to: "SPLK"),
-                .define("SWIFT_PACKAGE"), // Should be defined by default, Xcode 11.1 workaround.
-                .headerSearchPath("Dependencies/protobuf-c"),
-                .unsafeFlags(["-w"]) // Suppresses "Implicit conversion" warnings in protobuf.c
-            ],
-            linkerSettings: [
-                .linkedFramework("Foundation")
-            ]
-        ),
-        
-        
         // MARK: SplunkCrashReports
         
         .target(
             name: "SplunkCrashReports",
             dependencies: [
-                "SplunkCrashReporter",
                 "SplunkOpenTelemetry",
                 "SplunkCommon"
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
             exact: "1.14.0"
         ),
+        .package(url:"https://github.com/microsoft/plcrashreporter", from: "1.12.0"),
         sessionReplayDependency()
     ],
     targets: [
@@ -165,13 +166,14 @@ let package = Package(
             name: "SplunkCrashReports",
             dependencies: [
                 "SplunkOpenTelemetry",
-                "SplunkCommon"
+                "SplunkCommon",
+                .product(name: "CrashReporter", package: "PLCrashReporter")
             ],
             path: "SplunkCrashReports/Sources"
         ),
         .testTarget(
             name: "SplunkCrashReportsTests",
-            dependencies: ["SplunkCrashReports", "SplunkCommon"],
+            dependencies: ["SplunkCrashReports", "SplunkCommon", "PLCrashReporter"],
             path: "SplunkCrashReports/Tests"
         ),
         

--- a/Splunk.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Splunk.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "086cbf8ba05fee02327b46721643451f4c667c178e559c7a6787221339f1d7b4",
+  "originHash" : "a8d0bc78700fb2a39cf0a3e46912e6af56f823cfa7bf7e333f6fc31b3bc6cf26",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
         "version" : "0.5.2"
+      }
+    },
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "8c61e5e38e9f737dd68512ed1ea5ab081244ad65",
+        "version" : "1.12.0"
       }
     },
     {

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 		4B985E582D94C95700CB0321 /* StdoutExporter in Frameworks */ = {isa = PBXBuildFile; productRef = 4B985E572D94C95700CB0321 /* StdoutExporter */; };
 		4B985E5A2D94C96200CB0321 /* ZipkinExporter in Frameworks */ = {isa = PBXBuildFile; productRef = 4B985E592D94C96200CB0321 /* ZipkinExporter */; };
 		4B985E5B2D94C9F900CB0321 /* String+HexID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAC95E22D6C741C004FAE2C /* String+HexID.swift */; };
-		4BAA09F12D9361AB00B7D6AE /* SplunkCrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 4BAA09F02D9361AB00B7D6AE /* SplunkCrashReporter */; };
 		4BB680E52B7940C0000A54D4 /* SensitivityModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680CE2B7940C0000A54D4 /* SensitivityModifier.swift */; };
 		4BB680E82B7940C0000A54D4 /* RecordingMask+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680D32B7940C0000A54D4 /* RecordingMask+Conversions.swift */; };
 		4BB680E92B7940C0000A54D4 /* Status+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680D42B7940C0000A54D4 /* Status+Conversions.swift */; };
@@ -183,6 +182,7 @@
 		52D945C92DC0A7F500DE8220 /* CiscoLogger in Frameworks */ = {isa = PBXBuildFile; productRef = 52D945C82DC0A7F500DE8220 /* CiscoLogger */; };
 		BA7A63BC2DB8196800A44570 /* MutableAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A63BB2DB8196800A44570 /* MutableAttributesTests.swift */; };
 		BA7A63BE2DB8198200A44570 /* MutableAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A63BD2DB8198200A44570 /* MutableAttributes.swift */; };
+		BA80F9E42DCEB343007F64FA /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = BA80F9E32DCEB343007F64FA /* CrashReporter */; };
 		BAAC20C22DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC20C12DB9BA8B00BC8B60 /* NetworkInstrumentationIgnoreURLs.swift */; };
 		BAAC20C42DB9BB5E00BC8B60 /* IgnoreURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC20C32DB9BB5E00BC8B60 /* IgnoreURLsTests.swift */; };
 		BAAC20C62DBB0F2900BC8B60 /* ThreadSafeDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC20C52DBB0F2900BC8B60 /* ThreadSafeDictionaryTests.swift */; };
@@ -1031,8 +1031,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4754BC12DB8ED8F00E74532 /* CiscoLogger in Frameworks */,
+				BA80F9E42DCEB343007F64FA /* CrashReporter in Frameworks */,
 				4B9641132D60FEF4009A2E7F /* SplunkCommon.framework in Frameworks */,
-				4BAA09F12D9361AB00B7D6AE /* SplunkCrashReporter in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3453,8 +3453,8 @@
 			);
 			name = SplunkCrashReports;
 			packageProductDependencies = (
-				4BAA09F02D9361AB00B7D6AE /* SplunkCrashReporter */,
 				E4754BC02DB8ED8F00E74532 /* CiscoLogger */,
+				BA80F9E32DCEB343007F64FA /* CrashReporter */,
 			);
 			productName = SplunkCrashReports;
 			productReference = 4B9640E82D60FE72009A2E7F /* SplunkCrashReports.framework */;
@@ -3815,7 +3815,7 @@
 			packageReferences = (
 				4B9642812D613B32009A2E7F /* XCRemoteSwiftPackageReference "smartlook-ios-sdk-private" */,
 				4B0F23872D79F2C000EA575A /* XCRemoteSwiftPackageReference "opentelemetry-swift" */,
-				4BAA09ED2D9360A000B7D6AE /* XCLocalSwiftPackageReference "../SplunkCrashReporter" */,
+				BA80F9E22DCEB343007F64FA /* XCRemoteSwiftPackageReference "plcrashreporter" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3384F2A32AC879E900512D79 /* Products */;
@@ -7681,6 +7681,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -7721,6 +7722,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -7761,6 +7763,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -7801,6 +7804,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -7841,6 +7845,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -7881,6 +7886,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				OTHER_SWIFT_FLAGS = "-no-verify-emitted-module-interface";
 				PRODUCT_BUNDLE_IDENTIFIER = com.splunk.rum.SplunkCrashReports;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
@@ -10223,13 +10229,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		4BAA09ED2D9360A000B7D6AE /* XCLocalSwiftPackageReference "../SplunkCrashReporter" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../SplunkCrashReporter;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		4B0F23872D79F2C000EA575A /* XCRemoteSwiftPackageReference "opentelemetry-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -10245,6 +10244,14 @@
 			requirement = {
 				branch = develop;
 				kind = branch;
+			};
+		};
+		BA80F9E22DCEB343007F64FA /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/microsoft/plcrashreporter.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.12.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -10310,15 +10317,15 @@
 			package = 4B0F23872D79F2C000EA575A /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
 			productName = ZipkinExporter;
 		};
-		4BAA09F02D9361AB00B7D6AE /* SplunkCrashReporter */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4BAA09ED2D9360A000B7D6AE /* XCLocalSwiftPackageReference "../SplunkCrashReporter" */;
-			productName = SplunkCrashReporter;
-		};
 		52D945C82DC0A7F500DE8220 /* CiscoLogger */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4B9642812D613B32009A2E7F /* XCRemoteSwiftPackageReference "smartlook-ios-sdk-private" */;
 			productName = CiscoLogger;
+		};
+		BA80F9E32DCEB343007F64FA /* CrashReporter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA80F9E22DCEB343007F64FA /* XCRemoteSwiftPackageReference "plcrashreporter" */;
+			productName = CrashReporter;
 		};
 		C791ADFA2DAE72D5002AAA2B /* OpenTelemetryProtocolExporter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -19,7 +19,9 @@ internal import CiscoLogger
 import Foundation
 import SplunkCommon
 import CrashReporter
-//internal import SplunkCrashReporter
+
+// Temporarily remove local CrashReporter in favor of SPM version
+// internal import SplunkCrashReporter
 
 public class CrashReports {
 
@@ -50,8 +52,16 @@ public class CrashReports {
 #else
         let signalHandlerType = PLCrashReporterSignalHandlerType.mach
 #endif
+        // Setup private path for crash reports to avoid conflict with other
+        // instances of PLCrashReporter present in the client app
+        let fileManager = FileManager.default
+        let crashDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("SplunkCrashReports", isDirectory: true)
+        try? fileManager.createDirectory(at: crashDirectory, withIntermediateDirectories: true)
 
-        let signalConfig = PLCrashReporterConfig(signalHandlerType: signalHandlerType, symbolicationStrategy: [])
+        let signalConfig = PLCrashReporterConfig(
+            signalHandlerType: signalHandlerType,
+            symbolicationStrategy: [],
+            basePath: crashDirectory.path)
         guard let crashReporterInstance = PLCrashReporter(configuration: signalConfig) else {
             logger.log(level: .error) {
                 "PLCrashReporter failed to initialize."


### PR DESCRIPTION
- Added PLCrashReporter via github
- Added a separate on device folder to hold the crash reports, to avoid conflict with other instances (Firebase etc.)
- This folder is currently called 'SplunkCrashReports'
- Switched out SPLKPLCrashReporter from the build.

Please note:  Left SplunkCrashReporter in place in the project.  Code is not used and can be removed once testing is complete.
