### PR TITLE
DEMRUM-1307: Implement local sampling

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Random Number Providers/SystemRandomNumberProvider.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Random Number Providers/SystemRandomNumberProvider.swift
@@ -21,6 +21,7 @@ import Foundation
 protocol RandomNumberProvider {
 
     /// Generates a random `Double` within the specified inclusive range.
+    ///
     /// - Parameters:
     ///   - range: A `ClosedRange<Double>` specifying the lower and upper bounds for the random number.
     /// - Returns: A random `Double` within the specified range.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Random Number Providers/SystemRandomNumberProvider.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Random Number Providers/SystemRandomNumberProvider.swift
@@ -1,0 +1,43 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// A protocol designed for objects that can provide random numbers.
+protocol RandomNumberProvider {
+
+    /// Generates a random `Double` within the specified inclusive range.
+    /// - Parameters:
+    ///   - range: A `ClosedRange<Double>` specifying the lower and upper bounds for the random number.
+    /// - Returns: A random `Double` within the specified range.
+    func randomNumber(in range: ClosedRange<Double>) -> Double
+}
+
+/// A default implementation of `RandomNumberProvider` that utilizes the
+/// system's `Double.random(in:)` function for generating random numbers.
+///
+/// This provider is suitable for most general-purpose statistical samplers.
+struct SystemRandomNumberProvider: RandomNumberProvider {
+
+    /// Generates a random `Double` using `Double.random(in: range)`.
+    ///
+    /// - Parameter range: The inclusive range within which to generate the random number.
+    /// - Returns: A random `Double` within the specified range.
+    func randomNumber(in range: ClosedRange<Double>) -> Double {
+        return Double.random(in: range)
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/BaseSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/BaseSampler.swift
@@ -1,0 +1,29 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// A protocol defining the fundamental contract for all samplers.
+protocol BaseSampler: AnyObject {
+
+    /// Calculates a sampling decision.
+    ///
+    /// This function determines whether an item (or session) should be recorded or sampled out
+    /// based on the sampler's specific logic and configuration.
+    ///
+    /// - Returns: A `SamplingDecision` indicating whether to sample in (`.notSampledOut`)
+    ///            or sample out (`.sampledOut`).
+    func sample() -> SamplingDecision
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/BaseSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/BaseSampler.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A protocol defining the fundamental contract for all samplers.
+/// A protocol defining the fundamental behaviour for all samplers.
 protocol BaseSampler: AnyObject {
 
     /// Calculates a sampling decision.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOffAgentSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOffAgentSampler.swift
@@ -31,8 +31,8 @@ final class AlwaysOffAgentSampler: AgentSessionSampler {
 
     /// A non-operational configuration method.
     ///
-    /// - Parameter _: The agent configuration (ignored).
-    func configure(with _: any AgentConfigurationProtocol) {}
+    /// - Parameter configuration: The agent configuration (ignored).
+    func configure(with configuration: any AgentConfigurationProtocol) {}
 
 
     // MARK: - Sampling

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOffAgentSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOffAgentSampler.swift
@@ -1,0 +1,46 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// An internal helper implementation of `AgentSessionSampler` that always returns `.sampledOut`.
+final class AlwaysOffAgentSampler: AgentSessionSampler {
+
+    // MARK: - Constants
+
+    let upperBound: Double = 0
+
+    let lowerBound: Double = 0
+
+    let probability: Double = 0
+
+
+    // MARK: - Configuration
+
+    /// A non-operational configuration method.
+    ///
+    /// - Parameter _: The agent configuration (ignored).
+    func configure(with _: any AgentConfigurationProtocol) {}
+
+
+    // MARK: - Sampling
+
+    /// A non-operational sampling method.
+    ///
+    /// - Returns: Always returns `.sampledOut`.
+    func sample() -> SamplingDecision {
+        return .sampledOut
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOnAgentSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOnAgentSampler.swift
@@ -31,7 +31,7 @@ final class AlwaysOnAgentSampler: AgentSessionSampler {
 
     /// A non-operational configuration method.
     ///
-    /// - Parameter _: The agent configuration (ignored).
+    /// - Parameter configuration: The agent configuration (ignored).
     func configure(with configuration: any AgentConfigurationProtocol) {}
 
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOnAgentSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/AlwaysOnAgentSampler.swift
@@ -1,0 +1,46 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// An internal helper implementation of `AgentSessionSampler` that always returns `.notSampledOut`.
+final class AlwaysOnAgentSampler: AgentSessionSampler {
+
+    // MARK: - Constants
+
+    let probability: Double = 1.0
+
+    let upperBound: Double = 1.0
+
+    let lowerBound: Double = 0.0
+
+
+    // MARK: - Configuration
+
+    /// A non-operational configuration method.
+    ///
+    /// - Parameter _: The agent configuration (ignored).
+    func configure(with configuration: any AgentConfigurationProtocol) {}
+
+
+    // MARK: - Sampling
+
+    /// A non-operational sampling method.
+    ///
+    /// - Returns: Always returns `.notSampledOut`.
+    func sample() -> SamplingDecision {
+        return .notSampledOut
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/SamplerFactory.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/Sampler Factory/SamplerFactory.swift
@@ -1,0 +1,34 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// A factory enum providing convenient constructors for common `AgentSessionSampler` instances.
+enum SamplerFactory {
+
+    /// Creates an agent session sampler that always returns `.notSampledOut`.
+    ///
+    /// - Returns: An `AgentSessionSampler` instance.
+    static func alwaysOnSampler() -> AgentSessionSampler {
+        return AlwaysOnAgentSampler()
+    }
+
+    /// Creates an agent session sampler that always  returns `.sampledOut`.
+    ///
+    /// - Returns: An instance of `NoOpAgentSessionSampler`.
+    static func alwaysOffSampler() -> AgentSessionSampler {
+        return AlwaysOffAgentSampler()
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/StatisticalSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/StatisticalSampler.swift
@@ -18,7 +18,7 @@ limitations under the License.
 /// A protocol for samplers that calculate decisions based on statistical probability.
 protocol StatisticalSampler: BaseSampler {
 
-    /// The target probability of sampling an item (e.g., 0.5 for 50% sampling rate).
+    /// The target probability of sampling an item.
     var probability: Double { get }
 
     /// The upper bound of the interval used for generating random numbers in the sampling decision.
@@ -46,6 +46,11 @@ extension StatisticalSampler {
     /// - Returns: A `SamplingDecision`.
     func sample(randomNumberProvider: RandomNumberProvider = SystemRandomNumberProvider()) -> SamplingDecision {
 
+        // Filter out miss-configured bounds.
+        guard lowerBound <= upperBound, lowerBound >= 0.0, upperBound <= 1.0 else {
+            return .sampledOut
+        }
+
         // The user-configured sampling rate is 1, meaning we want to record all Agent sessions.
         if probability == 1.0 {
             return .notSampledOut
@@ -53,11 +58,6 @@ extension StatisticalSampler {
 
         // The user-configured sampling rate is 0, meaning we want to record no Agent sessions.
         if probability == 0.0 {
-            return .sampledOut
-        }
-
-        // Filter out miss-configured bounds.
-        guard lowerBound <= upperBound else {
             return .sampledOut
         }
 
@@ -71,7 +71,7 @@ extension StatisticalSampler {
 
         return .sampledOut
     }
-    
+
     /// Calculates a sampling decision using the default system random number provider by
     /// calling the default `sample(randomNumberProvider: RandomNumberProvider)` function.
     ///

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/StatisticalSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Samplers/StatisticalSampler.swift
@@ -1,0 +1,82 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// A protocol for samplers that calculate decisions based on statistical probability.
+protocol StatisticalSampler: BaseSampler {
+
+    /// The target probability of sampling an item (e.g., 0.5 for 50% sampling rate).
+    var probability: Double { get }
+
+    /// The upper bound of the interval used for generating random numbers in the sampling decision.
+    var upperBound: Double { get }
+
+    /// The lower bound of the interval used for generating random numbers in the sampling decision.
+    var lowerBound: Double { get }
+}
+
+extension StatisticalSampler {
+
+    // MARK: - Default sampling function implementation
+
+    /// Provides a default sampling decision logic for statistical samplers.
+    ///
+    /// This implementation compares a randomly generated number against the sampler's `probability`.
+    /// - If `probability` is 1.0, it always returns `.notSampledOut`.
+    /// - If `probability` is 0.0, it always returns `.sampledOut`.
+    /// - Otherwise, it generates a random number within the `[lowerBound, upperBound]` range.
+    ///   If this random number is less than or equal to `probability`, it returns `.notSampledOut`, otherwise, it returns `.sampledOut`.
+    ///   For miss-configured bounds, it returns `.sampledOut`.
+    ///
+    /// - Parameter randomNumberProvider: An object conforming to `RandomNumberProvider`
+    ///   used to generate the random number. Defaults to `SystemRandomNumberProvider()`.
+    /// - Returns: A `SamplingDecision`.
+    func sample(randomNumberProvider: RandomNumberProvider = SystemRandomNumberProvider()) -> SamplingDecision {
+
+        // The user-configured sampling rate is 1, meaning we want to record all Agent sessions.
+        if probability == 1.0 {
+            return .notSampledOut
+        }
+
+        // The user-configured sampling rate is 0, meaning we want to record no Agent sessions.
+        if probability == 0.0 {
+            return .sampledOut
+        }
+
+        // Filter out miss-configured bounds.
+        guard lowerBound <= upperBound else {
+            return .sampledOut
+        }
+
+        // For any other value, we want to generate a random constant...
+        let randomNumber = randomNumberProvider.randomNumber(in: lowerBound ... upperBound)
+
+        // ... and do a bound comparison against the configured sampling rate.
+        if randomNumber <= probability {
+            return .notSampledOut
+        }
+
+        return .sampledOut
+    }
+    
+    /// Calculates a sampling decision using the default system random number provider by
+    /// calling the default `sample(randomNumberProvider: RandomNumberProvider)` function.
+    ///
+    /// - Returns: A `SamplingDecision`.
+    func sample() -> SamplingDecision {
+        return sample(randomNumberProvider: SystemRandomNumberProvider())
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/SamplingDecision.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/SamplingDecision.swift
@@ -15,13 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a
-/// Calculated as the result of a `BaseSampler`'s `sample()` function call.
+/// Defines a sampling decision, calculated as the result of a `BaseSampler`'s `sample()` function call.
 enum SamplingDecision {
 
-    /// Indicates that the item/session should be sampled out (i.e., not recorded or traced).
+    /// Indicates that the item/session should be sampled out.
     case sampledOut
 
-    /// Indicates that the item/session should not be sampled out (i.e., should be recorded or traced).
+    /// Indicates that the item/session should not be sampled out.
     case notSampledOut
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/SamplingDecision.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/SamplingDecision.swift
@@ -1,0 +1,27 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Defines a
+/// Calculated as the result of a `BaseSampler`'s `sample()` function call.
+enum SamplingDecision {
+
+    /// Indicates that the item/session should be sampled out (i.e., not recorded or traced).
+    case sampledOut
+
+    /// Indicates that the item/session should not be sampled out (i.e., should be recorded or traced).
+    case notSampledOut
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/AgentSessionSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/AgentSessionSampler.swift
@@ -20,9 +20,9 @@ limitations under the License.
 /// It adds a mechanism to configure the sampler agent-specific session sampling rate.
 protocol AgentSessionSampler: StatisticalSampler {
 
-    /// Configures the session sampler with agent-specific session sampling rate.
+    /// Configures the session sampler with agent-specific configuration.
     ///
-    /// - Parameter configuration: A `AgentConfigurationProtocol` object
-    ///                          which provides the necessary `sessionSamplingRate` configuration.
+    /// - Parameter configuration: A `AgentConfigurationProtocol` object which provides
+    ///                           the necessary `sessionSamplingRate` configuration.
     func configure(with configuration: any AgentConfigurationProtocol)
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/AgentSessionSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/AgentSessionSampler.swift
@@ -1,0 +1,28 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// A specialized `StatisticalSampler` for agent-based session sampling.
+///
+/// It adds a mechanism to configure the sampler agent-specific session sampling rate.
+protocol AgentSessionSampler: StatisticalSampler {
+
+    /// Configures the session sampler with agent-specific session sampling rate.
+    ///
+    /// - Parameter configuration: A `AgentConfigurationProtocol` object
+    ///                          which provides the necessary `sessionSamplingRate` configuration.
+    func configure(with configuration: any AgentConfigurationProtocol)
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/DefaultAgentSessionSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/DefaultAgentSessionSampler.swift
@@ -17,7 +17,6 @@ limitations under the License.
 
 /// A default concrete implementation of `AgentSessionSampler`.
 ///
-/// This sampler uses a configurable sampling rate to make decisions.
 /// It defaults to a sampling rate of 1.0 (sample all sessions) until configured otherwise.
 /// The random number generation for sampling decisions uses the `[0.0, 1.0]` bounding interval.
 final class DefaultAgentSessionSampler: AgentSessionSampler {

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/DefaultAgentSessionSampler.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Sampling/Session Sampling/DefaultAgentSessionSampler.swift
@@ -1,0 +1,46 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// A default concrete implementation of `AgentSessionSampler`.
+///
+/// This sampler uses a configurable sampling rate to make decisions.
+/// It defaults to a sampling rate of 1.0 (sample all sessions) until configured otherwise.
+/// The random number generation for sampling decisions uses the `[0.0, 1.0]` bounding interval.
+final class DefaultAgentSessionSampler: AgentSessionSampler {
+
+    // MARK: - StatisticalSampler Conformance
+
+    /// The upper bound for random number generation, fixed at 1.0.
+    let upperBound: Double = 1.0
+
+    /// The lower bound for random number generation, fixed at 0.0.
+    let lowerBound: Double = 0.0
+
+    /// The probability of sampling a session, configurable via the `configure` method.
+    /// Defaults to 1.0 (always sample).
+    var probability: Double = 1.0
+
+
+    // MARK: - Configuration
+
+    /// Configures the sampler with the session sampling rate from the provided agent configuration.
+    /// - Parameter configuration: An object conforming to `AgentConfigurationProtocol` that
+    /// supplies the `sessionSamplingRate`.
+    func configure(with configuration: any AgentConfigurationProtocol) {
+        probability = configuration.sessionSamplingRate
+    }
+}

--- a/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
+++ b/SplunkAgent/SplunkAgent.xcodeproj/project.pbxproj
@@ -152,6 +152,18 @@
 		4BB680F52B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680E12B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift */; };
 		4BB680F62B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */; };
 		4BB680FF2B7A7A53000A54D4 /* API-1.0-ModuleProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */; };
+		4BEEA75C2DE33BEC006AC6C7 /* AgentSessionSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA75B2DE33BDF006AC6C7 /* AgentSessionSampler.swift */; };
+		4BEEA75F2DE3471E006AC6C7 /* DefaultAgentSessionSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA75E2DE34718006AC6C7 /* DefaultAgentSessionSampler.swift */; };
+		4BEEA7612DE347AF006AC6C7 /* SamplingDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7602DE347A9006AC6C7 /* SamplingDecision.swift */; };
+		4BEEA7632DE34A06006AC6C7 /* StatisticalSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7622DE349F6006AC6C7 /* StatisticalSampler.swift */; };
+		4BEEA7682DE364E7006AC6C7 /* BaseSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7672DE364D0006AC6C7 /* BaseSampler.swift */; };
+		4BEEA76B2DE37DA1006AC6C7 /* SystemRandomNumberProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA76A2DE37D9B006AC6C7 /* SystemRandomNumberProvider.swift */; };
+		4BEEA76E2DE38ACB006AC6C7 /* SamplerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA76D2DE38AC8006AC6C7 /* SamplerFactory.swift */; };
+		4BEEA7712DE3911C006AC6C7 /* AlwaysOnAgentSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7702DE39116006AC6C7 /* AlwaysOnAgentSampler.swift */; };
+		4BEEA7732DE3914E006AC6C7 /* AlwaysOffAgentSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7722DE39148006AC6C7 /* AlwaysOffAgentSampler.swift */; };
+		4BEEA7752DE3A6CA006AC6C7 /* DefaultAgentSessionSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7742DE3A6B8006AC6C7 /* DefaultAgentSessionSamplerTests.swift */; };
+		4BEEA7772DE3A777006AC6C7 /* SystemRandomNumberProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7762DE3A768006AC6C7 /* SystemRandomNumberProviderTests.swift */; };
+		4BEEA77A2DE3A81D006AC6C7 /* RandomNumberProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEA7792DE3A817006AC6C7 /* RandomNumberProviderMock.swift */; };
 		4BF895742DAD7C2100E171A4 /* SplunkConfigurationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF895732DAD7C2100E171A4 /* SplunkConfigurationHandler.swift */; };
 		4BF8957F2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF8957D2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift */; };
 		4BF895812DAD987D00E171A4 /* RemoteConfigurationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF895802DAD987D00E171A4 /* RemoteConfigurationModel.swift */; };
@@ -721,6 +733,18 @@
 		4BB680E12B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionReplayStatus.swift"; sourceTree = "<group>"; };
 		4BB680E22B7940C0000A54D4 /* API-1.0-SessionReplayModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "API-1.0-SessionReplayModule.swift"; sourceTree = "<group>"; };
 		4BB680FD2B7A7A04000A54D4 /* API-1.0-ModuleProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API-1.0-ModuleProxyTests.swift"; sourceTree = "<group>"; };
+		4BEEA75B2DE33BDF006AC6C7 /* AgentSessionSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionSampler.swift; sourceTree = "<group>"; };
+		4BEEA75E2DE34718006AC6C7 /* DefaultAgentSessionSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAgentSessionSampler.swift; sourceTree = "<group>"; };
+		4BEEA7602DE347A9006AC6C7 /* SamplingDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingDecision.swift; sourceTree = "<group>"; };
+		4BEEA7622DE349F6006AC6C7 /* StatisticalSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticalSampler.swift; sourceTree = "<group>"; };
+		4BEEA7672DE364D0006AC6C7 /* BaseSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSampler.swift; sourceTree = "<group>"; };
+		4BEEA76A2DE37D9B006AC6C7 /* SystemRandomNumberProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemRandomNumberProvider.swift; sourceTree = "<group>"; };
+		4BEEA76D2DE38AC8006AC6C7 /* SamplerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplerFactory.swift; sourceTree = "<group>"; };
+		4BEEA7702DE39116006AC6C7 /* AlwaysOnAgentSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysOnAgentSampler.swift; sourceTree = "<group>"; };
+		4BEEA7722DE39148006AC6C7 /* AlwaysOffAgentSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlwaysOffAgentSampler.swift; sourceTree = "<group>"; };
+		4BEEA7742DE3A6B8006AC6C7 /* DefaultAgentSessionSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAgentSessionSamplerTests.swift; sourceTree = "<group>"; };
+		4BEEA7762DE3A768006AC6C7 /* SystemRandomNumberProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemRandomNumberProviderTests.swift; sourceTree = "<group>"; };
+		4BEEA7792DE3A817006AC6C7 /* RandomNumberProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNumberProviderMock.swift; sourceTree = "<group>"; };
 		4BF895732DAD7C2100E171A4 /* SplunkConfigurationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkConfigurationHandler.swift; sourceTree = "<group>"; };
 		4BF8957D2DAD984D00E171A4 /* SplunkConfigurationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplunkConfigurationHandlerTests.swift; sourceTree = "<group>"; };
 		4BF895802DAD987D00E171A4 /* RemoteConfigurationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationModel.swift; sourceTree = "<group>"; };
@@ -2188,6 +2212,72 @@
 			path = SessionReplay;
 			sourceTree = "<group>";
 		};
+		4BEEA75A2DE33BD7006AC6C7 /* Sampling */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA7692DE37D7B006AC6C7 /* Random Number Providers */,
+				4BEEA7662DE364C7006AC6C7 /* Samplers */,
+				4BEEA7602DE347A9006AC6C7 /* SamplingDecision.swift */,
+				4BEEA75D2DE3470E006AC6C7 /* Session Sampling */,
+			);
+			path = Sampling;
+			sourceTree = "<group>";
+		};
+		4BEEA75D2DE3470E006AC6C7 /* Session Sampling */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA75E2DE34718006AC6C7 /* DefaultAgentSessionSampler.swift */,
+				4BEEA75B2DE33BDF006AC6C7 /* AgentSessionSampler.swift */,
+			);
+			path = "Session Sampling";
+			sourceTree = "<group>";
+		};
+		4BEEA7662DE364C7006AC6C7 /* Samplers */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA76F2DE390FB006AC6C7 /* Sampler Factory */,
+				4BEEA7672DE364D0006AC6C7 /* BaseSampler.swift */,
+				4BEEA7622DE349F6006AC6C7 /* StatisticalSampler.swift */,
+			);
+			path = Samplers;
+			sourceTree = "<group>";
+		};
+		4BEEA7692DE37D7B006AC6C7 /* Random Number Providers */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA76A2DE37D9B006AC6C7 /* SystemRandomNumberProvider.swift */,
+			);
+			path = "Random Number Providers";
+			sourceTree = "<group>";
+		};
+		4BEEA76C2DE3892D006AC6C7 /* Sampling */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA7782DE3A80C006AC6C7 /* Mocks */,
+				4BEEA7762DE3A768006AC6C7 /* SystemRandomNumberProviderTests.swift */,
+				4BEEA7742DE3A6B8006AC6C7 /* DefaultAgentSessionSamplerTests.swift */,
+			);
+			path = Sampling;
+			sourceTree = "<group>";
+		};
+		4BEEA76F2DE390FB006AC6C7 /* Sampler Factory */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA7722DE39148006AC6C7 /* AlwaysOffAgentSampler.swift */,
+				4BEEA7702DE39116006AC6C7 /* AlwaysOnAgentSampler.swift */,
+				4BEEA76D2DE38AC8006AC6C7 /* SamplerFactory.swift */,
+			);
+			path = "Sampler Factory";
+			sourceTree = "<group>";
+		};
+		4BEEA7782DE3A80C006AC6C7 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				4BEEA7792DE3A817006AC6C7 /* RandomNumberProviderMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		4BF8957E2DAD984D00E171A4 /* Splunk Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -2631,6 +2721,7 @@
 		E468964F2B220D8800727A6A /* Agent */ = {
 			isa = PBXGroup;
 			children = (
+				4BEEA76C2DE3892D006AC6C7 /* Sampling */,
 				C703FAB62BAD8526000CC11B /* AppState */,
 				C73FF49C2B6CE809009C53FF /* Configuration */,
 				2AA52B472B8DF4CD00DF9373 /* Events */,
@@ -2914,6 +3005,7 @@
 		E4F2E4F82B172911006EBA69 /* Agent */ = {
 			isa = PBXGroup;
 			children = (
+				4BEEA75A2DE33BD7006AC6C7 /* Sampling */,
 				C703FAAD2BA9D3A2000CC11B /* AppState */,
 				E4F2E4F72B172853006EBA69 /* Configuration */,
 				2AE43B3F2B861325002C4A98 /* Events */,
@@ -3938,6 +4030,7 @@
 				E4A708B32B9754B7002C692E /* RepeatingJob.swift in Sources */,
 				E4EE9ED42BA34A400000D594 /* SessionReplayNonOperationalState.swift in Sources */,
 				E4B737E12BBECEDD00086A93 /* PlatformSupport.swift in Sources */,
+				4BEEA7632DE34A06006AC6C7 /* StatisticalSampler.swift in Sources */,
 				2A1673CD2BA1F52600F85698 /* EventsModel.swift in Sources */,
 				BAAC20C82DBB0F4800BC8B60 /* ThreadSafeDictionary.swift in Sources */,
 				2AE43B0C2B7FAD9B002C4A98 /* DefaultResources.swift in Sources */,
@@ -3949,6 +4042,7 @@
 				E4134BAB2BC6AC5400F0D2FC /* API-1.0-Status.swift in Sources */,
 				4BF895AD2DB3CC7D00E171A4 /* API-1.0-SessionState.swift in Sources */,
 				4BB680F52B7940C0000A54D4 /* API-1.0-SessionReplayStatus.swift in Sources */,
+				4BEEA7612DE347AF006AC6C7 /* SamplingDecision.swift in Sources */,
 				5280E2912DC0AD6300770A90 /* API-1.0-WebViewInstrumentationModule.swift in Sources */,
 				E4F3ACB82DA7B800007EFC0A /* API-1.0-UserState.swift in Sources */,
 				E4E4B1122BA19A5B001CB6B3 /* SessionReplay.swift in Sources */,
@@ -3958,10 +4052,13 @@
 				2AE43B482B861325002C4A98 /* SessionReplayDataEvent.swift in Sources */,
 				E4BA26CC2BC3F8CE0067FC84 /* ConfigurationHandlerNonOperational.swift in Sources */,
 				E4BA26CA2BC3D75E0067FC84 /* CompileInfo.swift in Sources */,
+				4BEEA7732DE3914E006AC6C7 /* AlwaysOffAgentSampler.swift in Sources */,
 				E4F3ACB42DA7B444007EFC0A /* API-1.0-UserTrackingMode.swift in Sources */,
 				2AB51E972B7A670600307B77 /* SystemInfo.swift in Sources */,
 				E4F2E5072B1733C9006EBA69 /* AgentSession.swift in Sources */,
 				BA7A63BE2DB8198200A44570 /* MutableAttributes.swift in Sources */,
+				4BEEA76E2DE38ACB006AC6C7 /* SamplerFactory.swift in Sources */,
+				4BEEA75F2DE3471E006AC6C7 /* DefaultAgentSessionSampler.swift in Sources */,
 				4BB680E82B7940C0000A54D4 /* RecordingMask+Conversions.swift in Sources */,
 				E4AD34F42B56E075004976CA /* AgentModulesManager.swift in Sources */,
 				2AB51E982B7A670600307B77 /* AppInfo.swift in Sources */,
@@ -3998,6 +4095,7 @@
 				E4AD34F62B56E4BB004976CA /* DefaultModulesManager.swift in Sources */,
 				E4A537502DA66B5A002323E2 /* AgentRuntimeAttributes.swift in Sources */,
 				4BB680E92B7940C0000A54D4 /* Status+Conversions.swift in Sources */,
+				4BEEA75C2DE33BEC006AC6C7 /* AgentSessionSampler.swift in Sources */,
 				4BF895742DAD7C2100E171A4 /* SplunkConfigurationHandler.swift in Sources */,
 				E426CFAA2B28C18000094AC0 /* SessionsModel.swift in Sources */,
 				E42634832BB44B0F003706A9 /* SplunkAgent.docc in Sources */,
@@ -4006,12 +4104,15 @@
 				C703FAB32BA9D424000CC11B /* AppState.swift in Sources */,
 				E4F2E5102B1737F2006EBA69 /* API-1.0-Session.swift in Sources */,
 				C703FAB12BA9D41E000CC11B /* AppStateManager.swift in Sources */,
+				4BEEA7682DE364E7006AC6C7 /* BaseSampler.swift in Sources */,
 				C73FF4852B6CE749009C53FF /* RemoteConfiguration.swift in Sources */,
 				C7FFC4F52B7662E30035203B /* Service.swift in Sources */,
 				C73FF4792B6CE72A009C53FF /* ConfigurationDefaults.swift in Sources */,
 				E426CFAB2B28C18000094AC0 /* SessionItem.swift in Sources */,
 				E4B737DD2BBECBFB00086A93 /* PlatformSupportScope.swift in Sources */,
+				4BEEA7712DE3911C006AC6C7 /* AlwaysOnAgentSampler.swift in Sources */,
 				C73FF4872B6CE749009C53FF /* ConfigurationHandler+LoadRemote.swift in Sources */,
+				4BEEA76B2DE37DA1006AC6C7 /* SystemRandomNumberProvider.swift in Sources */,
 				C73FF4942B6CE777009C53FF /* Endpoint.swift in Sources */,
 				E4A537522DA66DB6002323E2 /* DefaultRuntimeAttributes.swift in Sources */,
 				E4E4B1162BA1A0DA001CB6B3 /* SessionReplay+RecordingMask.swift in Sources */,
@@ -4308,6 +4409,7 @@
 				E44D73BE2B99B10600121EA4 /* XCTestCase+SimulateWait.swift in Sources */,
 				2AAC95E42D6C7427004FAE2C /* String+HexID.swift in Sources */,
 				2AAC95E82D6C78DF004FAE2C /* HexIDTests.swift in Sources */,
+				4BEEA77A2DE3A81D006AC6C7 /* RandomNumberProviderMock.swift in Sources */,
 				E4EE9ECA2BA322F50000D594 /* SessionReplayTestBuilder.swift in Sources */,
 				E46896552B22102E00727A6A /* RuntimeStateTests.swift in Sources */,
 				2AE43B042B7BA352002C4A98 /* ResourcesTests.swift in Sources */,
@@ -4334,7 +4436,9 @@
 				E40549812DACF65D00B7A2E4 /* DefaultUserTestBuilder.swift in Sources */,
 				E4577D7B2B9F2BA700DFA2C2 /* XCTestCase+SimulateBackground.swift in Sources */,
 				E468964E2B21EDE000727A6A /* API-1.0-StateTests.swift in Sources */,
+				4BEEA7772DE3A777006AC6C7 /* SystemRandomNumberProviderTests.swift in Sources */,
 				2AC8C0952BAAE0710052ECF4 /* EventsModelTests.swift in Sources */,
+				4BEEA7752DE3A6CA006AC6C7 /* DefaultAgentSessionSamplerTests.swift in Sources */,
 				BA7A63BC2DB8196800A44570 /* MutableAttributesTests.swift in Sources */,
 				E46896362B21CA0300727A6A /* UserDefaultsStoragePrefixTests.swift in Sources */,
 				E4FAEEB22B6A6A73008D4E6E /* SessionReplayTestModule.swift in Sources */,

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/DefaultAgentSessionSamplerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/DefaultAgentSessionSamplerTests.swift
@@ -1,0 +1,121 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@testable import SplunkAgent
+import XCTest
+
+final class DefaultAgentSessionSamplerTests: XCTestCase {
+
+    var sampler: DefaultAgentSessionSampler!
+    var mockRandomNumberProvider: MockRandomNumberProvider!
+
+    override func setUp() {
+        super.setUp()
+
+        sampler = DefaultAgentSessionSampler()
+        mockRandomNumberProvider = MockRandomNumberProvider()
+    }
+
+    override func tearDown() {
+        sampler = nil
+        mockRandomNumberProvider = nil
+
+        super.tearDown()
+    }
+
+    func testInitialProbability() {
+        XCTAssertEqual(sampler.probability, 1.0, "Default probability should be 1.0 (always sample).")
+        XCTAssertEqual(sampler.lowerBound, 0.0, "Default lowerBound should be 0.0.")
+        XCTAssertEqual(sampler.upperBound, 1.0, "Default upperBound should be 1.0.")
+    }
+
+    func testConfigureUpdatesProbability() throws {
+        let newSamplingRate = 0.5
+
+        var configuration = try ConfigurationTestBuilder.buildDefault()
+        configuration.sessionSamplingRate = newSamplingRate
+
+        sampler.configure(with: configuration)
+
+        XCTAssertEqual(sampler.probability, newSamplingRate, "Probability should be updated by configure().")
+    }
+
+
+    func testSample_givenNotSamplesOut() {
+        sampler.probability = 1.0
+
+        let decision = sampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .notSampledOut)
+        XCTAssertTrue(mockRandomNumberProvider.nextRandomNumbers.isEmpty, "Random number provider should not be used if probability is 1.0")
+    }
+
+    func testSample_givenSamplesOut() {
+        sampler.probability = 0.0
+
+        let decision = sampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .sampledOut)
+        XCTAssertTrue(mockRandomNumberProvider.nextRandomNumbers.isEmpty, "Random number provider should not be used if probability is 0.0")
+    }
+
+    func testSample_givenRandomNumberLessThanOrEqualToProbability_shouldSample() {
+        sampler.probability = 0.75
+        mockRandomNumberProvider.nextRandomNumbers = [0.5]
+
+        let decision = sampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .notSampledOut)
+        XCTAssertEqual(mockRandomNumberProvider.rangesProvided.count, 1)
+        XCTAssertEqual(mockRandomNumberProvider.rangesProvided.first, sampler.lowerBound ... sampler.upperBound)
+    }
+
+    func testSample_givenRandomNumberGreaterThanProbability_shouldNotSampleOut() {
+        sampler.probability = 0.25
+        mockRandomNumberProvider.nextRandomNumbers = [0.5]
+
+        let decision = sampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .sampledOut)
+        XCTAssertEqual(mockRandomNumberProvider.rangesProvided.count, 1)
+        XCTAssertEqual(mockRandomNumberProvider.rangesProvided.first, sampler.lowerBound ... sampler.upperBound)
+    }
+
+    func testSample_givenRandomNumberEqualToProbability_shouldSample() {
+        sampler.probability = 0.5
+        mockRandomNumberProvider.nextRandomNumbers = [0.5]
+
+        let decision = sampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .notSampledOut)
+    }
+
+    func testSample_lowerBoundGreaterThanUpperBound_samplesOut() {
+        // This sanity tests the guard condition added in StatisticalSampler extension
+        class MisconfiguredSampler: StatisticalSampler {
+            let probability: Double = 0.5
+            let upperBound: Double = 0.0
+            let lowerBound: Double = 1.0
+        }
+
+        let misconfiguredSampler = MisconfiguredSampler()
+        let decision = misconfiguredSampler.sample(randomNumberProvider: mockRandomNumberProvider)
+
+        XCTAssertEqual(decision, .sampledOut)
+        XCTAssertTrue(mockRandomNumberProvider.nextRandomNumbers.isEmpty, "Random number provider should not be used if misconfigured.")
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/Mocks/RandomNumberProviderMock.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/Mocks/RandomNumberProviderMock.swift
@@ -1,0 +1,53 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+@testable import SplunkAgent
+
+class MockRandomNumberProvider: RandomNumberProvider {
+
+    // MARK: - Properties
+
+    var nextRandomNumbers: [Double] = []
+    var rangesProvided: [ClosedRange<Double>] = []
+
+    private var currentIndex = 0
+
+    func randomNumber(in range: ClosedRange<Double>) -> Double {
+        rangesProvided.append(range)
+
+        if nextRandomNumbers.isEmpty {
+            // Fallback if no numbers are provided, though tests should always provide them.
+            fatalError("MockRandomNumberProvider: nextRandomNumbers is empty. Test should set this.")
+        }
+
+        if currentIndex >= nextRandomNumbers.count {
+            fatalError("MockRandomNumberProvider: Not enough random numbers provided for the test.")
+        }
+
+        let number = nextRandomNumbers[currentIndex]
+        currentIndex += 1
+
+        return number
+    }
+
+    func reset() {
+        currentIndex = 0
+        nextRandomNumbers = []
+        rangesProvided = []
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/SystemRandomNumberProviderTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Sampling/SystemRandomNumberProviderTests.swift
@@ -1,0 +1,51 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@testable import SplunkAgent
+import XCTest
+
+final class SystemRandomNumberProviderTests: XCTestCase {
+
+    var provider: SystemRandomNumberProvider!
+
+    override func setUp() {
+        super.setUp()
+        provider = SystemRandomNumberProvider()
+    }
+
+    override func tearDown() {
+        provider = nil
+        super.tearDown()
+    }
+
+    func testRandomNumberWithinRange() {
+        let testRange = 0.25 ... 0.75
+
+        // Silly simulate randomness...
+        for _ in 0 ..< 100 {
+            let randomNumber = provider.randomNumber(in: testRange)
+            XCTAssertGreaterThanOrEqual(randomNumber, testRange.lowerBound)
+            XCTAssertLessThanOrEqual(randomNumber, testRange.upperBound)
+        }
+    }
+
+    func testRandomNumberWithZeroLengthRange() {
+        let testRange = 0.5 ... 0.5
+        let randomNumber = provider.randomNumber(in: testRange)
+        XCTAssertEqual(randomNumber, 0.5)
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -18,20 +18,34 @@ limitations under the License.
 @testable import SplunkAgent
 import XCTest
 
-final class API10AgentTests: XCTestCase {
+final class API10AgentTests: XCTest {
+
+    var agent: SplunkRum?
+
+    override func setUp() {
+        super.setUp()
+
+        agent = nil
+    }
+
+    override func tearDown() {
+        agent = nil
+
+        super.tearDown()
+    }
 
     // MARK: - API Tests
 
-    func testInstall() throws {
+    func testInstall_givenAgentNotSampledOut() throws {
         // Test initial state
         XCTAssertTrue(SplunkRum.shared.state.status == .notRunning(.notInstalled))
 
         // Agent initialization
-        _ = try AgentTestBuilder.buildDefault()
+        agent = try AgentTestBuilder.buildDefault()
 
         // Agent install
         let configuration = try ConfigurationTestBuilder.buildDefault()
-        var agent: SplunkRum? = try SplunkRum.install(with: configuration)
+        agent = try SplunkRum.install(with: configuration)
 
         // The agent should run after install
         let agentStatus = try XCTUnwrap(agent?.state.status)
@@ -44,8 +58,30 @@ final class API10AgentTests: XCTestCase {
         // Another attempt to install should return an instance from the previous attempt
         let anotherAgentInstance = try SplunkRum.install(with: configuration)
         XCTAssertTrue(agent === anotherAgentInstance)
+    }
 
-        agent = nil
+    func testInstall_givenAgentSampledOut() throws {
+        // Test initial state
+        XCTAssertTrue(SplunkRum.shared.state.status == .notRunning(.notInstalled))
+
+        // Agent initialization
+        agent = try AgentTestBuilder.buildDefault()
+
+        // Agent install
+        let configuration = try ConfigurationTestBuilder.buildDefaultSampledOut()
+        agent = try SplunkRum.install(with: configuration)
+
+        // The agent be sampled out after install
+        let agentStatus = try XCTUnwrap(agent?.state.status)
+
+        XCTAssertEqual(agentStatus, .notRunning(.sampledOut))
+
+        // Check OpenTelemetry instance
+        XCTAssertNotNil(agent?.openTelemetry)
+
+        // Another attempt to install should return an instance from the previous attempt
+        let anotherAgentInstance = try SplunkRum.install(with: configuration)
+        XCTAssertTrue(agent === anotherAgentInstance)
     }
 
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/AgentTestBuilder.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/AgentTestBuilder.swift
@@ -34,7 +34,8 @@ final class AgentTestBuilder {
     public static func build(
         with configuration: AgentConfiguration,
         session: AgentSession = DefaultSession(),
-        user: AgentUser = DefaultUser()
+        user: AgentUser = DefaultUser(),
+        sessionSampler: AgentSessionSampler = SamplerFactory.alwaysOnSampler()
     ) throws -> SplunkRum {
         // Custom key-value storage instance with different keys for testing
         let storage = UserDefaultsStorageTestBuilder.buildCleanStorage(named: "com.splunk.rum.test.")
@@ -53,7 +54,8 @@ final class AgentTestBuilder {
             configurationHandler: handler,
             user: user,
             session: session,
-            appStateManager: appStateManager
+            appStateManager: appStateManager,
+            sessionSampler: sessionSampler
         )
 
         // Links the current session with the agent

--- a/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/ConfigurationTestBuilder.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/ConfigurationTestBuilder.swift
@@ -51,7 +51,33 @@ final class ConfigurationTestBuilder {
 
         configuration.appVersion = appVersion
         configuration.enableDebugLogging = true
-        configuration.sessionSamplingRate = 0.1
+        configuration.sessionSamplingRate = 1
+        configuration.globalAttributes = MutableAttributes(dictionary: ["attribute": .string("value")])
+        configuration.spanInterceptor = { spanData in
+            spanData
+        }
+
+        return configuration
+    }
+
+    public static func buildDefaultSampledOut() throws -> AgentConfiguration {
+
+        // Default endpoint configuration for unit testing
+        let endpoint = EndpointConfiguration(
+            realm: realm,
+            rumAccessToken: rumAccessToken
+        )
+
+        // Default configuration for unit testing
+        var configuration = AgentConfiguration(
+            endpoint: endpoint,
+            appName: appName,
+            deploymentEnvironment: deploymentEnvironment
+        )
+
+        configuration.appVersion = appVersion
+        configuration.enableDebugLogging = true
+        configuration.sessionSamplingRate = 0
         configuration.globalAttributes = MutableAttributes(dictionary: ["attribute": .string("value")])
         configuration.spanInterceptor = { spanData in
             spanData


### PR DESCRIPTION
This PR implements the models and logic to support local sampling of the Agent sessions / instances.

It also extends the Agent API tests to verify the `.sampledOut` Agent status. 