### PR TITLE
DEMRUM-2084: Implement Session Replay modules as binary target dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,122 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
+// MARK: - Binary target registry
+
+/// Registry containing all Session Replay binary target definitions.
+struct SessionReplayBinaryRegistry {
+
+    /// Internal descriptor of the Target structure, including its Wrapper name for generation.
+    struct BinaryTargetInfo {
+        let name: String
+        let url: String
+        let checksum: String
+        let productName: String
+        let wrapperName: String
+    }
+
+    static let targets: [String: BinaryTargetInfo] = [
+        "logger": BinaryTargetInfo(
+            name: "CiscoLogger",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/logger-ios-sdk-1.0.1.zip",
+            checksum: "403cf7060207186c0d5a26a01fff0a1a4647cc81b608feb4eeb9230afa1e7b16",
+            productName: "CiscoLogger",
+            wrapperName: "CiscoLoggerWrapper"
+        ),
+        "encryptor": BinaryTargetInfo(
+            name: "CiscoEncryption",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/encryption-ios-sdk-1.0.254.zip",
+            checksum: "236d2ae950c7decb528d8290359c58c22c662cdc1e42899d7544edd9760d893c",
+            productName: "CiscoEncryption",
+            wrapperName: "CiscoEncryptionWrapper"
+        ),
+        "swizzling": BinaryTargetInfo(
+            name: "CiscoSwizzling",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/swizzling-ios-sdk-1.0.254.zip",
+            checksum: "a6cd8fb5c463bb9e660f560acfa5b33e4c5271fda222047b417bd531a8c0c956",
+            productName: "CiscoSwizzling",
+            wrapperName: "CiscoSwizzlingWrapper"
+        ),
+        "interactions": BinaryTargetInfo(
+            name: "CiscoInteractions",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/interactions-ios-sdk-1.0.254.zip",
+            checksum: "65c53ade295f34ad7876919f935f428b2ebb016236b21add72b5946a9f57789c",
+            productName: "CiscoInteractions",
+            wrapperName: "CiscoInteractionsWrapper"
+        ),
+        "diskStorage": BinaryTargetInfo(
+            name: "CiscoDiskStorage",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/disk-storage-ios-sdk-1.0.254.zip",
+            checksum: "1b47895f1793a690ce68fca431e72f689a38470423af392e9785135e514d93de",
+            productName: "CiscoDiskStorage",
+            wrapperName: "CiscoDiskStorageWrapper"
+        ),
+        "sessionReplay": BinaryTargetInfo(
+            name: "CiscoSessionReplay",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/session-replay-ios-sdk-1.0.6.254.zip",
+            checksum: "d1cf5141c4710fcd5af8c957aa57e319c7f28ee338cc64e6f7283f19aaa66a71",
+            productName: "CiscoSessionReplay",
+            wrapperName: "CiscoSessionReplayWrapper"
+        ),
+        "instanceManager": BinaryTargetInfo(
+            name: "CiscoInstanceManager",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/instance-manager-ios-sdk-1.0.254.zip",
+            checksum: "fe0bc116914ef408ac2e015aa0fa482774a35868cf803f19a7e593bbaeae6ef3",
+            productName: "CiscoInstanceManager",
+            wrapperName: "CiscoInstanceManagerWrapper"
+        ),
+        "runtimeCache": BinaryTargetInfo(
+            name: "CiscoRuntimeCache",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/runtime-cache-ios-sdk-1.0.254.zip",
+            checksum: "4bed11f441350f9b52726b2d8e88f1647bd702325e5128d956eb814b05ea028b",
+            productName: "CiscoRuntimeCache",
+            wrapperName: "CiscoRuntimeCacheWrapper"
+        )
+    ]
+}
+
+/// Determines which dependency resolution strategy to use.
+/// Defaults to `.binaryTargets`, present in the `current` property.
+enum DependencyResolutionStrategy {
+
+    /// SessionReplay dependencies are linked as binary targets
+    /// fetched from S3 storage.
+    case binaryTargets
+
+    /// SessionReplay dependencies are linked as products
+    /// from a SPM-linked SR repository.
+    case repositoryDependency
+
+    static var current: DependencyResolutionStrategy {
+        if shouldUseSessionReplayAsRepositoryDependency() {
+            return .repositoryDependency
+        } else {
+            return .binaryTargets
+        }
+    }
+}
+
+/// Resolves a dependency based on the current strategy
+/// - Parameter key: The key from SessionReplayBinaryRegistry.targets
+/// - Returns: A dependency reference (either wrapper target name or product reference)
+func resolveDependency(_ key: String) -> Target.Dependency {
+    guard let targetInfo = SessionReplayBinaryRegistry.targets[key] else {
+        fatalError("Unknown Session Replay dependency key: \(key)")
+    }
+
+    switch DependencyResolutionStrategy.current {
+    case .binaryTargets:
+        return .byName(name: targetInfo.wrapperName)
+
+    case .repositoryDependency:
+        return .product(name: targetInfo.productName, package: "smartlook-ios-sdk-private")
+    }
+}
+
+
+// MARK: - Package and target definitions
+
+// Create the package instance base.
 let package = Package(
     name: "SplunkAgent",
     platforms: [
@@ -21,11 +137,26 @@ let package = Package(
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
             exact: "1.14.0"
-        ),
-        sessionReplayDependency()
+        )
     ],
-    targets: [
-        
+    targets: []
+)
+
+//  Modify it based on current dependency resolution and add all targets to the package
+package.targets.append(contentsOf: generateBinaryTargets())
+package.targets.append(contentsOf: generateWrapperTargets())
+package.targets.append(contentsOf: generateMainTargets())
+
+// Conditionally add Session Replay as a repository dependency
+resolveSessionReplayRepositoryDependency()
+
+
+// MARK: - Helpers for target generation
+
+/// Generates the main library targets
+func generateMainTargets() -> [Target] {
+    return [
+
         // MARK: Splunk Agent
 
         .target(
@@ -38,9 +169,9 @@ let package = Package(
                 "SplunkSlowFrameDetector",
                 "SplunkOpenTelemetry",
                 "SplunkAppStart",
-		"SplunkWebView",
-		"SplunkWebViewProxy",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                "SplunkWebView",
+                "SplunkWebViewProxy",
+                resolveDependency("logger")
             ],
             path: "SplunkAgent",
             sources: ["Sources"],
@@ -61,10 +192,10 @@ let package = Package(
             ],
             swiftSettings: [.define("SPM_TESTS")]
         ),
-        
-        
-        // MARK: Splunk Network
-        
+
+
+        // MARK: - Splunk Network
+
         .target(
             name: "SplunkNetwork",
             dependencies: [
@@ -78,9 +209,10 @@ let package = Package(
             dependencies: ["SplunkNetwork"],
             path: "SplunkNetwork/Tests"
         ),
+
         
-        // MARK: Splunk Common
-        
+        // MARK: - Splunk Common
+
         .target(
             name: "SplunkCommon",
             path: "SplunkCommon/Sources"
@@ -90,10 +222,10 @@ let package = Package(
             dependencies: ["SplunkCommon"],
             path: "SplunkCommon/Tests"
         ),
-        
-        
-        // MARK: Splunk Slow Frame Detector
-        
+
+
+        // MARK: - Splunk Slow Frame Detector
+
         .target(
             name: "SplunkSlowFrameDetector",
             dependencies: [
@@ -107,10 +239,10 @@ let package = Package(
             dependencies: ["SplunkSlowFrameDetector", "SplunkCommon"],
             path: "SplunkSlowFrameDetector/Tests"
         ),
-        
-        
-        // MARK: Splunk Custom Data
-        
+
+
+        // MARK: - Splunk Custom Data
+
         .target(
             name: "SplunkCustomData",
             dependencies: [
@@ -123,10 +255,10 @@ let package = Package(
             dependencies: ["SplunkCustomData"],
             path: "SplunkCustomData/Tests"
         ),
-        
-        
-        // MARK: Splunk Error Reporting
-        
+
+
+        // MARK: - Splunk Error Reporting
+
         .target(
             name: "SplunkErrorReporting",
             dependencies: [
@@ -139,10 +271,10 @@ let package = Package(
             dependencies: ["SplunkErrorReporting"],
             path: "SplunkErrorReporting/Tests"
         ),
-        
-        
-        // MARK: SplunkCrashReporter
-        
+
+
+        // MARK: - SplunkCrashReporter
+
         .target(
             name: "SplunkCrashReporter",
             path: "SplunkCrashReporter",
@@ -174,10 +306,10 @@ let package = Package(
                 .linkedFramework("Foundation")
             ]
         ),
-        
-        
-        // MARK: SplunkCrashReports
-        
+
+
+        // MARK: - SplunkCrashReports
+
         .target(
             name: "SplunkCrashReports",
             dependencies: [
@@ -192,10 +324,10 @@ let package = Package(
             dependencies: ["SplunkCrashReports", "SplunkCommon"],
             path: "SplunkCrashReports/Tests"
         ),
-        
-        
-        // MARK: Splunk Otel
-        
+
+
+        // MARK: - Splunk Otel
+
         .target(
             name: "SplunkOpenTelemetry",
             dependencies: [
@@ -205,7 +337,7 @@ let package = Package(
                 .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
                 .product(name: "ResourceExtension", package: "opentelemetry-swift"),
                 .product(name: "SignPostIntegration", package: "opentelemetry-swift"),
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkOpenTelemetry/Sources"
         ),
@@ -214,17 +346,17 @@ let package = Package(
             dependencies: ["SplunkOpenTelemetry", "SplunkCommon"],
             path: "SplunkOpenTelemetry/Tests"
         ),
-        
-        
-        // MARK: Splunk OTel Background Exporter
+
+
+        // MARK: - Splunk OTel Background Exporter
         
         .target(
             name: "SplunkOpenTelemetryBackgroundExporter",
             dependencies: [
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift"),
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private"),
-                .product(name: "CiscoDiskStorage", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger"),
+                resolveDependency("diskStorage")
             ],
             path: "SplunkOpenTelemetryBackgroundExporter/Sources"
         ),
@@ -233,16 +365,16 @@ let package = Package(
             dependencies: ["SplunkOpenTelemetryBackgroundExporter", "SplunkCommon"],
             path: "SplunkOpenTelemetryBackgroundExporter/Tests"
         ),
-        
-        
-        // MARK: Splunk App Start
+
+
+        // MARK: - Splunk App Start
         
         .target(
             name: "SplunkAppStart",
             dependencies: [
                 "SplunkCommon",
                 "SplunkOpenTelemetry",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkAppStart/Sources"
         ),
@@ -252,19 +384,20 @@ let package = Package(
                 "SplunkAppStart",
                 "SplunkCommon",
                 "SplunkOpenTelemetry",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkAppStart/Tests"
         ),
-        
-        // MARK: Splunk Web Instrumentation
-    
+
+
+        // MARK: - Splunk Web Instrumentation
+
         .target(
             name: "SplunkWebView",
             dependencies: [
                 "SplunkCommon",
                 "SplunkOpenTelemetry",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkWebView/Sources"
         ),
@@ -276,15 +409,16 @@ let package = Package(
             path: "SplunkWebView/Tests"
         ),
 
-        // MARK: Splunk Web Instrumentation Proxy
-        
+
+        // MARK: - Splunk Web Instrumentation Proxy
+
         .target(
             name: "SplunkWebViewProxy",
             dependencies: [
                 "SplunkCommon",
                 "SplunkOpenTelemetry",
                 "SplunkWebView",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkWebViewProxy/Sources"
         ),
@@ -295,19 +429,19 @@ let package = Package(
                 "SplunkOpenTelemetry",
                 "SplunkWebView",
                 "SplunkWebViewProxy",
-                .product(name: "CiscoLogger", package: "smartlook-ios-sdk-private")
+                resolveDependency("logger")
             ],
             path: "SplunkWebViewProxy/Tests"
         ),
-        
-        
-        // MARK: Session Replay Proxy
-        
+
+
+        // MARK: - Session Replay Proxy
+
         .target(
             name: "SplunkSessionReplayProxy",
             dependencies: [
                 "SplunkCommon",
-                .product(name: "CiscoSessionReplay", package: "smartlook-ios-sdk-private")
+                resolveDependency("sessionReplay")
             ],
             path: "SplunkSessionReplayProxy/Sources"
         ),
@@ -317,44 +451,188 @@ let package = Package(
             path: "SplunkSessionReplayProxy/Tests"
         )
     ]
-)
+}
+
+/// Generates binary targets from the registry, based on the current `DependencyResolutionStrategy`.
+func generateBinaryTargets() -> [Target] {
+    
+    // First check the deps resolution whether we want to generate.
+    guard DependencyResolutionStrategy.current == .binaryTargets else {
+        return []
+    }
+
+    return SessionReplayBinaryRegistry.targets.values.map { info in
+        .binaryTarget(
+            name: info.name,
+            url: info.url,
+            checksum: info.checksum
+        )
+    }
+}
+
+/// Generates wrapper targets, based on the current `DependencyResolutionStrategy`.
+func generateWrapperTargets() -> [Target] {
+
+    // First check the deps resolution whether we want to generate.
+    guard DependencyResolutionStrategy.current == .binaryTargets else {
+        return []
+    }
+
+    return generateBinaryWrapperTargets()
+}
+
+/// Generates wrapper targets that depend on binary targets to correctly construct and link their dependency trees.
+func generateBinaryWrapperTargets() -> [Target] {
+    return [
+        .target(
+            name: "CiscoLoggerWrapper",
+            dependencies: ["CiscoLogger"],
+            path: "TargetWrappers/CiscoLoggerWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoEncryptionWrapper",
+            dependencies: ["CiscoEncryption"],
+            path: "TargetWrappers/CiscoEncryptionWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoSwizzlingWrapper",
+            dependencies: ["CiscoSwizzling"],
+            path: "TargetWrappers/CiscoSwizzlingWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoInteractionsWrapper",
+            dependencies: ["CiscoInteractions", resolveDependency("swizzling")],
+            path: "TargetWrappers/CiscoInteractionsWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoDiskStorageWrapper",
+            dependencies: ["CiscoDiskStorage", resolveDependency("encryptor")],
+            path: "TargetWrappers/CiscoDiskStorageWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoInstanceManagerWrapper",
+            dependencies: ["CiscoInstanceManager", resolveDependency("logger")],
+            path: "TargetWrappers/CiscoInstanceManagerWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoRuntimeCacheWrapper",
+            dependencies: ["CiscoRuntimeCache", resolveDependency("logger")],
+            path: "TargetWrappers/CiscoRuntimeCacheWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoSessionReplayWrapper",
+            dependencies: [
+                "CiscoSessionReplay",
+                resolveDependency("instanceManager"),
+                resolveDependency("diskStorage"),
+                resolveDependency("runtimeCache"),
+                resolveDependency("interactions"),
+                resolveDependency("logger"),
+                resolveDependency("swizzling")
+            ],
+            path: "TargetWrappers/CiscoSessionReplayWrapper/Sources"
+        )
+    ]
+}
 
 
-// MARK: Session Replay related helpers
+// MARK: - Session Replay related helpers
+
+/// Determines whether to use Session Replay as a repository dependency.
+/// This is the main switch between binary targets and repository-based approach.
+func shouldUseSessionReplayAsRepositoryDependency() -> Bool {
+
+    // Check the ENV first
+    if let envValue = ProcessInfo.processInfo.environment["USE_SESSION_REPLAY_REPO"],
+       let boolValue = Bool(envValue) {
+        return boolValue
+    }
+
+    // Default to binary targets approach
+    return false
+}
 
 /// Enables or disables having Session Replay as a local dependency (needs smartlook-ios-sdk checked out locally)
 /// or a remote dependency. If the value is `true`, overrides `remoteSessionReplayBranch()`.
 ///
 /// ✅ Feel free to use this flag for local development.
 func shouldUseLocalSessionReplayDependency() -> Bool {
+
+    // Check the ENV first
+    if let envValue = ProcessInfo.processInfo.environment["USE_LOCAL_SESSION_REPLAY"],
+       let boolValue = Bool(envValue) {
+        return boolValue
+    }
+
     return false
 }
 
 /// Sets remote dependency git branch.
-///
-/// ✅ Feel free to use this for development.
 func remoteSessionReplayBranch() -> String {
+
+    // Check the ENV first
+    if let environmentBranch = ProcessInfo.processInfo.environment["SESSION_REPLAY_BRANCH"] {
+        return environmentBranch
+    }
+
     return "develop"
 }
 
-/// SessionReplay swift package dependendency.
-///
-/// ⚠️ Don't touch this function. This function makes sure that our build script uses "main" branch during release process.
-func sessionReplayDependency() -> Package.Dependency {
-    // Session replay git repo
-    let packageGitUrl = "git@github.com:smartlook/smartlook-ios-sdk-private.git"
-    
-    // Check if a branch was set as an environment variable.
-    // Atm it's set in a build script in Tools/build_frameworks/050-Xarchives.sh
+/// Local path to Session Replay repository.
+func localSessionReplayPath() -> String {
 
-    if let environmentBranch = ProcessInfo.processInfo.environment["SESSION_REPLAY_BRANCH"] {
-        return .package(url: packageGitUrl, branch: environmentBranch)
+    // Check the ENV first
+    if let environmentPath = ProcessInfo.processInfo.environment["SESSION_REPLAY_LOCAL_PATH"] {
+        return environmentPath
     }
-    
-    // Local dependency, enables SessionReplay local development, needs smartlook-ios-sdk checked out locally
-    if shouldUseLocalSessionReplayDependency() {
-        return .package(name: "smartlook-ios-sdk-private", path: "../../smartlook-ios-sdk-private")
-    }
-    
-    return .package(url: packageGitUrl, branch: remoteSessionReplayBranch())
+
+    return "../../smartlook-ios-sdk-private"
 }
+
+/// SessionReplay SPM dependency resolution.
+///
+/// ⚠️ This function automatically determines the dependency strategy and adds the appropriate
+/// dependency to the package. It supports environment variables for CI/CD.
+func resolveSessionReplayRepositoryDependency() {
+
+    // Only add repository dependency if using repository strategy
+    guard shouldUseSessionReplayAsRepositoryDependency() else {
+        return
+    }
+
+    // Session replay git repo URL
+    let packageGitUrl = "git@github.com:smartlook/smartlook-ios-sdk-private.git"
+
+    // Local dependency has highest priority
+    if shouldUseLocalSessionReplayDependency() {
+        package.dependencies.append(
+            .package(name: "smartlook-ios-sdk-private", path: localSessionReplayPath())
+        )
+        return
+    }
+
+    // Remote dependency with branch
+    let branch = remoteSessionReplayBranch()
+    package.dependencies.append(
+        .package(url: packageGitUrl, branch: branch)
+    )
+}
+
+
+// MARK: - ENV var documentation
+
+/*
+ Environment Variables for Configuration:
+
+ USE_SESSION_REPLAY_REPO (Bool):
+   - true: Use repository-based dependencies (products from smartlook-ios-sdk-private)
+   - false: Use binary targets with wrapper approach (default)
+
+ USE_LOCAL_SESSION_REPLAY (Bool):
+   - true: Use local path dependency (for development)
+   - false: Use remote repository dependency (default when USE_SESSION_REPLAY_REPO=true)
+
+ SESSION_REPLAY_BRANCH (String):
+   - Specifies the git branch to use for remote repository dependency
+   - Default: "develop"
+*/

--- a/Package.swift
+++ b/Package.swift
@@ -3,119 +3,6 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-// MARK: - Binary target registry
-
-/// Registry containing all Session Replay binary target definitions.
-struct SessionReplayBinaryRegistry {
-
-    /// Internal descriptor of the Target structure, including its Wrapper name for generation.
-    struct BinaryTargetInfo {
-        let name: String
-        let url: String
-        let checksum: String
-        let productName: String
-        let wrapperName: String
-    }
-
-    static let targets: [String: BinaryTargetInfo] = [
-        "logger": BinaryTargetInfo(
-            name: "CiscoLogger",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/logger-ios-sdk-1.0.1.zip",
-            checksum: "403cf7060207186c0d5a26a01fff0a1a4647cc81b608feb4eeb9230afa1e7b16",
-            productName: "CiscoLogger",
-            wrapperName: "CiscoLoggerWrapper"
-        ),
-        "encryptor": BinaryTargetInfo(
-            name: "CiscoEncryption",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/encryption-ios-sdk-1.0.254.zip",
-            checksum: "236d2ae950c7decb528d8290359c58c22c662cdc1e42899d7544edd9760d893c",
-            productName: "CiscoEncryption",
-            wrapperName: "CiscoEncryptionWrapper"
-        ),
-        "swizzling": BinaryTargetInfo(
-            name: "CiscoSwizzling",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/swizzling-ios-sdk-1.0.254.zip",
-            checksum: "a6cd8fb5c463bb9e660f560acfa5b33e4c5271fda222047b417bd531a8c0c956",
-            productName: "CiscoSwizzling",
-            wrapperName: "CiscoSwizzlingWrapper"
-        ),
-        "interactions": BinaryTargetInfo(
-            name: "CiscoInteractions",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/interactions-ios-sdk-1.0.254.zip",
-            checksum: "65c53ade295f34ad7876919f935f428b2ebb016236b21add72b5946a9f57789c",
-            productName: "CiscoInteractions",
-            wrapperName: "CiscoInteractionsWrapper"
-        ),
-        "diskStorage": BinaryTargetInfo(
-            name: "CiscoDiskStorage",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/disk-storage-ios-sdk-1.0.254.zip",
-            checksum: "1b47895f1793a690ce68fca431e72f689a38470423af392e9785135e514d93de",
-            productName: "CiscoDiskStorage",
-            wrapperName: "CiscoDiskStorageWrapper"
-        ),
-        "sessionReplay": BinaryTargetInfo(
-            name: "CiscoSessionReplay",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/session-replay-ios-sdk-1.0.6.254.zip",
-            checksum: "d1cf5141c4710fcd5af8c957aa57e319c7f28ee338cc64e6f7283f19aaa66a71",
-            productName: "CiscoSessionReplay",
-            wrapperName: "CiscoSessionReplayWrapper"
-        ),
-        "instanceManager": BinaryTargetInfo(
-            name: "CiscoInstanceManager",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/instance-manager-ios-sdk-1.0.254.zip",
-            checksum: "fe0bc116914ef408ac2e015aa0fa482774a35868cf803f19a7e593bbaeae6ef3",
-            productName: "CiscoInstanceManager",
-            wrapperName: "CiscoInstanceManagerWrapper"
-        ),
-        "runtimeCache": BinaryTargetInfo(
-            name: "CiscoRuntimeCache",
-            url: "https://sdk.smartlook.com/splunk-agent-test/ios/runtime-cache-ios-sdk-1.0.254.zip",
-            checksum: "4bed11f441350f9b52726b2d8e88f1647bd702325e5128d956eb814b05ea028b",
-            productName: "CiscoRuntimeCache",
-            wrapperName: "CiscoRuntimeCacheWrapper"
-        )
-    ]
-}
-
-/// Determines which dependency resolution strategy to use.
-/// Defaults to `.binaryTargets`, present in the `current` property.
-enum DependencyResolutionStrategy {
-
-    /// SessionReplay dependencies are linked as binary targets
-    /// fetched from S3 storage.
-    case binaryTargets
-
-    /// SessionReplay dependencies are linked as products
-    /// from a SPM-linked SR repository.
-    case repositoryDependency
-
-    static var current: DependencyResolutionStrategy {
-        if shouldUseSessionReplayAsRepositoryDependency() {
-            return .repositoryDependency
-        } else {
-            return .binaryTargets
-        }
-    }
-}
-
-/// Resolves a dependency based on the current strategy
-/// - Parameter key: The key from SessionReplayBinaryRegistry.targets
-/// - Returns: A dependency reference (either wrapper target name or product reference)
-func resolveDependency(_ key: String) -> Target.Dependency {
-    guard let targetInfo = SessionReplayBinaryRegistry.targets[key] else {
-        fatalError("Unknown Session Replay dependency key: \(key)")
-    }
-
-    switch DependencyResolutionStrategy.current {
-    case .binaryTargets:
-        return .byName(name: targetInfo.wrapperName)
-
-    case .repositoryDependency:
-        return .product(name: targetInfo.productName, package: "smartlook-ios-sdk-private")
-    }
-}
-
-
 // MARK: - Package and target definitions
 
 // Create the package instance base.
@@ -210,7 +97,7 @@ func generateMainTargets() -> [Target] {
             path: "SplunkNetwork/Tests"
         ),
 
-        
+
         // MARK: - Splunk Common
 
         .target(
@@ -533,6 +420,119 @@ func generateBinaryWrapperTargets() -> [Target] {
             path: "TargetWrappers/CiscoSessionReplayWrapper/Sources"
         )
     ]
+}
+
+
+// MARK: - Binary target registry
+
+/// Registry containing all Session Replay binary target definitions.
+struct SessionReplayBinaryRegistry {
+
+    /// Internal descriptor of the Target structure, including its Wrapper name for generation.
+    struct BinaryTargetInfo {
+        let name: String
+        let url: String
+        let checksum: String
+        let productName: String
+        let wrapperName: String
+    }
+
+    static let targets: [String: BinaryTargetInfo] = [
+        "logger": BinaryTargetInfo(
+            name: "CiscoLogger",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/logger-ios-sdk-1.0.1.zip",
+            checksum: "403cf7060207186c0d5a26a01fff0a1a4647cc81b608feb4eeb9230afa1e7b16",
+            productName: "CiscoLogger",
+            wrapperName: "CiscoLoggerWrapper"
+        ),
+        "encryptor": BinaryTargetInfo(
+            name: "CiscoEncryption",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/encryption-ios-sdk-1.0.254.zip",
+            checksum: "236d2ae950c7decb528d8290359c58c22c662cdc1e42899d7544edd9760d893c",
+            productName: "CiscoEncryption",
+            wrapperName: "CiscoEncryptionWrapper"
+        ),
+        "swizzling": BinaryTargetInfo(
+            name: "CiscoSwizzling",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/swizzling-ios-sdk-1.0.254.zip",
+            checksum: "a6cd8fb5c463bb9e660f560acfa5b33e4c5271fda222047b417bd531a8c0c956",
+            productName: "CiscoSwizzling",
+            wrapperName: "CiscoSwizzlingWrapper"
+        ),
+        "interactions": BinaryTargetInfo(
+            name: "CiscoInteractions",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/interactions-ios-sdk-1.0.254.zip",
+            checksum: "65c53ade295f34ad7876919f935f428b2ebb016236b21add72b5946a9f57789c",
+            productName: "CiscoInteractions",
+            wrapperName: "CiscoInteractionsWrapper"
+        ),
+        "diskStorage": BinaryTargetInfo(
+            name: "CiscoDiskStorage",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/disk-storage-ios-sdk-1.0.254.zip",
+            checksum: "1b47895f1793a690ce68fca431e72f689a38470423af392e9785135e514d93de",
+            productName: "CiscoDiskStorage",
+            wrapperName: "CiscoDiskStorageWrapper"
+        ),
+        "sessionReplay": BinaryTargetInfo(
+            name: "CiscoSessionReplay",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/session-replay-ios-sdk-1.0.6.254.zip",
+            checksum: "d1cf5141c4710fcd5af8c957aa57e319c7f28ee338cc64e6f7283f19aaa66a71",
+            productName: "CiscoSessionReplay",
+            wrapperName: "CiscoSessionReplayWrapper"
+        ),
+        "instanceManager": BinaryTargetInfo(
+            name: "CiscoInstanceManager",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/instance-manager-ios-sdk-1.0.254.zip",
+            checksum: "fe0bc116914ef408ac2e015aa0fa482774a35868cf803f19a7e593bbaeae6ef3",
+            productName: "CiscoInstanceManager",
+            wrapperName: "CiscoInstanceManagerWrapper"
+        ),
+        "runtimeCache": BinaryTargetInfo(
+            name: "CiscoRuntimeCache",
+            url: "https://sdk.smartlook.com/splunk-agent-test/ios/runtime-cache-ios-sdk-1.0.254.zip",
+            checksum: "4bed11f441350f9b52726b2d8e88f1647bd702325e5128d956eb814b05ea028b",
+            productName: "CiscoRuntimeCache",
+            wrapperName: "CiscoRuntimeCacheWrapper"
+        )
+    ]
+}
+
+/// Determines which dependency resolution strategy to use.
+/// Defaults to `.binaryTargets`, present in the `current` property.
+enum DependencyResolutionStrategy {
+
+    /// SessionReplay dependencies are linked as binary targets
+    /// fetched from S3 storage.
+    case binaryTargets
+
+    /// SessionReplay dependencies are linked as products
+    /// from a SPM-linked SR repository.
+    case repositoryDependency
+
+    static var current: DependencyResolutionStrategy {
+        if shouldUseSessionReplayAsRepositoryDependency() {
+            return .repositoryDependency
+        } else {
+            return .binaryTargets
+        }
+    }
+}
+
+/// Resolves a dependency based on the current strategy
+/// - Parameter key: The key from SessionReplayBinaryRegistry.targets
+/// - Returns: A dependency reference (either wrapper target name or product reference)
+func resolveDependency(_ key: String) -> Target.Dependency {
+    guard let targetInfo = SessionReplayBinaryRegistry.targets[key] else {
+        fatalError("Unknown Session Replay dependency key: \(key)")
+    }
+
+    switch DependencyResolutionStrategy.current {
+    case .binaryTargets:
+        return .byName(name: targetInfo.wrapperName)
+
+    case .repositoryDependency:
+        return .product(name: targetInfo.productName, package: "smartlook-ios-sdk-private")
+    }
 }
 
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@testable import CiscoSessionReplay
+import CiscoSessionReplay
 @testable import SplunkAgent
 @testable import SplunkCommon
 @testable import SplunkOpenTelemetry

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@testable import CiscoSessionReplay
+import CiscoSessionReplay
 @testable import SplunkAgent
 
 import XCTest

--- a/TargetWrappers/CiscoDiskStorageWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoDiskStorageWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoEncryptionWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoEncryptionWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoInstanceManagerWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoInstanceManagerWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoInteractionsWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoInteractionsWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoLoggerWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoLoggerWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoRuntimeCacheWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoRuntimeCacheWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoSessionReplayWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoSessionReplayWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoSwizzlingWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoSwizzlingWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation


### PR DESCRIPTION
This PR brings in the implementation of Session Replay dependencies as binary targets.

Implementation details:
- The new binary targets are defined in a separate `registry` for easy enhancement and updates
- They require a "wrapping" target mechanism to properly resolve their dependency trees. The wrapping targets require their own folder structures, including empty stub files for the compiler. These are **not** added to the project files, as they are not relevant there
- The package still retains the functionality to link SR as either a remote or local package (repository) dependency
- The decision whether use binary targets or repository dependency (e.g. `DependencyResolutionStrategy`) is controlled using a set of `environment variables`
- All of the variables and their usage are documented in the `Package.swift` file
- The default is to use `.binaryTargets`, as that is the final distribution method 
- Due to our CI/CD restrictions, the future updates to the binary targets will have to be "manual", via a PR. The related functionality to emit the binaries, upload them to S3 and provide the updated metadata (urls and checksums) will come as a separate PR into the `smartlook-ios-sdk` repository

Important **integration / testing** information:
- Perform a full clean before testing out this PR and moving forward with future development. This includes:
- Delete any `Package.resolved` files in the repository. You can run `find . -name "Package.resolved*" command in the repository root, and delete all the occurrences (example in the attached screenshot). This is required as the old / cached Package.resolved files will contain references to `smartlook-ios-sdk-private` and will hard crash Xcode during package resolution steps on the new target architecture
<img width="1002" alt="package-resolved-occurrences" src="https://github.com/user-attachments/assets/c0f6af57-5b21-4875-9665-b1c11e152439" />

- Purge your derived data, e.g. run `rm -rf ~/Library/Developer/Xcode/DerivedData`
- Purge the local build folder, e.g. run `rm -rf .build` in the repository root
- Link the agent as a local SPM dependency to a testing app of your preference and enjoy!
- No other steps are required
- _NOTE_: The currently used binaries were **built locally** with `Xcode 16.2` and **are not signed** with a correct certificate. This is OK for testing purposes, will be fixed in a future PR once we land the related infrastructure PRs to session replay repository

Important further development information:
- This PR partially breaks the contract for full feature parity between the development using `workspace` / `project` and using the Agent as a `Swift package dependency`
- This is **intentional** as our goal should be to move away from the project-based development entirely and prioritise the SPM testing
- The project-based workflow is still supported, however Session Replay will always be linked from the private repository, as making it compatible and dependent on the binary targets is not possible at the moment - you can always download the binaries manually and link them into the project, tho not recommendino