### PR TITLE
DEMRUM-970 Update to PLCrashReporter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
             exact: "1.14.0"
+        ),
+        .package(
+            url:"https://github.com/microsoft/plcrashreporter",
+            from: "1.12.0"
         )
     ],
     targets: []
@@ -160,55 +164,20 @@ func generateMainTargets() -> [Target] {
         ),
 
 
-        // MARK: - SplunkCrashReporter
-
-        .target(
-            name: "SplunkCrashReporter",
-            path: "SplunkCrashReporter",
-            exclude: [
-                "Source/dwarf_opstream.hpp",
-                "Source/dwarf_stack.hpp",
-                "Source/PLCrashAsyncDwarfCFAState.hpp",
-                "Source/PLCrashAsyncDwarfCIE.hpp",
-                "Source/PLCrashAsyncDwarfEncoding.hpp",
-                "Source/PLCrashAsyncDwarfExpression.hpp",
-                "Source/PLCrashAsyncDwarfFDE.hpp",
-                "Source/PLCrashAsyncDwarfPrimitives.hpp",
-                "Source/PLCrashAsyncLinkedList.hpp",
-                "Source/PLCrashReport.proto"
-            ],
-            sources: [
-                "Source",
-                "Dependencies/protobuf-c"
-            ],
-            cSettings: [
-                .define("PLCR_PRIVATE"),
-                .define("PLCF_RELEASE_BUILD"),
-                .define("PLCRASHREPORTER_PREFIX", to: "SPLK"),
-                .define("SWIFT_PACKAGE"), // Should be defined by default, Xcode 11.1 workaround.
-                .headerSearchPath("Dependencies/protobuf-c"),
-                .unsafeFlags(["-w"]) // Suppresses "Implicit conversion" warnings in protobuf.c
-            ],
-            linkerSettings: [
-                .linkedFramework("Foundation")
-            ]
-        ),
-
-
         // MARK: - SplunkCrashReports
 
         .target(
             name: "SplunkCrashReports",
             dependencies: [
-                "SplunkCrashReporter",
                 "SplunkOpenTelemetry",
-                "SplunkCommon"
+                "SplunkCommon",
+                .product(name: "CrashReporter", package: "PLCrashReporter")
             ],
             path: "SplunkCrashReports/Sources"
         ),
         .testTarget(
             name: "SplunkCrashReportsTests",
-            dependencies: ["SplunkCrashReports", "SplunkCommon"],
+            dependencies: ["SplunkCrashReports", "SplunkCommon", "PLCrashReporter"],
             path: "SplunkCrashReports/Tests"
         ),
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on building, running t
 
 ## Troubleshooting
 
-For troubleshooting issues with the Splunk OpenTelemetry iOS instrumentation, see [Troubleshoot iOS instrumentation for Splunk Observability Cloud](https://docs.splunk.com/Observability/gdi/get-data-in/rum/ios/troubleshooting.html) in the official documentation.
+For troubleshooting issues with the Splunk OpenTelemetry iOS instrumentation, see [Troubleshoot iOS instrumentation for Splunk Observability Cloud](https://help.splunk.com/Observability/gdi/get-data-in/rum/ios/troubleshooting.html) in the official documentation.
 
 ## License
 

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -18,7 +18,10 @@ limitations under the License.
 internal import CiscoLogger
 import Foundation
 import SplunkCommon
-internal import SplunkCrashReporter
+import CrashReporter
+
+// Temporarily remove local CrashReporter in favor of SPM version
+// internal import SplunkCrashReporter
 
 public class CrashReports {
 
@@ -27,7 +30,7 @@ public class CrashReports {
     /// An instance of the Agent shared state object, which is used to obtain agent's state, e.g. a session id.
     public unowned var sharedState: AgentSharedState?
 
-    private var crashReporter: SPLKPLCrashReporter?
+    private var crashReporter: PLCrashReporter?
     private let logger = DefaultLogAgent(poolName: PackageIdentifier.instance(), category: "CrashReports")
     private var allUsedImageNames: [String] = []
     private var deviceDataDictionary: [CrashReportKeys: String] = [:]
@@ -49,9 +52,17 @@ public class CrashReports {
 #else
         let signalHandlerType = PLCrashReporterSignalHandlerType.mach
 #endif
+        // Setup private path for crash reports to avoid conflict with other
+        // instances of PLCrashReporter present in the client app
+        let fileManager = FileManager.default
+        let crashDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("SplunkCrashReports", isDirectory: true)
+        try? fileManager.createDirectory(at: crashDirectory, withIntermediateDirectories: true)
 
-        let signalConfig = SPLKPLCrashReporterConfig(signalHandlerType: signalHandlerType, symbolicationStrategy: [])
-        guard let crashReporterInstance = SPLKPLCrashReporter(configuration: signalConfig) else {
+        let signalConfig = PLCrashReporterConfig(
+            signalHandlerType: signalHandlerType,
+            symbolicationStrategy: [],
+            basePath: crashDirectory.path)
+        guard let crashReporterInstance = PLCrashReporter(configuration: signalConfig) else {
             logger.log(level: .error) {
                 "PLCrashReporter failed to initialize."
             }
@@ -87,7 +98,7 @@ public class CrashReports {
             let data = try crashReporter?.loadPendingCrashReportDataAndReturnError()
 
             // Retrieving crash reporter data.
-            let report = try SPLKPLCrashReport(data: data)
+            let report = try PLCrashReport(data: data)
 
             // And collect stack frames
             let stackFrames = stackFramesFromCrashReport(report: report)
@@ -224,12 +235,12 @@ public class CrashReports {
 
     // Report formatting
 
-    private func stackFramesFromCrashReport(report: SPLKPLCrashReport) -> [CrashReportKeys: Any] {
+    private func stackFramesFromCrashReport(report: PLCrashReport) -> [CrashReportKeys: Any] {
         var stackFrames: [CrashReportKeys: Any] = [:]
         var threads: [Any] = []
 
         for thread in report.threads {
-            if let thread = thread as? SPLKPLCrashReportThreadInfo {
+            if let thread = thread as? PLCrashReportThreadInfo {
                 let thr = threadFromReport(thread: thread, report: report)
 
                 threads.append(thr)
@@ -240,7 +251,7 @@ public class CrashReports {
         return stackFrames
     }
 
-    private func formatCrashReport(report: SPLKPLCrashReport, stackFrames: [CrashReportKeys: Any]) -> [CrashReportKeys: Any] {
+    private func formatCrashReport(report: PLCrashReport, stackFrames: [CrashReportKeys: Any]) -> [CrashReportKeys: Any] {
 
         var reportDict: [CrashReportKeys: Any] = [:]
 
@@ -312,12 +323,12 @@ public class CrashReports {
         return crashPayload
     }
 
-    private func convertStackFrames(frames: [Any], report: SPLKPLCrashReport) -> [Any] {
+    private func convertStackFrames(frames: [Any], report: PLCrashReport) -> [Any] {
 
         var stackFrames: [Any] = []
         var isFirstTime = true
 
-        guard let frames = frames as? [SPLKPLCrashReportStackFrameInfo] else {
+        guard let frames = frames as? [PLCrashReportStackFrameInfo] else {
             logger.log(level: .error) {
                 "CrashReporter received incorrect stackFrame type."
             }
@@ -366,7 +377,7 @@ public class CrashReports {
         return stackFrames
     }
 
-    private func threadFromReport(thread: SPLKPLCrashReportThreadInfo, report: SPLKPLCrashReport) -> [CrashReportKeys: Any] {
+    private func threadFromReport(thread: PLCrashReportThreadInfo, report: PLCrashReport) -> [CrashReportKeys: Any] {
 
         var oneThread: [CrashReportKeys: Any] = [:]
         oneThread[.details] = thread
@@ -382,7 +393,7 @@ public class CrashReports {
             var threadDictionary: [CrashReportKeys: Any] = [:]
             threadDictionary[.stackFrames] = thread[CrashReportKeys.stackFrames]
 
-            if let info = thread[CrashReportKeys.details] as? SPLKPLCrashReportThreadInfo {
+            if let info = thread[CrashReportKeys.details] as? PLCrashReportThreadInfo {
                 threadDictionary[.threadNumber] = info.threadNumber
                 threadDictionary[threadKey] = info.crashed
             }
@@ -399,7 +410,7 @@ public class CrashReports {
         var outputImages: [Any] = []
         for image in images {
             var imageDictionary: [CrashReportKeys: Any] = [:]
-            guard let image = image as? SPLKPLCrashReportBinaryImageInfo else {
+            guard let image = image as? PLCrashReportBinaryImageInfo else {
                 continue
             }
             // Only add the image to the list if it was noted in the stack traces


### PR DESCRIPTION
- Using PLCrashReporter from Github rather than the internal version
- Added a separate on device folder to hold the crash reports, to avoid conflict with other instances (Firebase etc.)
- This folder is currently called 'SplunkCrashReports'
- Switched out SPLKPLCrashReporter from the build.

Please note: Left SplunkCrashReporter in place in the project. Code is not used and can be removed once testing is complete.