### PR TITLE
DEMRUM-2270: fix attribute count crash

### DIFF
--- a/Applications/AgentTestApp/AgentTestApp/AppDelegate.swift
+++ b/Applications/AgentTestApp/AgentTestApp/AppDelegate.swift
@@ -45,7 +45,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 var modifiedSpan = spanData
                 modifiedSpan.settingAttributes(attributes)
-                modifiedSpan.settingTotalAttributeCount(attributes.count)
 
                 return modifiedSpan
             }

--- a/Package.swift
+++ b/Package.swift
@@ -95,7 +95,9 @@ func generateMainTargets() -> [Target] {
                 "SplunkCommon",
                 .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
-                .product(name: "ResourceExtension", package: "opentelemetry-swift")
+                .product(name: "ResourceExtension", package: "opentelemetry-swift"),
+                .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
+                .product(name: "SignPostIntegration", package: "opentelemetry-swift")
             ],
             path: "SplunkNetwork/Sources"
         ),
@@ -197,9 +199,7 @@ func generateMainTargets() -> [Target] {
                 "SplunkOpenTelemetryBackgroundExporter",
                 .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
-                .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
-                .product(name: "ResourceExtension", package: "opentelemetry-swift"),
-                .product(name: "SignPostIntegration", package: "opentelemetry-swift"),
+                .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift"),
                 resolveDependency("logger")
             ],
             path: "SplunkOpenTelemetry/Sources"
@@ -281,7 +281,7 @@ func generateMainTargets() -> [Target] {
         .testTarget(
             name: "SplunkWebViewProxyTests",
             dependencies: [
-                "SplunkWebView"
+                "SplunkWebViewProxy"
             ],
             path: "SplunkWebViewProxy/Tests"
         ),

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Modules/DefaultModulesManagerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Modules/DefaultModulesManagerTests.swift
@@ -163,6 +163,7 @@ final class DefaultModulesManagerTests: XCTestCase {
 
 
         let dataExpectation = expectation(description: "Data from module not be delivered.")
+        dataExpectation.assertForOverFulfill = false
 
         // We simulate taking and deleting data from modules
         modulesManager.onModulePublish { metadata, data in

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Model/MutableAttributesTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Model/MutableAttributesTests.swift
@@ -402,7 +402,7 @@ final class MutableAttributesTests: XCTestCase {
         attributes[int: "age"] = 30
         attributes[bool: "active"] = true
 
-        let description = attributes.description()
+        let description = attributes.description
         XCTAssertTrue(description.contains("name: \"John Doe\""))
         XCTAssertTrue(description.contains("age: 30"))
         XCTAssertTrue(description.contains("active: true"))

--- a/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
@@ -72,7 +72,7 @@ final class SessionReplayTestBuilder {
 
     public static func sampleVideoData() throws -> Data {
         #if SPM_TESTS
-        let fileUrl = Bundle.module.url(forResource: "v", withExtension: "mp4")
+        let fileUrl = Bundle.module.url(forResource: "v", withExtension: "mp4")!
 
         #else
         let bundle = Bundle(for: EventsTests.self)

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
@@ -56,7 +56,7 @@ class SpanInterceptorExporter: SpanExporter {
         }
 
         // Invoke the interceptor and only pass through non-nil spans.
-        var interceptedSpans = spans.compactMap { span in spanInterceptor(span) }
+        let interceptedSpans = spans.compactMap { span in spanInterceptor(span) }
 
         /*
          Recalculate `totalAttributeCount`.
@@ -71,7 +71,7 @@ class SpanInterceptorExporter: SpanExporter {
          which means that the `droppedAttributesCount` will have a wrong value. If the `droppedAttributesCount` parameter
          is required in the future, we should consider another approach.
         */
-        interceptedSpans = interceptedSpans.map {
+        let recalculatedSpans = interceptedSpans.map {
             var span = $0
             let attributeCount = span.attributes.count
 
@@ -82,6 +82,6 @@ class SpanInterceptorExporter: SpanExporter {
             return span
         }
 
-        return proxyExporter.export(spans: interceptedSpans)
+        return proxyExporter.export(spans: recalculatedSpans)
     }
 }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Interceptor Exporter/SpanInterceptorExporter.swift
@@ -56,7 +56,31 @@ class SpanInterceptorExporter: SpanExporter {
         }
 
         // Invoke the interceptor and only pass through non-nil spans.
-        let interceptedSpans = spans.compactMap { span in spanInterceptor(span) }
+        var interceptedSpans = spans.compactMap { span in spanInterceptor(span) }
+
+        /*
+         Recalculate `totalAttributeCount`.
+
+         We allow attribute mutation in the `spanInterceptor`. SpanData stores information
+         about total number of attributes (`totalAttributeCount`), which is used to calculate and track
+         a number of dropped attributes in case of exceeding maximum number of attributes.
+         Having `span.attributes.count` larger than `span.totalAttributeCount` causes a crash when calculating
+         `droppedAttributesCount`.
+
+         ‼️ By recalculating the `totalAttributeCount`, we effectively disable the `droppedAttributesCount` calculation,
+         which means that the `droppedAttributesCount` will have a wrong value. If the `droppedAttributesCount` parameter
+         is required in the future, we should consider another approach.
+        */
+        interceptedSpans = interceptedSpans.map {
+            var span = $0
+            let attributeCount = span.attributes.count
+
+            if span.totalAttributeCount != attributeCount {
+                return span.settingTotalAttributeCount(attributeCount)
+            }
+
+            return span
+        }
 
         return proxyExporter.export(spans: interceptedSpans)
     }


### PR DESCRIPTION
This PR addresses the "totalAttributeCount" crash, which happens when spanInterceptor adds attributes into intercepted spans. We need to recalculate the "totalAttributeCount" so that the subsequent "droppedAttributesCount" calculation does not cause a crash.

PR also fixes some inconsistencies in dependency tree defined in Package.swift. PR also fixes couple of tests.