### PR TITLE
DEMRUM-1044: clean up slow rendering detection config

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Module/SlowFrameDetectorConfiguration.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Module/SlowFrameDetectorConfiguration.swift
@@ -26,8 +26,6 @@ public struct SlowFrameDetectorRemoteConfiguration: RemoteModuleConfiguration {
 
     struct SlowFrameDetector: Decodable {
         let enabled: Bool
-        let slowFrameDetectorThresholdMilliseconds: CFTimeInterval
-        let frozenFrameDetectorThresholdMilliseconds: CFTimeInterval
     }
 
     struct MRUMRoot: Decodable {
@@ -49,18 +47,11 @@ public struct SlowFrameDetectorRemoteConfiguration: RemoteModuleConfiguration {
     // MARK: - Internal variables
 
     public var enabled: Bool
-    var slowFrameThresholdMilliseconds: CFTimeInterval
-    var frozenFrameThresholdMilliseconds: CFTimeInterval
 
     public init?(from data: Data) {
         guard let root = try? JSONDecoder().decode(Root.self, from: data) else {
             return nil
         }
-
         enabled = root.configuration.mrum.slowFrameDetector.enabled
-
-        slowFrameThresholdMilliseconds = root.configuration.mrum.slowFrameDetector.slowFrameDetectorThresholdMilliseconds
-
-        frozenFrameThresholdMilliseconds = root.configuration.mrum.slowFrameDetector.frozenFrameDetectorThresholdMilliseconds
     }
 }

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
@@ -51,7 +51,7 @@ public final class SlowFrameDetector {
 
     // Candidate future configuration options. If exposed, will need clamping.
     private var tolerancePercentage: Double = 15.0
-    private var frozenDurationMultipler: Double = 40.0
+    private var frozenDurationMultiplier: Double = 40.0
 
 
     // MARK: - SlowFrameDetector lifecycle
@@ -184,7 +184,7 @@ public final class SlowFrameDetector {
         let isSlow = actualDuration > expectedDuration + tolerance
 
         // Frozen is much longer duration than simply "slow"
-        let isFrozen = actualDuration > expectedDuration * frozenDurationMultipler
+        let isFrozen = actualDuration > expectedDuration * frozenDurationMultiplier
 
         // Apply isFrozen check first because it's a subset of isSlow
         if isFrozen {


### PR DESCRIPTION
removing SlowFrameDetector properties:
- slowFrameDetectorThresholdMilliseconds
- frozenFrameDetectorThresholdMilliseconds

and SlowFrameDetectorRemoteConfiguration properties:
- slowFrameThresholdMilliseconds
- frozenFrameThresholdMilliseconds

These are supplanted by internal values tolerancePercentage and frozenDurationMultiplier which are conceptually different and do not have a direct mapping to or from the old values.