### PR TITLE
DEMRUM-861: fix merge conflict resolution typo

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -110,6 +110,7 @@ public class SplunkRum: ObservableObject {
     /// An object that holds Custom Tracking  module.
     public var customTracking: any CustomTrackingModule {
         customTrackingProxy
+    }
 
     /// An object that holds Navigation module.
     public var navigation: any NavigationModule {


### PR DESCRIPTION
This is to fix a very small typo introduced during merge conflict resolution, a missing curly bracket.
