### PR TITLE
DEMRUM-861: fill out error tracking demo calls

### DIFF
--- a/Applications/DevelApp/DevelApp.xcodeproj/project.pbxproj
+++ b/Applications/DevelApp/DevelApp.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		522DB6CA2DC135920047FBCD /* SessionReplayDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522DB6C92DC135920047FBCD /* SessionReplayDemoView.swift */; };
 		522DB6CC2DC135BC0047FBCD /* TemplateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522DB6CB2DC135BC0047FBCD /* TemplateView.swift */; };
 		522DB6CE2DC135E30047FBCD /* WebViewDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522DB6CD2DC135E30047FBCD /* WebViewDemoView.swift */; };
+		5238CC822DFB6AD400206F6C /* ObjCExceptionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5238CC812DFB6AD400206F6C /* ObjCExceptionHelper.m */; };
+		52400B7B2DFBC33200F88CD8 /* HelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52400B7A2DFBC33200F88CD8 /* HelperViews.swift */; };
 		524479292DE7EEA200E93C77 /* CustomTrackingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524479282DE7EE9C00E93C77 /* CustomTrackingDemoView.swift */; };
 		527070DC2DC145F900EDD390 /* DemoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527070DB2DC145F900EDD390 /* DemoHeaderView.swift */; };
 		527070DE2DC1468100EDD390 /* CrashDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527070DD2DC1468100EDD390 /* CrashDemoView.swift */; };
@@ -32,6 +34,10 @@
 		522DB6C92DC135920047FBCD /* SessionReplayDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayDemoView.swift; sourceTree = "<group>"; };
 		522DB6CB2DC135BC0047FBCD /* TemplateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateView.swift; sourceTree = "<group>"; };
 		522DB6CD2DC135E30047FBCD /* WebViewDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewDemoView.swift; sourceTree = "<group>"; };
+		5238CC812DFB6AD400206F6C /* ObjCExceptionHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionHelper.m; sourceTree = "<group>"; };
+		5238CC832DFB6AD600206F6C /* DevelApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DevelApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		5238CC842DFB6AF700206F6C /* ObjCExceptionHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionHelper.h; sourceTree = "<group>"; };
+		52400B7A2DFBC33200F88CD8 /* HelperViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperViews.swift; sourceTree = "<group>"; };
 		524479282DE7EE9C00E93C77 /* CustomTrackingDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTrackingDemoView.swift; sourceTree = "<group>"; };
 		527070DB2DC145F900EDD390 /* DemoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoHeaderView.swift; sourceTree = "<group>"; };
 		527070DD2DC1468100EDD390 /* CrashDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDemoView.swift; sourceTree = "<group>"; };
@@ -70,6 +76,7 @@
 		3384F2882AC8795800512D79 /* DevelApp */ = {
 			isa = PBXGroup;
 			children = (
+				5238CC852DFB6B6100206F6C /* ObjC */,
 				3384F2AE2AC87A3B00512D79 /* Info.plist */,
 				527070DF2DC147AB00EDD390 /* AgentDataSource.swift */,
 				527070DD2DC1468100EDD390 /* CrashDemoView.swift */,
@@ -80,6 +87,7 @@
 				522DB6C92DC135920047FBCD /* SessionReplayDemoView.swift */,
 				522DB6CD2DC135E30047FBCD /* WebViewDemoView.swift */,
 				522DB6CB2DC135BC0047FBCD /* TemplateView.swift */,
+				52400B7A2DFBC33200F88CD8 /* HelperViews.swift */,
 				3384F28D2AC8795800512D79 /* Assets.xcassets */,
 				3384F28F2AC8795800512D79 /* DevelApp.entitlements */,
 				3384F2902AC8795800512D79 /* Preview Content */,
@@ -100,6 +108,16 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5238CC852DFB6B6100206F6C /* ObjC */ = {
+			isa = PBXGroup;
+			children = (
+				5238CC832DFB6AD600206F6C /* DevelApp-Bridging-Header.h */,
+				5238CC842DFB6AF700206F6C /* ObjCExceptionHelper.h */,
+				5238CC812DFB6AD400206F6C /* ObjCExceptionHelper.m */,
+			);
+			path = ObjC;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -135,6 +153,7 @@
 				TargetAttributes = {
 					3384F2852AC8795800512D79 = {
 						CreatedOnToolsVersion = 15.0;
+						LastSwiftMigration = 1640;
 					};
 				};
 			};
@@ -199,9 +218,11 @@
 			files = (
 				527070DC2DC145F900EDD390 /* DemoHeaderView.swift in Sources */,
 				522DB6C82DC134C70047FBCD /* RoutingView.swift in Sources */,
+				52400B7B2DFBC33200F88CD8 /* HelperViews.swift in Sources */,
 				527070E02DC147AB00EDD390 /* AgentDataSource.swift in Sources */,
 				522DB6CE2DC135E30047FBCD /* WebViewDemoView.swift in Sources */,
 				524479292DE7EEA200E93C77 /* CustomTrackingDemoView.swift in Sources */,
+				5238CC822DFB6AD400206F6C /* ObjCExceptionHelper.m in Sources */,
 				3384F28A2AC8795800512D79 /* DevelAppApp.swift in Sources */,
 				522DB6CC2DC135BC0047FBCD /* TemplateView.swift in Sources */,
 				527070DE2DC1468100EDD390 /* CrashDemoView.swift in Sources */,
@@ -334,6 +355,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = DevelApp/DevelApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -367,6 +389,8 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DevelApp/ObjC/DevelApp-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				TVOS_DEPLOYMENT_TARGET = 17.0;
@@ -379,6 +403,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = DevelApp/DevelApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -412,6 +437,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DevelApp/ObjC/DevelApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				TVOS_DEPLOYMENT_TARGET = 17.0;

--- a/Applications/DevelApp/DevelApp/CustomTrackingDemoView.swift
+++ b/Applications/DevelApp/DevelApp/CustomTrackingDemoView.swift
@@ -1,19 +1,19 @@
 //
 /*
- Copyright 2025 Splunk Inc.
+Copyright 2025 Splunk Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- */
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 import SplunkAgent
 import SwiftUI

--- a/Applications/DevelApp/DevelApp/CustomTrackingDemoView.swift
+++ b/Applications/DevelApp/DevelApp/CustomTrackingDemoView.swift
@@ -1,72 +1,68 @@
 //
 /*
-Copyright 2025 Splunk Inc.
+ Copyright 2025 Splunk Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 import SplunkAgent
 import SwiftUI
 
 struct CustomTrackingDemoView: View {
     var body: some View {
-        VStack {
-            DemoHeaderView()
+        ScrollView {
+            VStack(spacing: 16) {
+                DemoHeaderView()
 
-            // Button for tracking a custom event
-            Button("Track Event") {
-                trackCustomEvent()
+                FeatureSection(title: "Custom Event Tracking") {
+                    FeatureButton(label: "Track Event") {
+                        trackCustomEvent()
+                    }
+                }
+
+                FeatureSection(title: "Custom Workflow Tracking") {
+                    FeatureButton(label: "Track Workflow (Span)") {
+                        trackWorkflow()
+                    }
+                }
+
+                FeatureSection(title: "Custom Error Tracking") {
+                    FeatureButton(label: "Track Error String") {
+                        let attributes = SampleAttributes.forStringError()
+                        SplunkRum.shared.customTracking.trackError(DemoErrors.stringError(), attributes)
+                    }
+
+                    FeatureButton(label: "Track Swift Error type") {
+                        let attributes = SampleAttributes.forSwiftError()
+                        SplunkRum.shared.customTracking.trackError(DemoErrors.swiftError(), attributes)
+                    }
+
+                    FeatureButton(label: "Track NSError") {
+                        let attributes = SampleAttributes.forNSError()
+                        SplunkRum.shared.customTracking.trackError(DemoErrors.nsError(), attributes)
+                    }
+
+                    FeatureButton(label: "Track NSException") {
+                        let attributes = SampleAttributes.forNSException()
+                        SplunkRum.shared.customTracking.trackException(DemoErrors.nsException(), attributes)
+                    }
+                }
+
+                Spacer()
             }
-            .padding()
-
-            // Button for tracking an error (String message)
-            Button("Track Error (String)") {
-                trackErrorString()
-            }
-            .padding()
-
-            // Button for tracking an Error (Swift conforming type)
-            Button("Track Error (Error)") {
-                trackErrorType()
-            }
-            .padding()
-
-            // Button for tracking an NSError
-            Button("Track Error (NSError)") {
-                trackNSError()
-            }
-            .padding()
-
-            // Button for tracking an NSException
-            Button("Track Exception (NSException)") {
-                trackNSException()
-            }
-            .padding()
-
-            // Button for tracking a Workflow
-            Button("Track Workflow (Span)") {
-                trackWorkflow()
-            }
-            .padding()
-
-            Spacer()
         }
         .navigationTitle("Custom Tracking")
-        .padding()
     }
-
-
-    // MARK: - Custom Tracking Functions
 
     func trackCustomEvent() {
         let attributes = MutableAttributes()
@@ -77,46 +73,77 @@ struct CustomTrackingDemoView: View {
         SplunkRum.shared.customTracking.trackCustomEvent("Demo Button Clicked", attributes)
     }
 
-    func trackErrorString() {
-        let attributes = MutableAttributes()
-        attributes["ErrorType"] = .string("StringError")
-        attributes["ErrorSeverity"] = .string("Critical")
-        SplunkRum.shared.customTracking.trackError("This is a sample string error", attributes)
-    }
-
-    func trackErrorType() {
-        let attributes = MutableAttributes()
-        attributes["ErrorType"] = .string("SwiftError")
-        attributes["ErrorCode"] = .int(404)
-        let sampleError: Error = NSError(domain: "com.example.error", code: 100, userInfo: [NSLocalizedDescriptionKey: "Sample Swift error"])
-        SplunkRum.shared.customTracking.trackError(sampleError, attributes)
-    }
-
-    func trackNSError() {
-        let attributes = MutableAttributes()
-        attributes["ErrorDomain"] = .string("com.example.nserror")
-        attributes["ErrorCode"] = .int(200)
-        attributes["Description"] = .string("Sample NSError description")
-        let nsError = NSError(domain: "com.example.nserror", code: 200, userInfo: [NSLocalizedDescriptionKey: "Sample NSError"])
-        SplunkRum.shared.customTracking.trackError(nsError, attributes)
-    }
-
-    func trackNSException() {
-        let attributes = MutableAttributes()
-        attributes["ExceptionName"] = .string("GenericException")
-        attributes["Reason"] = .string("Sample NSException reason")
-        attributes["Handled"] = .bool(true)
-        let exception = NSException(name: .genericException, reason: "Sample NSException reason", userInfo: ["Key": "Value"])
-        SplunkRum.shared.customTracking.trackException(exception, attributes)
-    }
-
     func trackWorkflow() {
         let customSpan = SplunkRum.shared.customTracking.trackWorkflow("Custom Workflow")
         customSpan.setAttribute(key: "test", value: "qwerty")
 
-        // End span after 15 seconds
         DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
-                customSpan.end()
+            customSpan.end()
         }
+    }
+}
+
+struct DemoErrors {
+    // String error (no stack trace needed)
+    static func stringError() -> String {
+        "This is a string representing an error message"
+    }
+
+    // Swift Error with stack trace
+    static func swiftError() -> Error {
+        struct SampleError: Error, LocalizedError {
+            var errorDescription: String? { "This is a Swift Error" }
+        }
+        return SampleError()
+    }
+
+    // NSError with stack trace
+    static func nsError() -> NSError {
+        NSError(domain: "com.example.error", code: 42, userInfo: [NSLocalizedDescriptionKey: "This is an NSError"])
+    }
+
+    // NSException with stack trace (from callStackSymbols)
+    static func nsException() -> NSException {
+        // Use the Objective-C helper to trigger and catch an NSException
+        let exception = ObjCExceptionHelper.performBlockAndCatchException {
+            // Trigger an NSException by calling an unrecognized selector
+            NSObject().perform(Selector(("nonExistentMethod")))
+        }
+
+        // Ensure the exception was captured
+        guard let exception = exception else {
+            fatalError("Failed to trigger NSException")
+        }
+
+        return exception
+    }
+}
+
+struct SampleAttributes {
+    static func forStringError() -> MutableAttributes {
+        let attributes = MutableAttributes()
+        attributes.setString("sampleValue", for: "stringKey")
+        return attributes
+    }
+
+    static func forSwiftError() -> MutableAttributes {
+        let attributes = MutableAttributes()
+        attributes.setBool(true, for: "isSwiftError")
+        attributes.setInt(404, for: "errorCode")
+        return attributes
+    }
+
+    static func forNSError() -> MutableAttributes {
+        let attributes = MutableAttributes()
+        attributes.setString("NSErrorDomain", for: "domain")
+        attributes.setInt(42, for: "code")
+        return attributes
+    }
+
+    static func forNSException() -> MutableAttributes {
+        let attributes = MutableAttributes()
+        attributes.setString("NSExceptionName", for: "exceptionName")
+        attributes.setString("Sample reason", for: "reason")
+        return attributes
     }
 }

--- a/Applications/DevelApp/DevelApp/HelperViews.swift
+++ b/Applications/DevelApp/DevelApp/HelperViews.swift
@@ -1,0 +1,57 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SwiftUI
+
+struct FeatureSection<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+
+            content
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(red: 0.87, green: 0.93, blue: 1.0))
+        .cornerRadius(12)
+        .padding(.horizontal, 16)
+    }
+}
+
+struct FeatureButton: View {
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.blue)
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/Applications/DevelApp/DevelApp/ObjC/DevelApp-Bridging-Header.h
+++ b/Applications/DevelApp/DevelApp/ObjC/DevelApp-Bridging-Header.h
@@ -1,0 +1,19 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#import "ObjCExceptionHelper.h" // Helper is used by trackError(nsException:)

--- a/Applications/DevelApp/DevelApp/ObjC/ObjCExceptionHelper.h
+++ b/Applications/DevelApp/DevelApp/ObjC/ObjCExceptionHelper.h
@@ -1,0 +1,31 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCExceptionHelper : NSObject
+
+/// Executes a block and returns any thrown NSException.
+/// @param block The block to execute.
+/// @return The NSException that was thrown, or nil if no exception was thrown.
++ (nullable NSException *)performBlockAndCatchException:(void (^)(void))block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Applications/DevelApp/DevelApp/ObjC/ObjCExceptionHelper.m
+++ b/Applications/DevelApp/DevelApp/ObjC/ObjCExceptionHelper.m
@@ -1,0 +1,31 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#import "ObjCExceptionHelper.h"
+
+@implementation ObjCExceptionHelper
+
++ (nullable NSException *)performBlockAndCatchException:(void (^)(void))block {
+    @try {
+        block();
+    } @catch (NSException *exception) {
+        return exception;
+    }
+    return nil;
+}
+
+@end

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -110,6 +110,7 @@ public class SplunkRum: ObservableObject {
     /// An object that holds Custom Tracking  module.
     public var customTracking: any CustomTrackingModule {
         customTrackingProxy
+    }
 
     /// An object that holds Navigation module.
     public var navigation: any NavigationModule {


### PR DESCRIPTION
Improve error tracking api calls in DevelApp

- Add sample attributes to each error
- Add missing stack trace to Error and NSException (for NSError it already worked)
- Add Objective-C code to generate and handle an NSException

Triggering a real NSException gives a more  accurate reflection of real usage where we take content from the callStackSymbols property to populate the stack trace for NSException tracking.

We use Objective-C for generating the exception and this requires that we add bridging header to the DevelApp project.
