### PR TITLE
DEMRUM-861: add correct component

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Events/CustomTrackingDataEvent.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Events/CustomTrackingDataEvent.swift
@@ -45,7 +45,7 @@ struct CustomTrackingDataEvent: AgentEvent {
         domain = "data"
         name = data.name
         instrumentationScope = "com.splunk.rum.customtracking"
-        component = "custom_tracking"
+        component = data.component
         self.sessionID = sessionID
         timestamp = metadata.timestamp
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -110,6 +110,7 @@ public class SplunkRum: ObservableObject {
     /// An object that holds Custom Tracking  module.
     public var customTracking: any CustomTrackingModule {
         customTrackingProxy
+    }
 
     /// An object that holds Navigation module.
     public var navigation: any NavigationModule {

--- a/SplunkCustomTracking/Sources/SplunkCustomTracking/CustomTracking+Tracking.swift
+++ b/SplunkCustomTracking/Sources/SplunkCustomTracking/CustomTracking+Tracking.swift
@@ -38,7 +38,9 @@ public extension CustomTrackingInternal {
         // Metadata and data for the event
         let metadata = CustomTrackingMetadata()
 
-        let data = CustomTrackingData(name: event.typeName, attributes: event.toAttributesDictionary())
+        let data = CustomTrackingData(name: event.typeName,
+                                      component: "event",
+                                      attributes: event.toAttributesDictionary())
 
         // Publish the event using the block
         onPublishBlock(metadata, data)
@@ -63,7 +65,9 @@ public extension CustomTrackingInternal {
         let combinedAttributes = attributes.merging(issue.toAttributesDictionary()) { $1 }
 
         // Create the tracking data
-        let data = CustomTrackingData(name: issue.typeName, attributes: combinedAttributes)
+        let data = CustomTrackingData(name: issue.typeName,
+                                      component: "error",
+                                      attributes: combinedAttributes)
 
         // Publish the issue using the block
         onPublishBlock(metadata, data)

--- a/SplunkCustomTracking/Sources/SplunkCustomTracking/CustomTracking.swift
+++ b/SplunkCustomTracking/Sources/SplunkCustomTracking/CustomTracking.swift
@@ -27,10 +27,12 @@ public struct CustomTrackingMetadata: ModuleEventMetadata {
 
 public struct CustomTrackingData: ModuleEventData {
     public let name: String
+    public let component: String
     public let attributes: [String: AttributeValue]
 
-    public init(name: String, attributes: [String: AttributeValue]) {
+    public init(name: String, component: String, attributes: [String: AttributeValue]) {
         self.name = name
+        self.component = component
         self.attributes = attributes
     }
 }


### PR DESCRIPTION
Fix incorrect value for the `component` field in event and error spans.

Previously the value was "custom_tracking"; this PR updates it to be "error" for error tracking spans, and "event" for custom event spans.

Custom workflows do not require the `component` attribute, so they are not included in this PR.
