### PR TITLE
DEMRUM-2288: Add segmentMetadata attribute to Session Replay

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Events/SessionReplayDataEvent.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Events/SessionReplayDataEvent.swift
@@ -49,23 +49,19 @@ class SessionReplayDataEvent: AgentEvent {
     ///   - sessionID: The `session ID` of a session in which the event occurred.
     ///               Optional so that we can see sessions with no session id in the backend.
     public init(metadata: Metadata, data: Data, index: Int, sessionID: String?) {
-
         // Event properties
         let timestamp = metadata.timestamp
-        let startTimestamp = metadata.startUnixMs
-        let endTimestamp = metadata.endUnixMs
-        // let recordId = metadata.recordId
+        self.timestamp = timestamp
 
         if let sessionID {
             self.sessionID = sessionID
         }
 
-        self.timestamp = timestamp
         body = EventAttributeValue(data)
 
         attributes = [
-            "replay.start_timestamp": EventAttributeValue.int(startTimestamp),
-            "replay.end_timestamp": EventAttributeValue.int(endTimestamp),
+            // Chunk metadata
+            "segmentMetadata": .string(metadataToJSONString(metadata)),
 
             // Experimental attributes for integration PoC
             "rr-web.total-chunks": .int(1),
@@ -73,5 +69,21 @@ class SessionReplayDataEvent: AgentEvent {
             "rr-web.event": .int(index),
             "rr-web.offset": .int(index)
         ]
+    }
+
+
+    // MARK: - Private methods
+
+    private func metadataToJSONString(_ metadata: Metadata) -> String {
+        // We always prefer conversion with a standard encoder ...
+        guard
+            let metadataContent = try? JSONEncoder().encode(metadata),
+            let jsonString = String(data: metadataContent, encoding: .utf8)
+        else {
+            // ... but if something fails, we can build it manually
+            return "{\"startUnixMs\":\(metadata.startUnixMs), \"endUnixMs\":\(metadata.endUnixMs), \"source\":\"\(metadata.source)\"}"
+        }
+
+        return jsonString
     }
 }

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-ConfigurationTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-ConfigurationTests.swift
@@ -93,7 +93,7 @@ final class API10ConfigurationTests: XCTestCase {
         // User configuration
         full.user.trackingMode = .noTracking
         XCTAssertEqual(full.user.trackingMode, .noTracking)
-        
+
         var userConfiguration = UserConfiguration()
         userConfiguration.trackingMode = .anonymousTracking
         full = full.userConfiguration(userConfiguration)
@@ -161,7 +161,7 @@ final class API10ConfigurationTests: XCTestCase {
 
         var sessionConfiguration = SessionConfiguration()
         sessionConfiguration.samplingRate = 0.4
-        
+
         var userConfiguration = UserConfiguration()
         userConfiguration.trackingMode = .anonymousTracking
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
@@ -47,25 +47,20 @@ final class SessionReplayTestBuilder {
         let sampleVideoData = try Self.sampleVideoData()
 
         let sessionID = UUID().uuidString
-        let recordID = UUID().uuidString
-        let replaySessionID = UUID().uuidString
         let timestamp = Date()
         let endTimestamp = Date()
 
-        // let recordMetadata = RecordMetadata(
-        //    recordId: recordID,
-        //    recordIndex: 0,
-        //    timestamp: timestamp,
-        //    timestampEnd: endTimestamp,
-        //    replaySessionId: replaySessionID
-        // )
-
-        let datachunkMetadata = Metadata(
+        let chunkMetadata = Metadata(
             startUnixMs: Int(timestamp.timeIntervalSince1970 * 1000.0),
             endUnixMs: Int(endTimestamp.timeIntervalSince1970 * 1000.0)
         )
 
-        let event = SessionReplayDataEvent(metadata: datachunkMetadata, data: sampleVideoData, sessionID: sessionID)
+        let event = SessionReplayDataEvent(
+            metadata: chunkMetadata,
+            data: sampleVideoData,
+            index: 1,
+            sessionID: sessionID
+        )
 
         return event
     }


### PR DESCRIPTION
**Changes:**
-  Added the `segmentMetadata` attribute to the Session Replay log.