### PR TITLE
DEMRUM-2525: Implement support for binary body in Log records.

### DIFF
--- a/Applications/AgentTestApp/AgentTestApp/AppDelegate.swift
+++ b/Applications/AgentTestApp/AgentTestApp/AppDelegate.swift
@@ -58,6 +58,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Navigation Instrumentation
         SplunkRum.shared.navigation.preferences.enableAutomatedTracking = true
 
+        // Start session replay
+        SplunkRum.shared.sessionReplay.start()
+
         return true
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -235,6 +235,7 @@ func generateMainTargets() -> [Target] {
         .target(
             name: "SplunkOpenTelemetryBackgroundExporter",
             dependencies: [
+                "SplunkCommon",
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift"),
                 resolveDependency("logger"),

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkAttributeValue.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkAttributeValue.swift
@@ -1,0 +1,251 @@
+// swiftlint:disable all
+// swiftformat:disable all
+
+// Changes made:
+// - prefix filename
+// - prefix enum and struct names
+// - import OpenTelemetryApi
+// - add Data case
+// - disable linters
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+/// An enum that represents all the possible values for an attribute.
+public enum SplunkAttributeValue: Equatable, CustomStringConvertible, Hashable {
+  case string(String)
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case data(Data)
+  @available(*, deprecated, message: "replaced by .array(AttributeArray)") case stringArray([String])
+  @available(*, deprecated, message: "replaced by .array(AttributeArray)") case boolArray([Bool])
+  @available(*, deprecated, message: "replaced by .array(AttributeArray)") case intArray([Int])
+  @available(*, deprecated, message: "replaced by .array(AttributeArray)") case doubleArray([Double])
+  case array(AttributeArray)
+  case set(AttributeSet)
+
+  public var description: String {
+    switch self {
+    case let .string(value):
+      return value
+    case let .bool(value):
+      return value ? "true" : "false"
+    case let .int(value):
+      return String(value)
+    case let .double(value):
+      return String(value)
+    case let .data(value):
+      return String(value.description)
+    case let .stringArray(value):
+      return value.description
+    case let .boolArray(value):
+      return value.description
+    case let .intArray(value):
+      return value.description
+    case let .doubleArray(value):
+      return value.description
+    case let .array(value):
+      return value.description
+    case let .set(value):
+      return value.labels.description
+    }
+  }
+
+  // swiftlint:disable cyclomatic_complexity
+  public init?(_ value: Any) {
+    switch value {
+    case is String:
+      // swiftlint:disable force_cast
+      self = .string(value as! String)
+    // swiftlint:enable force_cast
+    case let val as Bool:
+      self = .bool(val)
+    case let val as Int:
+      self = .int(val)
+    case let val as Double:
+      self = .double(val)
+    case let val as Data:
+      self = .data(val)
+    case let val as [String]:
+      self = .array(AttributeArray(values: val.map { AttributeValue.string($0) }))
+    case let val as [Bool]:
+      self = .array(AttributeArray(values: val.map { AttributeValue.bool($0) }))
+    case let val as [Int]:
+      self = .array(AttributeArray(values: val.map { AttributeValue.int($0) }))
+    case let val as [Double]:
+      self = .array(AttributeArray(values: val.map { AttributeValue.double($0) }))
+    case let val as AttributeArray:
+      self = .array(val)
+    case let val as AttributeSet:
+      self = .set(val)
+    default:
+      return nil
+    }
+  }
+  // swiftlint:enable cyclomatic_complexity
+}
+
+public extension SplunkAttributeValue {
+  init(_ value: String) {
+    self = .string(value)
+  }
+
+  init(_ value: Bool) {
+    self = .bool(value)
+  }
+
+  init(_ value: Int) {
+    self = .int(value)
+  }
+
+  init(_ value: Double) {
+    self = .double(value)
+  }
+
+  init(_ value: Data) {
+    self = .data(value)
+  }
+
+  init(_ value: [String]) {
+    self = .array(AttributeArray(values: value.map { element in
+      return AttributeValue.string(element)
+    }))
+  }
+
+  init(_ value: [Int]) {
+    self = .array(AttributeArray(values: value.map { element in
+      return AttributeValue.int(element)
+    }))
+  }
+
+  init(_ value: [Double]) {
+    self = .array(AttributeArray(values: value.map { element in
+      return AttributeValue.double(element)
+    }))
+  }
+
+  init(_ value: [Bool]) {
+    self = .array(AttributeArray(values: value.map { element in
+      return AttributeValue.bool(element)
+    }))
+  }
+
+  init(_ value: AttributeArray) {
+    self = .array(value)
+  }
+
+  init(_ value: AttributeSet) {
+    self = .set(value)
+  }
+}
+
+struct SplunkAttributeValueExplicitCodable: Codable {
+  let attributeValue: SplunkAttributeValue
+
+  enum CodingKeys: String, CodingKey {
+    case string
+    case bool
+    case int
+    case double
+    case data
+    case array
+    case set
+  }
+
+  enum AssociatedValueCodingKeys: String, CodingKey {
+    case associatedValue = "_0"
+  }
+
+  init(attributeValue: SplunkAttributeValue) {
+    self.attributeValue = attributeValue
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    guard container.allKeys.count == 1 else {
+      let context = DecodingError.Context(codingPath: container.codingPath,
+                                          debugDescription: "Invalid number of keys found, expected one.")
+      throw DecodingError.typeMismatch(Status.self, context)
+    }
+
+    switch container.allKeys.first.unsafelyUnwrapped {
+    case .string:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .string)
+      attributeValue = try .string(
+        nestedContainer.decode(String.self, forKey: .associatedValue))
+    case .bool:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .bool)
+      attributeValue = try .bool(nestedContainer.decode(Bool.self, forKey: .associatedValue))
+    case .int:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .int)
+      attributeValue = try .int(nestedContainer.decode(Int.self, forKey: .associatedValue))
+    case .double:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .double)
+      attributeValue = try .double(
+        nestedContainer.decode(Double.self, forKey: .associatedValue))
+    case .data:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .data)
+      attributeValue = try .data(
+        nestedContainer.decode(Data.self, forKey: .associatedValue))
+    case .array:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      attributeValue = try .array(nestedContainer.decode(AttributeArray.self, forKey: .associatedValue))
+    case .set:
+      let nestedContainer = try container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .set)
+      attributeValue = try .set(
+        nestedContainer.decode(AttributeSet.self, forKey: .associatedValue))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    switch attributeValue {
+    case let .string(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .string)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .bool(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .bool)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .int(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .int)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .double(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .double)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .data(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .data)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .set(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .set)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .array(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .stringArray(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .boolArray(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .intArray(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    case let .doubleArray(value):
+      var nestedContainer = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .array)
+      try nestedContainer.encode(value, forKey: .associatedValue)
+    }
+  }
+}
+
+extension SplunkAttributeValue: Codable {}
+
+// swiftlint:disable all
+// swiftformat:disable all

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkCommonAdapter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkCommonAdapter.swift
@@ -1,0 +1,120 @@
+// swiftlint:disable all
+// swiftformat:disable all
+
+// Changes made:
+// - prefix filename
+// - prefix enum name
+// - import OpenTelemetryProtocolExporterCommon
+// - use SplunkAttributeValue intead of AttributeValue
+// - add Data cases
+// - enum and methods internal
+// - disable linters
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+
+enum SplunkCommonAdapter {
+    static func toProtoAttribute(key: String, attributeValue: SplunkAttributeValue)
+    -> Opentelemetry_Proto_Common_V1_KeyValue {
+        var keyValue = Opentelemetry_Proto_Common_V1_KeyValue()
+        keyValue.key = key
+        switch attributeValue {
+        case let .string(value):
+            keyValue.value.stringValue = value
+        case let .bool(value):
+            keyValue.value.boolValue = value
+        case let .int(value):
+            keyValue.value.intValue = Int64(value)
+        case let .double(value):
+            keyValue.value.doubleValue = value
+        case let .data(value):
+            keyValue.value.bytesValue = value
+        case let .set(value):
+            keyValue.value.kvlistValue.values = value.labels.map {
+                return toProtoAttribute(key: $0, attributeValue: SplunkAttributeValue(otelAttributeValue: $1))
+            }
+        case let .array(value):
+            keyValue.value.arrayValue.values = value.values.map {
+                return toProtoAnyValue(attributeValue: SplunkAttributeValue(otelAttributeValue: $0))
+            }
+        case let .stringArray(value):
+            keyValue.value.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .string($0))
+            }
+        case let .boolArray(value):
+            keyValue.value.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .bool($0))
+            }
+        case let .intArray(value):
+            keyValue.value.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .int($0))
+            }
+        case let .doubleArray(value):
+            keyValue.value.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .double($0))
+            }
+        }
+        return keyValue
+    }
+    
+    static func toProtoAnyValue(attributeValue: SplunkAttributeValue) -> Opentelemetry_Proto_Common_V1_AnyValue {
+        var anyValue = Opentelemetry_Proto_Common_V1_AnyValue()
+        switch attributeValue {
+        case let .string(value):
+            anyValue.stringValue = value
+        case let .bool(value):
+            anyValue.boolValue = value
+        case let .int(value):
+            anyValue.intValue = Int64(value)
+        case let .double(value):
+            anyValue.doubleValue = value
+        case let .data(value):
+            anyValue.bytesValue = value
+        case let .set(value):
+            anyValue.kvlistValue.values = value.labels.map {
+                return toProtoAttribute(key: $0, attributeValue: SplunkAttributeValue(otelAttributeValue: $1))
+            }
+        case let .array(value):
+            anyValue.arrayValue.values = value.values.map {
+                return toProtoAnyValue(attributeValue: SplunkAttributeValue(otelAttributeValue: $0))
+            }
+        case let .stringArray(value):
+            anyValue.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .string($0))
+            }
+        case let .boolArray(value):
+            anyValue.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .bool($0))
+            }
+        case let .intArray(value):
+            anyValue.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .int($0))
+            }
+        case let .doubleArray(value):
+            anyValue.arrayValue.values = value.map {
+                return toProtoAnyValue(attributeValue: .double($0))
+            }
+        }
+        return anyValue
+    }
+    
+    static func toProtoInstrumentationScope(instrumentationScopeInfo: InstrumentationScopeInfo)
+    -> Opentelemetry_Proto_Common_V1_InstrumentationScope {
+        var instrumentationScope = Opentelemetry_Proto_Common_V1_InstrumentationScope()
+        instrumentationScope.name = instrumentationScopeInfo.name
+        if let version = instrumentationScopeInfo.version {
+            instrumentationScope.version = version
+        }
+        return instrumentationScope
+    }
+}
+
+// swiftformat:enable all
+// swiftlint:enable all

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkLogRecordAdapter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkLogRecordAdapter.swift
@@ -1,0 +1,104 @@
+// swiftlint:disable all
+// swiftformat:disable all
+
+// Changes made:
+// - prefix filename
+// - prefix class name
+// - import import OpenTelemetryProtocolExporterCommon
+// - use SplunkReadableLogRecord instead of ReadableLogRecord
+// - use SplunkCommonAdapter instead of CommonAdapter
+// - class and methods internal
+// - copy TraceProtoUtils and rename to SplunkTraceProtoUtils
+// - disable linters
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+
+class SplunkLogRecordAdapter {
+  static func toProtoResourceRecordLog(logRecordList: [SplunkReadableLogRecord]) -> [Opentelemetry_Proto_Logs_V1_ResourceLogs] {
+    let resourceAndScopeMap = groupByResourceAndScope(logRecordList: logRecordList)
+    var resourceLogs = [Opentelemetry_Proto_Logs_V1_ResourceLogs]()
+    resourceAndScopeMap.forEach { resMap in
+      var scopeLogs = [Opentelemetry_Proto_Logs_V1_ScopeLogs]()
+      resMap.value.forEach { scopeInfo, logRecords in
+        var protoScopeLogs = Opentelemetry_Proto_Logs_V1_ScopeLogs()
+        protoScopeLogs.scope = SplunkCommonAdapter.toProtoInstrumentationScope(instrumentationScopeInfo: scopeInfo)
+        logRecords.forEach { record in
+          protoScopeLogs.logRecords.append(record)
+        }
+        scopeLogs.append(protoScopeLogs)
+      }
+      var resourceLog = Opentelemetry_Proto_Logs_V1_ResourceLogs()
+      resourceLog.resource = ResourceAdapter.toProtoResource(resource: resMap.key)
+      resourceLog.scopeLogs.append(contentsOf: scopeLogs)
+      resourceLogs.append(resourceLog)
+    }
+    return resourceLogs
+  }
+
+  static func groupByResourceAndScope(logRecordList: [SplunkReadableLogRecord]) -> [Resource: [InstrumentationScopeInfo: [Opentelemetry_Proto_Logs_V1_LogRecord]]] {
+    var result = [Resource: [InstrumentationScopeInfo: [Opentelemetry_Proto_Logs_V1_LogRecord]]]()
+    logRecordList.forEach { logRecord in
+      result[logRecord.resource, default: [InstrumentationScopeInfo: [Opentelemetry_Proto_Logs_V1_LogRecord]]()][logRecord.instrumentationScopeInfo, default: [Opentelemetry_Proto_Logs_V1_LogRecord]()].append(toProtoLogRecord(logRecord: logRecord))
+    }
+    return result
+  }
+
+  static func toProtoLogRecord(logRecord: SplunkReadableLogRecord) -> Opentelemetry_Proto_Logs_V1_LogRecord {
+    var protoLogRecord = Opentelemetry_Proto_Logs_V1_LogRecord()
+
+    if let observedTimestamp = logRecord.observedTimestamp {
+      protoLogRecord.observedTimeUnixNano = observedTimestamp.timeIntervalSince1970.toNanoseconds
+    }
+
+    protoLogRecord.timeUnixNano = logRecord.timestamp.timeIntervalSince1970.toNanoseconds
+
+    if let body = logRecord.body {
+      protoLogRecord.body = SplunkCommonAdapter.toProtoAnyValue(attributeValue: body)
+    }
+
+    if let severity = logRecord.severity {
+      protoLogRecord.severityText = severity.description
+      if let protoSeverity = Opentelemetry_Proto_Logs_V1_SeverityNumber(rawValue: severity.rawValue) {
+        protoLogRecord.severityNumber = protoSeverity
+      }
+    }
+
+    if let context = logRecord.spanContext {
+      protoLogRecord.spanID = SplunkTraceProtoUtils.toProtoSpanId(spanId: context.spanId)
+      protoLogRecord.traceID = SplunkTraceProtoUtils.toProtoTraceId(traceId: context.traceId)
+      protoLogRecord.flags = UInt32(context.traceFlags.byte)
+    }
+
+    var protoAttributes = [Opentelemetry_Proto_Common_V1_KeyValue]()
+    logRecord.attributes.forEach { key, value in
+      protoAttributes.append(SplunkCommonAdapter.toProtoAttribute(key: key, attributeValue: value))
+    }
+    protoLogRecord.attributes = protoAttributes
+    return protoLogRecord
+  }
+}
+
+private enum SplunkTraceProtoUtils {
+  static func toProtoSpanId(spanId: SpanId) -> Data {
+    var spanIdData = Data(count: SpanId.size)
+    spanId.copyBytesTo(dest: &spanIdData, destOffset: 0)
+    return spanIdData
+  }
+
+  static func toProtoTraceId(traceId: TraceId) -> Data {
+    var traceIdData = Data(count: TraceId.size)
+    traceId.copyBytesTo(dest: &traceIdData, destOffset: 0)
+    return traceIdData
+  }
+}
+
+// swiftlint:enable all
+// swiftformat:enable all

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkReadableLogRecord.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/From upstream/SplunkReadableLogRecord.swift
@@ -1,0 +1,44 @@
+// swiftlint:disable all
+// swiftformat:disable all
+
+// Changes made:
+// - prefix filename
+// - prefix struct name
+// - import OpenTelemetrySdk
+// - use SplunkAttributeValue intead of AttributeValue
+// - make setters public
+// - disable linters
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+public struct SplunkReadableLogRecord: Codable {
+  public init(resource: Resource, instrumentationScopeInfo: InstrumentationScopeInfo, timestamp: Date, observedTimestamp: Date? = nil, spanContext: SpanContext? = nil, severity: Severity? = nil, body: SplunkAttributeValue? = nil, attributes: [String: SplunkAttributeValue]) {
+    self.resource = resource
+    self.instrumentationScopeInfo = instrumentationScopeInfo
+    self.timestamp = timestamp
+    self.observedTimestamp = observedTimestamp
+    self.spanContext = spanContext
+    self.severity = severity
+    self.body = body
+    self.attributes = attributes
+  }
+
+  public private(set) var resource: Resource
+  public private(set) var instrumentationScopeInfo: InstrumentationScopeInfo
+  public private(set) var timestamp: Date
+  public private(set) var observedTimestamp: Date?
+  public private(set) var spanContext: SpanContext?
+  public private(set) var severity: Severity?
+  public var body: SplunkAttributeValue?
+  public var attributes: [String: SplunkAttributeValue]
+}
+
+// swiftlint:enable all
+// swiftformat:enable all

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/OTLPBackgroundHTTPLogExporterBinary.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/OTLPBackgroundHTTPLogExporterBinary.swift
@@ -1,0 +1,79 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import CiscoDiskStorage
+import Foundation
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
+
+/// This class mirrors the `OTLPBackgroundHTTPLogExporter`, allows exporting `SplunkReadableLogRecord`.
+///
+/// These changes are implemented to add support for `SplunkReadableLogRecord` export:
+/// - removes the `LogRecordExporter` protocol conformance,
+/// - utilizes the `SplunkLogRecordAdapter`
+public class OTLPBackgroundHTTPLogExporterBinary: OTLPBackgroundHTTPBaseExporter {
+
+    // MARK: - SplunkReadableLogRecord export
+
+    /// Exports `SplunkReadableLogRecord`.
+    public func export(logRecords: [SplunkReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
+        let body = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest.with { request in
+            request.resourceLogs = SplunkLogRecordAdapter.toProtoResourceRecordLog(logRecordList: logRecords)
+        }
+
+        let requestId = UUID()
+
+        do {
+            let storeData = try body.serializedData()
+            try diskStorage.insert(
+                storeData,
+                forKey: KeyBuilder(
+                    requestId.uuidString,
+                    parrentKeyBuilder: getStorageKey()
+                )
+            )
+        } catch {
+
+            return .failure
+        }
+
+        let timeout = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, config.timeout)
+
+        let requestDescriptor = RequestDescriptor(
+            id: requestId,
+            endpoint: endpoint,
+            explicitTimeout: timeout,
+            fileKeyType: getFileKeyType()
+        )
+
+        do {
+            try httpClient.send(requestDescriptor)
+
+            return .success
+        } catch {
+
+            return .failure
+        }
+    }
+
+
+    // MARK: - Local override
+
+    override func getFileKeyType() -> String {
+        fileType ?? "logs_binary"
+    }
+}

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/SplunkAttributeValue+AttributeValue.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/SplunkAttributeValue+AttributeValue.swift
@@ -1,0 +1,57 @@
+//
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import OpenTelemetryApi
+
+public extension SplunkAttributeValue {
+
+    /// Converts `AttributeValue` to `SplunkAttributeValue`.
+    init(otelAttributeValue attributeValue: AttributeValue) {
+        switch attributeValue {
+        case let .string(attributeValue):
+            self = .string(attributeValue)
+
+        case let .bool(attributeValue):
+            self = .bool(attributeValue)
+
+        case let .int(attributeValue):
+            self = .int(attributeValue)
+
+        case let .double(attributeValue):
+            self = .double(attributeValue)
+
+        case let .stringArray(attributeValue):
+            self = .stringArray(attributeValue)
+
+        case let .boolArray(attributeValue):
+            self = .boolArray(attributeValue)
+
+        case let .intArray(attributeValue):
+            self = .intArray(attributeValue)
+
+        case let .doubleArray(attributeValue):
+            self = .doubleArray(attributeValue)
+
+        case let .array(attributeValue):
+            self = .array(attributeValue)
+
+        case let .set(attributeValue):
+            self = .set(attributeValue)
+        }
+    }
+}

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/SplunkAttributeValue+EventAttributeValue.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/logs/Binary body support/SplunkAttributeValue+EventAttributeValue.swift
@@ -1,0 +1,39 @@
+//
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SplunkCommon
+
+public extension SplunkAttributeValue {
+
+    /// Converts `EventAttributeValue` to `SplunkAttributeValue`.
+    init(eventAttributeValue eventAttributeValue: EventAttributeValue) {
+        switch eventAttributeValue {
+        case let .string(eventAttributeValue):
+            self = .string(eventAttributeValue)
+
+        case let .int(eventAttributeValue):
+            self = .int(eventAttributeValue)
+
+        case let .double(eventAttributeValue):
+            self = .double(eventAttributeValue)
+
+        case let .data(eventAttributeValue):
+            self = .data(eventAttributeValue)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for Logs binary body.

This is achieved by bypassing the processors-exporters chain in the session replay event processor. A LogRecord with `Data` body support (`SplunkReadableLogRecord`) is created manually and sent to an exporter directly. 

These four files from the upstream are used and modified so that the LogRecord is able to ingest a `Data` body, and that the exporter is able to ingest this modified LogRecord.
- `AttributeValue.swift`
- `CommonAdapter.swift`
- `LogRecordAdapter.swift`
- `ReadableLogRecord.swift`
