### PR TITLE
DEMRUM-2357: Fix sessionId in closeSession log

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Session/DefaultSession.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Session/DefaultSession.swift
@@ -255,21 +255,19 @@ class DefaultSession: AgentSession {
     func closeSession() {
         currentSession.closed = true
 
+        let currentSessionId = currentSession.id
+
         // Updates corresponding item in `SessionsModel`
         let currentSessionIndex = sessionsModel.sessions.firstIndex { item in
-            item.id == currentSession.id
+            item.id == currentSessionId
         }
 
         if let currentSessionIndex {
             sessionsModel.sessions[currentSessionIndex] = currentSession
         }
 
-        logger.log(level: .info) { [weak self] in
-            guard let sessionId = self?.currentSession.id else {
-                return "Current session has been closed."
-            }
-
-            return "Current session (id \(sessionId)) has been closed."
+        logger.log(level: .info) {
+            "Current session (id \(currentSessionId)) has been closed."
         }
     }
 


### PR DESCRIPTION
When the closeSession() method was called, self.currentSession.id was logged inside a closure. However, the closure is asynchronous, and before it was executed, the currentSession = createSession() method was called, which created a new session and thus a new session ID. When the closure was finally executed, it used the new session ID. This has been fixed by storing the session ID in a variable before the log, and the log now uses only the stored session ID.