### PR TITLE
NO-TICKET: remove obsolete modules from testables

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SplunkAgent.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SplunkAgent.xcscheme
@@ -34,16 +34,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SplunkANRReporterTests"
-               BuildableName = "SplunkANRReporterTests"
-               BlueprintName = "SplunkANRReporterTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "SplunkAgentTests"
                BuildableName = "SplunkAgentTests"
                BlueprintName = "SplunkAgentTests"
@@ -77,26 +67,6 @@
                BlueprintIdentifier = "SplunkCrashReportsTests"
                BuildableName = "SplunkCrashReportsTests"
                BlueprintName = "SplunkCrashReportsTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SplunkCustomDataTests"
-               BuildableName = "SplunkCustomDataTests"
-               BlueprintName = "SplunkCustomDataTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SplunkErrorReportingTests"
-               BuildableName = "SplunkErrorReportingTests"
-               BlueprintName = "SplunkErrorReportingTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
Take the following module tests out of the `<Testables>` array in `SplunkAgent.xcscheme` because their modules are obsolete and no longer present in the repo:

```
SplunkANRReporterTests
SplunkCustomDataTests
SplunkErrorReportingTests

```