### PR TITLE
NO-TICKET: Fix resource object assignment in release builds

### DIFF
--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
@@ -119,10 +119,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         resource.merge(with: resources)
         resource.merge(other: replayResources)
 
-        // Store resources object for Unit tests
-        #if DEBUG
-            self.resource = resource
-        #endif
+        self.resource = resource
     }
 
 


### PR DESCRIPTION
This PR fixes a bug where in the `OTLPSessionReplayEventProcessor` we are storing the `resource` object for resources to be added into all session replay logs manually. This assignment failed in release builds as the resource object assignment was done inside a debug macro.