### PR TITLE
DEMRUM-2684: Fix package build warnings.

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -128,7 +128,7 @@ public class SplunkRum: ObservableObject {
     public var slowFrameDetector: any SlowFrameDetectorModule {
         slowFrameDetectorProxy
     }
-    
+
     /// An object that provides a bridge for WebView instrumentation.
     public var webViewNativeBridge: any WebViewInstrumentationModule {
         webViewProxy

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -243,9 +243,7 @@ public class NetworkInstrumentation {
         span.setAttribute(key: SemanticAttributes.httpResponseStatusCode, value: Int(response?.statusCode ?? 0))
 
         // Try to capture IP address from the response/connection
-        if let httpResponse = response,
-           let url = httpResponse.url,
-           let host = url.host {
+        if let httpResponse = response {
             // Update network.peer.address with actual IP if we can get it
             if let ipAddress = getIPAddressFromResponse(httpResponse) {
                 span.setAttribute(key: "network.peer.address", value: ipAddress)

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
@@ -209,7 +209,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         let logRecords = [logRecord]
 
         // Export log record
-        backgroundLogExporter.export(logRecords: logRecords)
+        _ = backgroundLogExporter.export(logRecords: logRecords)
 
         // Print contents to stdout
         if debugEnabled {
@@ -234,7 +234,7 @@ extension OTLPSessionReplayEventProcessor {
     /// ‼️ This code mirrors `SplunkStdoutLogExporter`.
     private func log(_ logRecords: [SplunkReadableLogRecord]) {
         for logRecord in logRecords {
-            var bodyDescription: String
+            let bodyDescription: String
 
             switch logRecord.body {
             case let .data(data):


### PR DESCRIPTION
This PR fixes couple of warnings when building the agent as a swift package (when opening the package in Xcode directly, instead of using it as a dependency in a test application).

This PR does not fix linter issues or other warnings when the package is opened from the TestApp or the DevelApp.