### PR TITLE
DEMRUM-1791: Update api docc

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-RuntimeState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-RuntimeState.swift
@@ -18,28 +18,29 @@ limitations under the License.
 import Combine
 import Foundation
 
-/// A state object that is representation for the current state of the Agent.
+/// An observable object that represents the current runtime state of the agent.
 ///
-/// The individual properties are a combination of:
+/// This class provides read-only access to the agent's configuration and status.
+/// The values are a combination of:
 /// - Default SDK settings.
-/// - Initial configuration specified by  ``Configuration``.
+/// - The initial ``AgentConfiguration`` provided by the user.
 /// - Settings retrieved from the backend.
 ///
-/// - Note: The states of individual properties in this class can
-///         change during the application's runtime.
+/// - Note: The state of individual properties can change during the application's runtime.
 ///
-/// The class conforms to `Combine.ObservableObject` protocol to make
-/// the published properties available for Combine and SwiftUI.
-///
+/// This class conforms to `Combine.ObservableObject`, allowing you to subscribe to state
+/// changes in SwiftUI and other Combine-based frameworks.
 public final class RuntimeState: AgentState, ObservableObject {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns and provides the runtime state.
     private unowned let owner: SplunkRum
 
 
     // MARK: - Initialization
 
+    /// Initializes the runtime state with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -50,7 +51,7 @@ public extension RuntimeState {
 
     // MARK: - Agent status
 
-    /// A `Status` of agent recording.
+    /// The current recording status of the agent.
     var status: Status {
         owner.currentStatus
     }
@@ -58,27 +59,29 @@ public extension RuntimeState {
 
     // MARK: - User configuration
 
-    /// A `String` that contains the name used for the application identification.
+    /// The name of the application.
     var appName: String {
         owner.agentConfiguration.appName
     }
 
-    /// A `String` that contains the used application version.
+    /// The version of the application.
     var appVersion: String {
         owner.agentConfiguration.appVersion
     }
 
-    /// A `EndpointConfiguration` containing either the specified realm, or endpoint urls.
+    /// The endpoint configuration for the agent.
+    ///
+    /// See ``EndpointConfiguration`` for more details.
     var endpointConfiguration: EndpointConfiguration {
         owner.agentConfiguration.endpoint
     }
 
-    /// A `String` containing the used application deployment environment.
+    /// The deployment environment of the application (e.g., `dev`, `production`).
     var deploymentEnvironment: String {
         owner.agentConfiguration.deploymentEnvironment
     }
 
-    /// A `Bool` value determining whether the debug logging has been enabled.
+    /// A Boolean value indicating whether debug logging is enabled.
     var isDebugLoggingEnabled: Bool {
         owner.agentConfiguration.enableDebugLogging
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
@@ -17,22 +17,28 @@ limitations under the License.
 
 import Foundation
 
-/// A session object is a representation of the current user session.
+/// An object that represents the current user session.
+///
+/// This class provides access to the session identifier and its current state.
 public final class Session {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns this session.
     private unowned let owner: SplunkRum
 
 
     // MARK: - State
 
-    /// An object that reflects the current session's state.
+    /// An object that reflects the current state of the session.
+    ///
+    /// See ``SessionState`` for more details.
     public private(set) lazy var state = SessionState(for: owner)
 
 
     // MARK: - Initialization
 
+    /// Initializes the session with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -43,12 +49,13 @@ public extension Session {
 
     // MARK: - Identifier
 
-    /// Identification of recorded session in given time.
+    /// Returns the session identifier for a specific point in time.
     ///
     /// Some events can be tracked with a delay caused by, e.g., its asynchronous pre-processing
-    /// or an application crash.
+    /// or an application crash. This method returns the correct session ID for the timestamp when the event originated.
     ///
-    /// This method returns the respective session ID for the timestamp the event originates.
+    /// - Parameter timestamp: The `Date` for which to retrieve the session ID.
+    /// - Returns: The session ID as a `String`, or `nil` if no session exists at that time.
     func sessionId(for timestamp: Date) -> String? {
         owner.currentSession.sessionId(for: timestamp)
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-SessionState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-SessionState.swift
@@ -15,16 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A state object that reflects the current session's state.
+/// A state object that provides read-only access to the current session's state.
 public final class SessionState {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns this session state.
     private unowned let owner: SplunkRum
 
 
     // MARK: - Initialization
 
+    /// Initializes the session state with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -34,14 +36,16 @@ public extension SessionState {
 
     // MARK: - Public properties
 
-    /// Identification of recorded session.
+    /// The unique identifier of the current session.
     ///
-    /// When the agent is initialized, there is always some session ID.
+    /// A session ID is always available when the agent is initialized.
     var id: String {
         owner.currentSession.currentSessionId
     }
 
-    /// Value of the currently used session sampling rate.
+    /// The sampling rate applied to the current session.
+    ///
+    /// This is a value between 0.0 and 1.0 that determines the percentage of sessions being recorded.
     var samplingRate: Double {
         owner.agentConfiguration.session.samplingRate
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-User.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-User.swift
@@ -15,25 +15,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A user object is a representation of the user.
+/// An object that represents the current user, providing access to their preferences and state.
 public final class User {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns this user object.
     private unowned let owner: SplunkRum
 
 
     // MARK: - Public API
 
-    /// An object that holds preferred settings for the user.
+    /// An object for managing the user's preferences.
+    ///
+    /// See ``UserPreferences`` for more details.
     public private(set) lazy var preferences = UserPreferences(for: owner)
 
-    /// An object reflects the current user's state.
+    /// An object that reflects the current state of the user.
+    ///
+    /// See ``UserState`` for more details.
     public private(set) lazy var state = UserState(for: owner)
 
 
     // MARK: - Initialization
 
+    /// Initializes the user object with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -44,7 +50,7 @@ extension User {
 
     // MARK: - Identifier
 
-    /// Identification of the recorded user.
+    /// The unique identifier for the current user.
     var identifier: String {
         owner.currentUser.userIdentifier
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-UserPreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-UserPreferences.swift
@@ -15,16 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// The user preferences object represents the preferred settings related to the user.
+/// An object for managing user-specific preferences, such as the tracking mode.
 public final class UserPreferences {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns these user preferences.
     private unowned let owner: SplunkRum
 
 
     // MARK: - Initialization
 
+    /// Initializes the user preferences with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -35,7 +37,9 @@ public extension UserPreferences {
 
     // MARK: - User identification
 
-    /// The required tracking mode for user identification.
+    /// The tracking mode that controls how the user is identified.
+    ///
+    /// See ``UserTrackingMode`` for available options.
     var trackingMode: UserTrackingMode {
         get {
             owner.currentUser.trackingMode
@@ -45,11 +49,15 @@ public extension UserPreferences {
         }
     }
 
-    /// Sets required tracking mode for user identification.
+    /// Sets the tracking mode for user identification.
     ///
-    /// - Parameter trackingMode: The required tracking mode.
-    ///
+    /// - Parameter trackingMode: The tracking mode to apply.
     /// - Returns: The updated user preferences object.
+    ///
+    /// ### Example ###
+    /// ```
+    /// SplunkRum.user.preferences.trackingMode(.anonymous)
+    /// ```
     @discardableResult func trackingMode(_ trackingMode: UserTrackingMode) -> UserPreferences {
         owner.currentUser.trackingMode = trackingMode
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-UserState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-UserState.swift
@@ -15,16 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A state object reflects the current user's state.
+/// A state object that provides read-only access to the current user's state.
 public final class UserState {
 
     // MARK: - Internal
 
+    // The SplunkRum instance that owns this user state.
     private unowned let owner: SplunkRum
 
 
     // MARK: - Initialization
 
+    /// Initializes the user state with its owning `SplunkRum` instance.
     init(for owner: SplunkRum) {
         self.owner = owner
     }
@@ -35,7 +37,9 @@ public extension UserState {
 
     // MARK: - User identification
 
-    /// The currently used tracking mode.
+    /// The tracking mode currently being used to identify the user.
+    ///
+    /// See ``UserTrackingMode`` for available options.
     var trackingMode: UserTrackingMode {
         owner.currentUser.trackingMode
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-CustomTracking.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-CustomTracking.swift
@@ -21,9 +21,9 @@ public extension SplunkRum {
 
     // MARK: - Custom Tracking
 
-    /// Reports an error using a String. Legacy mapping.
+    /// Reports a string-based error.
     ///
-    /// - Parameter string: A String error message.
+    /// - Parameter string: The error message.
     @available(
         *,
         deprecated,
@@ -34,9 +34,9 @@ public extension SplunkRum {
         _ = shared.customTracking.trackError(string)
     }
 
-    /// Reports an error with a Swift Error or NSError. Legacy mapping.
+    /// Reports an error from a Swift `Error` or `NSError` instance.
     ///
-    /// - Parameter error: An instance of an Error-conforming type.
+    /// - Parameter error: An object that conforms to the `Error` protocol.
     @available(
         *,
         deprecated,
@@ -47,9 +47,9 @@ public extension SplunkRum {
         _ = shared.customTracking.trackError(error)
     }
 
-    /// Reports an exception with an NSException. Legacy mapping.
+    /// Reports an error from an `NSException` instance.
     ///
-    /// - Parameter exception: An NSException instance.
+    /// - Parameter exception: An `NSException` instance.
     @available(
         *,
         deprecated,
@@ -60,10 +60,10 @@ public extension SplunkRum {
         _ = shared.customTracking.trackException(exception)
     }
 
-    /// Reports a custom event with name and attributes. Legacy mapping.
+    /// Reports a custom event with a name and attributes.
     ///
-    /// - Parameter name: A user-assigned String name for the event.
-    /// - Parameter attribues: An NSDictionary with user-provided event attributes.
+    /// - Parameter name: The name of the custom event.
+    /// - Parameter attributes: A dictionary of attributes to associate with the event.
     @available(
         *,
         deprecated,

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-ScreenName.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-ScreenName.swift
@@ -19,9 +19,11 @@ public extension SplunkRum {
 
     // MARK: - Screen name
 
-    /// Sets a manual screen name. This setting is valid until a new name is set.
+    /// Sets a custom screen name.
     ///
-    /// - Parameter name: The name to be tracked as the screen name until being changed.
+    /// This name will be used for all subsequent screen-related spans until a new name is set.
+    ///
+    /// - Parameter name: The custom screen name.
     @available(
         *,
         deprecated,
@@ -32,9 +34,10 @@ public extension SplunkRum {
         shared.navigation.track(screen: name)
     }
 
-    /// Observe screen name changes in the Navigation module.
+    /// Registers a callback to observe screen name changes.
     ///
-    /// - Parameter callback: A closure for taking over screen name change.
+    /// - Parameter callback: A closure that receives the new screen name as a `String`.
+    ///                       Pass `nil` to remove a previously registered callback.
     @available(*, deprecated, message: "This method will be removed in a later version.")
     static func addScreenNameChangeCallback(_ callback: ((String) -> Void)?) {
         shared.screenNameChangeCallback = callback

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-SplunkRum.swift
@@ -19,41 +19,30 @@ import Foundation
 
 public extension SplunkRum {
 
-    /// Identification of recorded session.
-    ///
-    /// When the agent is initialized, there is always some session ID.
-    /// - Returns: The current session ID as a 'String'.
-    /// - Note: This function is deprecated and will be removed in a later version.
+    /// Returns the current session identifier.
     @available(*, deprecated, message: "This function will be removed in a later version. Use the new `SplunkRum.shared.session.state.id` API instead.")
     static func getSessionId() -> String {
         SplunkRum.shared.session.state.id
     }
 
-    /// A boolean determinning the `Status` of agent recording.
-    ///
-    /// - Returns: True when the status resolves to `.running`.
-    /// - Note: This function is deprecated and will be removed in a later version.
+    /// Checks if the agent's status is currently `.running`.
     @available(*, deprecated, message: "This function will be removed in a later version. Use the new `SplunkRum.shared.state.status` API instead.")
     static func isInitialized() -> Bool {
         SplunkRum.shared.state.status == .running
     }
 
-    /// Sets global attributes to be added to all spans.
+    /// Adds global attributes to all subsequent spans.
     ///
-    /// - Parameters:
-    ///   - attributes: A dictionary of key-value pairs to add as global attributes.
-    /// - Note: This function is deprecated and will be removed in a later version.
+    /// - Parameter attributes: A dictionary of attributes to add.
     @available(*, deprecated, message: "This function will be removed in a later version. Use the new `SplunkRum.shared.globalAttributes` API instead.")
     static func setGlobalAttributes(_ attributes: [String: Any]) {
         let globalAttributes = MutableAttributes(from: attributes)
         SplunkRum.shared.globalAttributes.addDictionary(globalAttributes.getAll())
     }
 
-    /// Removes a global attribute by key.
+    /// Removes a global attribute by its key.
     ///
-    /// - Parameters:
-    ///   - key: The key of the attribute to remove from global attributes.
-    /// - Note: This function is deprecated and will be removed in a later version.
+    /// - Parameter key: The key of the attribute to remove.
     @available(*, deprecated, message: "This function will be removed in a later version. Use the new `SplunkRum.shared.globalAttributes` API instead.")
     static func removeGlobalAttribute(_ key: String) {
         SplunkRum.shared.globalAttributes[key] = nil
@@ -61,9 +50,7 @@ public extension SplunkRum {
 
     /// Logs a debug message.
     ///
-    /// - Parameters:
-    ///   - msg: The debug message to log.
-    /// - Note: This function is deprecated and will be removed in a later version.
+    /// - Parameter msg: The debug message to log.
     @available(*, deprecated, message: "This function will be removed in a later version.")
     static func debugLog(_ msg: String) {}
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-WebView.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/API-1.0-WebView.swift
@@ -21,9 +21,19 @@ public extension SplunkRum {
 
     // MARK: - WebView
 
-    /// Injects JavaScript `getNativeSessionId()` function into `WKWebView`. Legacy mapping.
+    /// Integrates the native RUM agent with a browser RUM agent running in a `WKWebView`.
     ///
-    /// - Parameter webView: The `WKWebView` instance into which the JavaScript `getNativeSessionId()` and `getNativeSessionIdAsync()` APIs will be injected.
+    /// This method injects a JavaScript bridge into the web view, allowing the browser RUM agent
+    /// to retrieve the native session ID. This links the user's session across both the native
+    /// and web portions of your application.
+    ///
+    /// - Parameter webView: The `WKWebView` instance to integrate with.
+    ///
+    /// ### Example ###
+    /// ```
+    /// let myWebView = WKWebView()
+    /// SplunkRum.integrateWithBrowserRum(myWebView)
+    /// ```
     @available(
         *,
         deprecated,

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/Model/API-1.0-SplunkRumBuilder.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/Model/API-1.0-SplunkRumBuilder.swift
@@ -23,6 +23,7 @@ internal import SplunkSlowFrameDetector
 
 import Foundation
 
+/// A deprecated builder for initializing the RUM agent.
 @available(*, deprecated, message:
     """
     The SplunkRumBuilder class is no longer supported and will be removed in a later version.
@@ -32,33 +33,47 @@ public class SplunkRumBuilder {
 
     // MARK: - Configuration properties
 
+    // The beacon URL for sending trace data.
     private var beaconUrl: String
+    // The RUM authentication token.
     private var rumAuth: String
+    // A flag to enable or disable debug logging.
     private var debug: Bool = false
+    // The deployment environment string.
     private var environment: String?
+    // The session sampling ratio, from 0.0 to 1.0.
     private var sessionSamplingRatio: Double = ConfigurationDefaults.sessionSamplingRate
+    // The name of the application.
     private var appName: String?
+    // A dictionary of global attributes.
     private var globalAttributes: [String: Any]?
-
+    // The modern endpoint configuration object.
     private var endpointConfiguration: EndpointConfiguration?
 
 
     // MARK: - Instrumentations properties
 
+    // A flag to enable or disable screen name spans.
     private var screenNameSpans: Bool = true
+    // A flag to enable or disable automatic view controller instrumentation.
     private var showVCInstrumentation: Bool = false
+    // A flag to enable or disable slow rendering detection.
     private var slowRenderingDetectionEnabled: Bool = true
+    // A flag to enable or disable network instrumentation.
     private var networkInstrumentation: Bool = true
+    // A regex for URLs to ignore in network instrumentation.
     private var ignoreURLs: NSRegularExpression?
 
 
     // MARK: - Logging
 
+    // The internal logger for the builder.
     private let logger = DefaultLogAgent(poolName: PackageIdentifier.instance(), category: "SplunkRumBuilder")
 
 
     // MARK: - Builder initialization
 
+    /// Initializes the builder with a beacon URL and RUM authentication token.
     @available(*, deprecated, message:
         """
         This initializer will be removed in a later version.
@@ -79,6 +94,7 @@ public class SplunkRumBuilder {
         endpointConfiguration = EndpointConfiguration(trace: traceUrl)
     }
 
+    /// Initializes the builder with a realm and RUM authentication token.
     @available(*, deprecated, message:
         """
         This initializer will be removed in a later version.
@@ -94,6 +110,7 @@ public class SplunkRumBuilder {
 
     // MARK: - Public configuration builder methods
 
+    /// Enables or disables debug logging.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -105,6 +122,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the deployment environment.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -116,6 +134,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the session sampling ratio.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -127,6 +146,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the application name.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -138,6 +158,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// This method is a no-op and has no effect.
     @available(*, deprecated, message:
         """
         This builder method is a no-op and will be removed in a later version.
@@ -147,6 +168,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets global attributes to be included in all spans.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -160,10 +182,9 @@ public class SplunkRumBuilder {
 
     // MARK: - Instrumentations builder methods
 
-    /// Sets whether or not the Navigation module should automatically detect navigation in the application.
+    /// Enables or disables automatic tracking of view controller appearances.
     ///
-    /// - Parameter show: If `true`, the Navigation module will automatically detect navigation.
-    ///
+    /// - Parameter show: If `true`, the Navigation module will automatically track view controllers.
     /// - Returns: The updated builder instance.
     @available(*, deprecated, message:
         """
@@ -177,10 +198,9 @@ public class SplunkRumBuilder {
     }
 
 
-    /// Specifies whether the Navigation module should be activated and generate navigation spans.
+    /// Enables or disables the creation of screen name spans.
     ///
-    /// - Parameter enabled: If `true`, the Navigation module generates navigation spans.
-    ///
+    /// - Parameter enabled: If `true`, the Navigation module generates screen name spans.
     /// - Returns: The updated builder instance.
     @available(*, deprecated, message: "This builder method will be removed in a later version.")
     @discardableResult
@@ -189,10 +209,9 @@ public class SplunkRumBuilder {
         return self
     }
 
-    /// Specifies whether the SlowFrameDetection should be activated and generate slow frame detection spans.
+    /// Enables or disables slow and frozen frame detection.
     ///
-    /// - Parameter enabled: If `true`, the SlowFrameDetection module generates slow frame detection spans.
-    ///
+    /// - Parameter isEnabled: If `true`, the agent will detect and report slow and frozen frames.
     /// - Returns: The updated builder instance.
     @available(*, deprecated, message: "This builder method will be removed in a later version.")
     public func slowRenderingDetectionEnabled(_ isEnabled: Bool) -> SplunkRumBuilder {
@@ -200,10 +219,9 @@ public class SplunkRumBuilder {
         return self
     }
 
-    /// Specifies the legacy threshold for slow frame detection. This setting is now ignored.
+    /// This method is a no-op and has no effect. Thresholds are now managed automatically.
     ///
-    /// - Parameter thresholdMs: The legacy threshold in milliseconds. This value is not used.
-    ///
+    /// - Parameter thresholdMs: This parameter is ignored.
     /// - Returns: The builder instance to allow for continued chaining.
     @available(*, deprecated, message: "This configuration has been discontinued and has no effect. Thresholds are now managed automatically.")
     @discardableResult
@@ -213,10 +231,9 @@ public class SplunkRumBuilder {
         return self
     }
 
-    /// Specifies the legacy threshold for frozen frame detection. This setting is now ignored.
+    /// This method is a no-op and has no effect. Thresholds are now managed automatically.
     ///
-    /// - Parameter thresholdMs: The legacy threshold in milliseconds. This value is not used.
-    ///
+    /// - Parameter thresholdMs: This parameter is ignored.
     /// - Returns: The builder instance to allow for continued chaining.
     @available(*, deprecated, message: "This configuration has been discontinued and has no effect. Thresholds are now managed automatically.")
     @discardableResult
@@ -226,10 +243,9 @@ public class SplunkRumBuilder {
         return self
     }
 
-    /// Specifies whether the Network Instrumentation module should be activated and generate spans.
+    /// Enables or disables network instrumentation.
     ///
-    /// - Parameter enabled: If `true`, the Network Instrumentation module generates spans.
-    ///
+    /// - Parameter enabled: If `true`, the agent will automatically instrument network requests.
     /// - Returns: The updated builder instance.
     @available(*, deprecated, message: "This builder method will be removed in a later version.")
     @discardableResult
@@ -239,10 +255,9 @@ public class SplunkRumBuilder {
     }
 
 
-    /// Network Instrumention can ignore URLs as appropriate
+    /// Sets a regular expression to exclude certain URLs from network instrumentation.
     ///
-    /// - Parameter ignoreURLs: A regular expression that resolves to URLs to be ignored during network activity
-    ///
+    /// - Parameter ignoreURLs: A regular expression matching URLs to be ignored.
     /// - Returns: The updated builder instance.
     @available(*, deprecated, message: "This builder method will be removed in a later version.")
     @discardableResult
@@ -254,6 +269,7 @@ public class SplunkRumBuilder {
 
     // MARK: - Build translation method
 
+    /// Translates the builder settings into the modern configuration and initializes the RUM agent.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-AgentConfigurationError.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-AgentConfigurationError.swift
@@ -17,19 +17,25 @@ limitations under the License.
 
 import Foundation
 
-/// Describes an invalid agent configuration.
+/// An error that indicates an invalid agent configuration.
 enum AgentConfigurationError: Error, Equatable {
 
-    /// Invalid endpoint. Either one of the supplied endpoint urls (traces, session replay) is invalid, or the supplied realm is empty.
+    /// An error indicating that the provided endpoint configuration is invalid.
+    ///
+    /// This can occur if the endpoint URLs cannot be constructed or are missing.
+    /// - Parameter supplied: The invalid ``EndpointConfiguration`` that was provided.
     case invalidEndpoint(supplied: EndpointConfiguration)
 
-    /// Invalid app name.
+    /// An error indicating that the application name is missing or empty.
+    /// - Parameter supplied: The invalid app name that was provided.
     case invalidAppName(supplied: String?)
 
-    /// Invalid RUM access token.
+    /// An error indicating that the RUM access token is missing or empty.
+    /// - Parameter supplied: The invalid token that was provided.
     case invalidRumAccessToken(supplied: String?)
 
-    /// Invalid deployment environment.
+    /// An error indicating that the deployment environment is missing or empty.
+    /// - Parameter supplied: The invalid environment string that was provided.
     case invalidDeploymentEnvironment(supplied: String?)
 }
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
@@ -18,28 +18,53 @@ limitations under the License.
 import Foundation
 import OpenTelemetryApi
 
+/// A thread-safe, mutable collection of attributes for enriching telemetry data.
+///
+/// This class provides a dictionary-like interface for managing attributes that conform to
+/// `OpenTelemetryApi.AttributeValue`. It is designed to be used across multiple threads safely.
+///
+/// ### Usage ###
+///
+/// You can initialize an empty collection and add attributes using typed subscripts:
+///
+/// ```
+/// let attributes = MutableAttributes()
+/// attributes[string: "user.name"] = "Alice"
+/// attributes[int: "login.count"] = 5
+/// attributes[bool: "is.subscribed"] = true
+///
+/// // To remove an attribute, set its value to nil
+/// attributes[bool: "is.subscribed"] = nil
+/// ```
 public class MutableAttributes {
 
     // MARK: - Private
 
+    // The underlying thread-safe dictionary that stores the attributes.
     var attributes: ThreadSafeDictionary<String, AttributeValue>
 
 
     // MARK: - Initialize
 
+    /// Initializes an empty collection of attributes.
     public init() {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
     }
 
+    /// Initializes the collection with attributes from a dictionary.
+    /// - Parameter dictionary: A dictionary of `AttributeValue` items to add.
     public init(dictionary: [String: AttributeValue]) {
         attributes = ThreadSafeDictionary<String, AttributeValue>(dictionary: dictionary)
     }
 
+    /// Initializes the collection with attributes from an `AttributeSet`.
+    /// - Parameter attributeSet: An `AttributeSet` to copy attributes from.
     public init(attributeSet: AttributeSet) {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
         addAttributeSet(attributeSet)
     }
 
+    /// Initializes the collection by decoding from a `Decoder`.
     public required init(from decoder: Decoder) throws {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
         let container = try decoder.container(keyedBy: StringCodingKey.self)
@@ -55,6 +80,9 @@ public extension MutableAttributes {
 
     // MARK: - Subscripts
 
+    /// Accesses the `AttributeValue` for the given key.
+    ///
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(key: String) -> AttributeValue? {
         get {
             return attributes[key]
@@ -68,6 +96,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `String` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not a string.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(string key: String) -> String? {
         get {
             if case let .string(string) = attributes[key] {
@@ -84,6 +116,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `Bool` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not a boolean.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(bool key: String) -> Bool? {
         get {
             if case let .bool(bool) = attributes[key] {
@@ -100,6 +136,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `Int` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not an integer.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(int key: String) -> Int? {
         get {
             if case let .int(int) = attributes[key] {
@@ -116,6 +156,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `Double` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not a double.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(double key: String) -> Double? {
         get {
             if case let .double(double) = attributes[key] {
@@ -132,6 +176,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `AttributeArray` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not an array.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(array key: String) -> AttributeArray? {
         get {
             if case let .array(array) = attributes[key] {
@@ -148,6 +196,10 @@ public extension MutableAttributes {
         }
     }
 
+    /// Accesses the `AttributeSet` value for the given key.
+    ///
+    /// Returns `nil` if the key is not found or the value is not a set.
+    /// Setting a value to `nil` removes the key-value pair.
     subscript(set key: String) -> AttributeSet? {
         get {
             if case let .set(attributeSet) = attributes[key] {
@@ -169,10 +221,12 @@ public extension MutableAttributes {
 
     // MARK: - Getters and setters
 
+    /// Returns the `AttributeValue` for the given key.
     func getValue(for key: String) -> AttributeValue? {
         return attributes[key]
     }
 
+    /// Returns the `String` value for the given key, or `nil` if the key is not found or the value is not a string.
     func getString(for key: String) -> String? {
         if case let .string(string) = attributes[key] {
             return string
@@ -180,6 +234,7 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Returns the `Bool` value for the given key, or `nil` if the key is not found or the value is not a boolean.
     func getBool(for key: String) -> Bool? {
         if case let .bool(bool) = attributes[key] {
             return bool
@@ -187,6 +242,7 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Returns the `Int` value for the given key, or `nil` if the key is not found or the value is not an integer.
     func getInt(for key: String) -> Int? {
         if case let .int(int) = attributes[key] {
             return int
@@ -194,6 +250,7 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Returns the `Double` value for the given key, or `nil` if the key is not found or the value is not a double.
     func getDouble(for key: String) -> Double? {
         if case let .double(double) = attributes[key] {
             return double
@@ -201,6 +258,7 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Returns the `AttributeArray` for the given key, or `nil` if the key is not found or the value is not an array.
     func getArray(for key: String) -> AttributeArray? {
         if case let .array(array) = attributes[key] {
             return array
@@ -208,6 +266,7 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Returns the `AttributeSet` for the given key, or `nil` if the key is not found or the value is not a set.
     func getSet(for key: String) -> AttributeSet? {
         if case let .set(attributeSet) = attributes[key] {
             return attributeSet
@@ -215,30 +274,37 @@ public extension MutableAttributes {
         return nil
     }
 
+    /// Sets or updates the `AttributeValue` for the given key.
     func setValue(_ value: AttributeValue, for key: String) {
         attributes[key] = value
     }
 
+    /// Sets or updates a `String` value for the given key.
     func setString(_ string: String, for key: String) {
         attributes[key] = AttributeValue.string(string)
     }
 
+    /// Sets or updates a `Bool` value for the given key.
     func setBool(_ bool: Bool, for key: String) {
         attributes[key] = AttributeValue.bool(bool)
     }
 
+    /// Sets or updates an `Int` value for the given key.
     func setInt(_ int: Int, for key: String) {
         attributes[key] = AttributeValue.int(int)
     }
 
+    /// Sets or updates a `Double` value for the given key.
     func setDouble(_ double: Double, for key: String) {
         attributes[key] = AttributeValue.double(double)
     }
 
+    /// Sets or updates an `AttributeArray` value for the given key.
     func setArray(_ array: AttributeArray, for key: String) {
         attributes[key] = AttributeValue.array(array)
     }
 
+    /// Sets or updates an `AttributeSet` value for the given key.
     func setSet(_ attributeSet: AttributeSet, for key: String) {
         attributes[key] = AttributeValue.set(attributeSet)
     }
@@ -248,6 +314,9 @@ public extension MutableAttributes {
 
     // MARK: - Iterative setters
 
+    /// Adds or updates attributes from a given dictionary.
+    /// - Parameter dictionary: A dictionary of attributes to add.
+    /// - Returns: The number of attributes added or updated.
     @discardableResult
     func addDictionary(_ dictionary: [String: AttributeValue]) -> Int {
         var count = 0
@@ -258,6 +327,10 @@ public extension MutableAttributes {
         return count
     }
 
+    /// Adds or updates attributes from a dictionary, prefixing each key with a namespace.
+    /// - Parameter dictionary: A dictionary of attributes to add.
+    /// - Parameter namespace: A string to prepend to each key, followed by a dot.
+    /// - Returns: The number of attributes added or updated.
     @discardableResult
     func addDictionary(_ dictionary: [String: AttributeValue], intoNamespace namespace: String) -> Int {
         var count = 0
@@ -269,6 +342,9 @@ public extension MutableAttributes {
         return count
     }
 
+    /// Adds or updates attributes from a given `AttributeSet`.
+    /// - Parameter attributeSet: An `AttributeSet` to copy attributes from.
+    /// - Returns: The number of attributes added or updated.
     @discardableResult
     func addAttributeSet(_ attributeSet: AttributeSet) -> Int {
         var count = 0
@@ -279,6 +355,10 @@ public extension MutableAttributes {
         return count
     }
 
+    /// Adds or updates attributes from an `AttributeSet`, prefixing each key with a namespace.
+    /// - Parameter attributeSet: An `AttributeSet` to copy attributes from.
+    /// - Parameter namespace: A string to prepend to each key, followed by a dot.
+    /// - Returns: The number of attributes added or updated.
     @discardableResult
     func addAttributeSet(_ attributeSet: AttributeSet, intoNamespace namespace: String) -> Int {
         var count = 0
@@ -295,35 +375,47 @@ public extension MutableAttributes {
 
     // MARK: - Utilities
 
+    /// Removes the attribute for the given key.
+    /// - Parameter key: The key of the attribute to remove.
+    /// - Returns: The value that was removed, or `nil` if the key was not present.
     @discardableResult
     func remove(for key: String) -> AttributeValue? {
         return attributes.removeValue(forKey: key)
     }
 
+    /// Removes all attributes from the collection.
     func removeAll() {
         attributes.removeAll()
     }
 
+    /// Returns a Boolean value indicating whether the collection contains an attribute for the given key.
+    /// - Parameter key: The key to check for.
+    /// - Returns: `true` if an attribute with the specified key exists, otherwise `false`.
     func contains(key: String) -> Bool {
         return attributes.contains(key: key)
     }
 
+    /// Returns a dictionary containing all attributes.
     func getAll() -> [String: AttributeValue] {
         return attributes.getAll()
     }
 
+    /// Returns an array of all attribute keys.
     func getAllKeys() -> [String] {
         return attributes.allKeys()
     }
 
+    /// Returns an array of all attribute values.
     func getAllValues() -> [AttributeValue] {
         return attributes.allValues()
     }
 
+    /// Returns the number of attributes in the collection.
     func count() -> Int {
         return attributes.count()
     }
 
+    // Converts the internal `AttributeValue` dictionary to a `[String: Any]` dictionary.
     private func getAllAsAny() -> [String: Any] {
         var result: [String: Any] = [:]
         let dictionary = attributes.getAll()
@@ -335,6 +427,7 @@ public extension MutableAttributes {
         return result
     }
 
+    /// A dictionary containing all attributes, with values converted to `Any`.
     var all: [String: Any] {
         return getAllAsAny()
     }
@@ -344,6 +437,7 @@ extension MutableAttributes: CustomStringConvertible {
 
     // MARK: - Description
 
+    /// A human-readable description of the attributes, sorted by key.
     public var description: String {
         var result = "[\n"
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-SessionConfiguration.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-SessionConfiguration.swift
@@ -15,13 +15,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A configuration object representing properties of the Agent's `Session`.
+/// A configuration for session-related settings, such as the session sampling rate.
 public struct SessionConfiguration: Codable, Equatable {
 
     // MARK: - Public properties
 
-    /// A sampling rate in the `<0.0, 1.0>` interval.
-    /// `1.0` equals to zero sampling (all instrumentation is sent), `0.0` equals to all session being sampled, `0.5` equals to 50% sampling.
+    /// The session sampling rate, controlling what percentage of sessions are recorded.
+    ///
+    /// This value must be in the range `0.0` to `1.0`.
+    /// - `1.0` means 100% of sessions are recorded.
+    /// - `0.5` means 50% of sessions are recorded.
+    /// - `0.0` means 0% of sessions are recorded.
     ///
     /// Defaults to `1.0`.
     public var samplingRate = ConfigurationDefaults.sessionSamplingRate
@@ -29,17 +33,18 @@ public struct SessionConfiguration: Codable, Equatable {
 
     // MARK: - Initialization
 
-    /// Default empty constructor.
-    ///
-    /// Initializes the configuration object's properties with default values.
+    /// Initializes the session configuration with default values.
     public init() {}
 
-    /// Initializes the configuration object.
+    /// Initializes the session configuration with a custom sampling rate.
     ///
-    /// - Parameters:
-    /// - samplingRate: A sampling rate in the `<0.0, 1.0>` interval.
-    /// `1.0` equals to zero sampling (all instrumentation is sent),
-    /// `0.0` equals to all session being sampled, `0.5` equals to 50% sampling.
+    /// - Parameter samplingRate: The session sampling rate, a value between `0.0` and `1.0`.
+    ///
+    /// ### Example ###
+    /// ```
+    /// // Record 25% of all user sessions
+    /// let sessionConfig = SessionConfiguration(samplingRate: 0.25)
+    /// ```
     public init(samplingRate: Double) {
         self.samplingRate = samplingRate
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-Status.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-Status.swift
@@ -15,28 +15,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A status of agent instance.
+/// An enumeration that represents the lifecycle status of the agent.
 ///
-/// Describes the possible states for agent in which can be during its lifecycle.
+/// You can check this status to understand whether the agent is actively recording and sending data.
+///
+/// ### Example ###
+/// ```
+/// switch SplunkRum.shared.state.status {
+/// case .running:
+///     print("Agent is running.")
+/// case .notRunning(let cause):
+///     print("Agent is not running due to: \(cause)")
+/// }
+/// ```
 public enum Status: Equatable {
 
-    /// Recording is in progress.
+    /// The agent is actively recording and sending telemetry data.
     case running
 
-    /// Recording is not in progress. A ``Cause`` determines the reason for this status.
+    /// The agent is not recording. The associated `Cause` value provides the specific reason.
     case notRunning(Cause)
 
 
-    /// The cause why the recording is currently not running.
+    /// The reason why the agent's status is `.notRunning`.
     public enum Cause {
 
-        /// The agent has not been installed.
+        /// The agent has not been installed via `SplunkRum.install`.
         case notInstalled
 
-        /// The agent is not supported on the current platform.
+        /// The agent does not support the current operating system or platform.
         case unsupportedPlatform
 
-        /// The agent is not running because of being sampled out locally.
+        /// The agent is not running for this session because it has been sampled out
+        /// based on the configured sampling rate.
         case sampledOut
     }
 }
@@ -46,6 +57,7 @@ extension Status.Cause: CustomStringConvertible, CustomDebugStringConvertible {
 
     // MARK: - StringConvertible methods
 
+    /// A human-readable description of the cause.
     public var description: String {
         switch self {
         case .notInstalled:

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-UserConfiguration.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-UserConfiguration.swift
@@ -15,28 +15,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A configuration object representing properties of the Agent's `User`.
+/// A configuration for user-related settings, such as the user tracking mode.
 public struct UserConfiguration: Codable, Equatable {
 
     // MARK: - Public properties
 
-    /// Sets the preferred `UserTrackingMode`.
+    /// The mode for tracking and identifying the user.
     ///
-    /// Defaults to `.noTracking`
+    /// Defaults to `.default`. See ``UserTrackingMode`` for all available options.
     public var trackingMode: UserTrackingMode = .default
 
 
     // MARK: - Initialization
 
-    /// Default empty constructor.
-    ///
-    /// Initializes the configuration object's properties with default values.
+    /// Initializes the user configuration with default values.
     public init() {}
 
-    /// Initializes the configuration object.
+    /// Initializes the user configuration with a specific tracking mode.
     ///
-    /// - Parameters:
-    /// - trackingMode: The preferred `UserTrackingMode`.
+    /// - Parameter trackingMode: The preferred ``UserTrackingMode``.
+    ///
+    /// ### Example ###
+    /// ```
+    /// // Configure user tracking to be anonymous
+    /// let userConfig = UserConfiguration(trackingMode: .anonymous)
+    /// ```
     public init(trackingMode: UserTrackingMode) {
         self.trackingMode = trackingMode
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-UserTrackingMode.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-UserTrackingMode.swift
@@ -15,27 +15,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A mode of user tracking.
+/// An enumeration that defines how the user is tracked and identified.
 ///
-/// Determines whether and, if necessary, how the user will be tracked.
+/// You can set this mode in the ``UserConfiguration`` to control user privacy.
+///
+/// ### Example ###
+/// ```
+/// var config = UserConfiguration()
+/// config.trackingMode = .anonymousTracking
+/// ```
 public enum UserTrackingMode: Codable, Equatable {
 
-    /// No tracking. Individual user sessions are not linked in any way.
+    /// Disables user tracking.
     ///
-    /// This is a default option for user tracking.
+    /// When this mode is active, individual user sessions are not linked together.
     case noTracking
 
-    /// Anonymous tracking. Allows you to link individual sessions
-    /// under an anonymized user ID.
+    /// Enables anonymous user tracking.
     ///
-    /// - Note: An anonymous user ID is used, which cannot be traced
-    /// to an individual for tracking across applications.
+    /// This mode links individual sessions together under a single, anonymized user ID.
+    ///
+    /// - Note: The anonymous user ID is generated locally and cannot be used to
+    ///         identify the user across different applications or devices.
     case anonymousTracking
 }
 
 
 public extension UserTrackingMode {
 
-    /// Default user tracking mode.
+    /// The default user tracking mode, which is ``noTracking``.
     static let `default`: UserTrackingMode = .noTracking
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Custom Tracking/Public API/API-1.0-CustomTrackingModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Custom Tracking/Public API/API-1.0-CustomTrackingModule.swift
@@ -23,69 +23,86 @@ import OpenTelemetryApi
 
 // MARK: - CustomTracking
 
-/// Defines a public API for the CustomTracking  module.
+/// An interface for tracking custom application events, errors, and user-defined workflows.
 public protocol CustomTrackingModule {
 
     // MARK: - Track Custom Events
 
-    /// Track a custom event with a name and attributes.
+    /// Tracks a custom event with a specific name and optional attributes.
     ///
-    /// - Parameter name: The event name assigned by the user.
-    ///
-    /// - Parameter attributes: MutableAttributes instance.
-    ///
-    /// - Returns: The updated `CustomTrackingModule` instance.
+    /// - Parameter name: The name of the event.
+    /// - Parameter attributes: A ``MutableAttributes`` object containing attributes for the event.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackCustomEvent(_ name: String, _ attributes: MutableAttributes) -> any CustomTrackingModule
 
     // MARK: - Track Errors
 
-    /// Track an error (String message) with optional attributes.
+    /// Tracks a string-based error with optional attributes.
     ///
     /// - Parameter message: A concise summary of the error condition.
-    ///
-    /// - Parameter attributes: Optional MutableAttributes instance to associate with the error.
-    ///
-    /// - Returns: The updated `CustomTrackingModule` instance.
+    /// - Parameter attributes: A ``MutableAttributes`` object to associate with the error.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackError(_ message: String, _ attributes: MutableAttributes) -> any CustomTrackingModule
 
-    /// Track an Error, including NSError (any Swift Error conforming type) with optional attributes.
+    /// Tracks an error based on a Swift `Error` object, with optional attributes.
     ///
-    /// - Parameter error: An instance of a type conforming to the Swift Error protocol.
-    ///
-    /// - Parameter attributes: Optional MutableAttributes instance to associate with the error.
-    ///
-    /// - Returns: The updated `CustomTrackingModule` instance.
+    /// - Parameter error: An instance of a type conforming to the `Error` protocol.
+    /// - Parameter attributes: A ``MutableAttributes`` object to associate with the error.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackError(_ error: Error, _ attributes: MutableAttributes) -> any CustomTrackingModule
 
 
-    /// Track an NSException object with optional attributes.
+    /// Tracks an error based on an `NSException` object, with optional attributes.
     ///
-    /// - Parameter exception: An NSException instance such as one caught after a throw.
-    ///
-    /// - Parameter attributes: Optional MutableAttributes instance to associate with the error.
-    ///
-    /// - Returns: The updated `CustomTrackingModule` instance.
+    /// - Parameter exception: An `NSException` instance.
+    /// - Parameter attributes: A ``MutableAttributes`` object to associate with the error.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackException(_ exception: NSException, _ attributes: MutableAttributes) -> any CustomTrackingModule
 
 
     // MARK: - Track Custom Workflow
 
-    /// Track a workflow with a name and return a Span object.
+    /// Starts a new span to track a multi-step user workflow.
+    ///
+    /// - Warning: You are responsible for ending the returned `Span` by calling its `end()` method
+    ///            at the appropriate time. Failure to do so will result in a leaked span.
     ///
     /// - Parameter workflowName: The name of the workflow to track.
+    /// - Returns: A `Span` object representing the workflow.
     ///
-    /// - Returns: A Span object representing the workflow.
+    /// ### Example ###
+    /// ```
+    /// let workflow = SplunkRum.shared.customTracking.trackWorkflow("Onboarding")
+    /// // ... perform onboarding steps ...
+    /// workflow.end()
+    /// ```
     func trackWorkflow(_ workflowName: String) -> Span
 
 
     // MARK: - Single argument helpers (signatures)
 
+    /// Tracks a custom event with a specific name and no additional attributes.
+    ///
+    /// - Parameter name: The name of the event.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackCustomEvent(_ name: String) -> any CustomTrackingModule
 
+    /// Tracks a string-based error with no additional attributes.
+    ///
+    /// - Parameter message: A concise summary of the error condition.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackError(_ message: String) -> any CustomTrackingModule
 
+    /// Tracks an error based on a Swift `Error` object with no additional attributes.
+    ///
+    /// - Parameter error: An instance of a type conforming to the `Error` protocol.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackError(_ error: Error) -> any CustomTrackingModule
 
+    /// Tracks an error based on an `NSException` object with no additional attributes.
+    ///
+    /// - Parameter exception: An `NSException` instance.
+    /// - Returns: The `CustomTrackingModule` instance to allow for chaining.
     @discardableResult func trackException(_ exception: NSException) -> any CustomTrackingModule
 }
 
@@ -93,7 +110,8 @@ extension CustomTrackingModule {
 
     // MARK: - Custom Event single argument helper
 
-    @discardableResult func trackCustomEvent(_ name: String) -> any CustomTrackingModule {
+    /// Tracks a custom event with a specific name and no additional attributes.
+    @discardableResult public func trackCustomEvent(_ name: String) -> any CustomTrackingModule {
         return trackCustomEvent(name, MutableAttributes())
     }
 }
@@ -102,15 +120,18 @@ extension CustomTrackingModule {
 
     // MARK: - Error single argument helpers
 
-    @discardableResult func trackError(_ message: String) -> any CustomTrackingModule {
+    /// Tracks a string-based error with no additional attributes.
+    @discardableResult public func trackError(_ message: String) -> any CustomTrackingModule {
         return trackError(message, MutableAttributes())
     }
 
-    @discardableResult func trackError(_ error: Error) -> any CustomTrackingModule {
+    /// Tracks an error based on a Swift `Error` object with no additional attributes.
+    @discardableResult public func trackError(_ error: Error) -> any CustomTrackingModule {
         return trackError(error, MutableAttributes())
     }
 
-    @discardableResult func trackException(_ exception: NSException) -> any CustomTrackingModule {
+    /// Tracks an error based on an `NSException` object with no additional attributes.
+    @discardableResult public func trackException(_ exception: NSException) -> any CustomTrackingModule {
         return trackException(exception, MutableAttributes())
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
@@ -17,36 +17,55 @@ limitations under the License.
 
 import Combine
 
-/// Defines a public API for the Navigation module.
+/// An interface for tracking screen transitions and other navigation-related events.
+///
+/// This module can be configured to track navigation automatically or can be used to
+/// track screen views manually.
 public protocol NavigationModule: ObservableObject {
 
     // MARK: - Preferences
 
-    // An object that holds preferred settings for the module.
+    /// The preferences that control the behavior of the navigation module.
+    ///
+    /// See ``NavigationModulePreferences`` for available options.
     var preferences: NavigationModulePreferences { get set }
 
-    /// Sets preferred settings for the module.
+    /// Sets the preferences for the navigation module.
     ///
-    /// - Parameter preferences: The preferred settings for the module.
+    /// - Parameter preferences: The ``NavigationModulePreferences`` to apply.
+    /// - Returns: The `NavigationModule` instance to allow for chaining.
     ///
-    /// - Returns: The actual `Navigation` instance.
+    /// ### Example ###
+    /// ```
+    /// var navPrefs = NavigationModulePreferences()
+    /// navPrefs.enableAutomatedTracking = false
+    /// SplunkRum.shared.navigation.preferences(navPrefs)
+    /// ```
     @discardableResult func preferences(_ preferences: NavigationModulePreferences) -> any NavigationModule
 
 
     // MARK: - State
 
-    /// An object that reflects the current state and settings used for the module.
+    /// An object that reflects the current state of the navigation module.
+    ///
+    /// See ``NavigationModuleState`` for more details.
     var state: NavigationModuleState { get }
 
 
     // MARK: - Manual detection
 
-    /// Sets a manual screen name. This setting is valid until a new name is set.
+    /// Manually tracks a screen view with a custom name.
     ///
-    /// - Parameter name: The name to be tracked as the screen name until being changed.
+    /// This name will be used for all subsequent screen-related spans until a new name is set.
     ///
-    /// - Returns: The actual `Navigation` instance.
+    /// - Parameter name: The custom name for the screen.
+    /// - Returns: The `NavigationModule` instance to allow for chaining.
     ///
-    /// - Note: The set value is not linked to any specific UI element.
+    /// - Note: The screen name set via this method is not linked to any specific UI element.
+    ///
+    /// ### Example ###
+    /// ```
+    /// SplunkRum.shared.navigation.track(screen: "ProductDetailsView")
+    /// ```
     @discardableResult func track(screen name: String) -> any NavigationModule
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModulePreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModulePreferences.swift
@@ -15,26 +15,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a public API for the user's preferred settings.
+/// An interface for configuring the behavior of the navigation module.
 public protocol NavigationModulePreferences {
 
     // MARK: - Automated tracking
 
-    /// A `Boolean` value determines whether the module should automatically detect navigation in the application.
+    /// A Boolean value that enables or disables automatic tracking of view controller transitions.
+    ///
+    /// If set to `true`, the module automatically creates screen name spans for view controller appearances.
+    /// If `false`, you must track screen views manually using ``NavigationModule/track(screen:)``.
+    /// A value of `nil` restores the default behavior.
     var enableAutomatedTracking: Bool? { get set }
 
-    /// Sets whether or not the module should automatically detect navigation in the application.
+    /// Enables or disables automatic tracking of view controller transitions.
     ///
-    /// - Parameter enable: If `true`, the module will automatically detect navigation.
-    ///
-    /// - Returns: The updated preferences object.
+    /// - Parameter enable: A `Bool` to enable or disable tracking. Pass `nil` to restore the default behavior.
+    /// - Returns: The updated preferences object to allow for chaining.
     @discardableResult func enableAutomatedTracking(_ enable: Bool?) -> any NavigationModulePreferences
 
 
     // MARK: - Convenience init
 
-    /// Initializes new preferences object with preconfigured values.
+    /// Initializes a new preferences object.
     ///
-    /// - Parameter enableAutomatedTracking: If `true`, the module will automatically detect navigation.
+    /// - Parameter enableAutomatedTracking: A `Bool` to enable or disable automatic tracking.
+    ///   Pass `nil` to use the default setting.
+    ///
+    /// ### Example ###
+    /// ```
+    /// // Create preferences to disable automatic screen tracking
+    /// let navPrefs = ConcreteNavigationPreferences(enableAutomatedTracking: false)
+    /// SplunkRum.shared.navigation.preferences(navPrefs)
+    /// ```
     init(enableAutomatedTracking: Bool?)
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModuleState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModuleState.swift
@@ -15,22 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a public API for the current state of the `Navigation` module.
+/// An interface that provides read-only access to the current state of the navigation module.
 ///
-/// The individual properties are a combination of:
-/// - Default settings.
-/// - Initial default configuration.
-/// - Settings retrieved from the backend.
-/// - Preferred behavior.
+/// The state properties reflect the final, effective settings being used by the module,
+/// which are a combination of:
+/// - Default SDK settings.
+/// - The initial module configuration.
+/// - Settings retrieved from a remote configuration source.
+/// - User-defined preferences.
 ///
-/// - Note: The states of individual properties in this class can
-///         and usually also change during the application's runtime.
+/// - Note: The values of these properties can change during the application's runtime.
+///
+/// ### Example ###
+/// ```
+/// if SplunkRum.shared.navigation.state.isAutomatedTrackingEnabled {
+///     print("Automatic screen tracking is active.")
+/// }
+/// ```
 public protocol NavigationModuleState {
 
     // MARK: - Automated tracking
 
-    /// Indicates whether automatic navigation detection is enabled.
-    ///
-    /// The default value is `false`.
+    /// A Boolean value indicating whether automatic tracking of view controller transitions is enabled.
     var isAutomatedTrackingEnabled: Bool { get }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-CustomId+UIView.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-CustomId+UIView.swift
@@ -20,9 +20,24 @@ import UIKit
 
 public extension UIView {
 
-    /// Element custom id for the specified `UIView` instance.
+    /// A custom identifier for this view, used for Session Replay and Interaction Tracking.
     ///
-    /// Assigning `nil` removes previously assigned custom id.
+    /// Setting this ID allows you to uniquely identify and reference this specific view in your RUM data.
+    /// This is particularly useful for masking or unmasking sensitive content in Session Replay or for
+    /// tracking user interactions with specific UI elements.
+    ///
+    /// Assigning `nil` to this property removes any previously set identifier.
+    ///
+    /// ### Example ###
+    /// ```
+    /// let loginButton = UIButton()
+    /// loginButton.splunkRumId = "login-button"
+    ///
+    /// // Later, you can retrieve it
+    /// if let id = loginButton.splunkRumId {
+    ///     print("Button ID: \(id)") // Prints "Button ID: login-button"
+    /// }
+    /// ```
     var splunkRumId: String? {
         get {
             SplunkRum.shared.sessionReplay.customIdentifiers[self]

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+SwiftUI.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+SwiftUI.swift
@@ -21,15 +21,26 @@ public extension View {
 
     // MARK: - View sensitivity (SwiftUI)
 
-    /// Sets an recording sensitivity for the specified `View`.
+    /// Masks this view and its subviews during Session Replay recordings to protect sensitive information.
     ///
-    /// To set the sensitivity of Views that encapsulate native UIKit elements,
-    /// you must first set their sensitivity using the UIKit methods
-    /// and then hide the View using this modifier.
+    /// By default, this modifier treats the view as sensitive and applies a masking effect.
     ///
-    /// - Parameter sensitive: A new state of element sensitivity.
+    /// - Note: This modifier only affects SwiftUI views. If your view wraps a UIKit element
+    ///   (e.g., using `UIViewRepresentable`), you must also configure the sensitivity
+    ///   of the underlying `UIView` for masking to work correctly.
     ///
-    /// - Returns: The `View` with defined sensitivity for recording in Session Replay module.
+    /// - Parameter sensitive: A Boolean value that determines whether the view should be masked.
+    ///   Defaults to `true`.
+    /// - Returns: A view that is configured for sensitivity in Session Replay recordings.
+    ///
+    /// ### Example ###
+    /// ```
+    /// VStack {
+    ///     Text("This is public information.")
+    ///     TextField("Password", text: $password)
+    ///         .sessionReplaySensitive() // This TextField will be masked
+    /// }
+    /// ```
     func sessionReplaySensitive(_ sensitive: Bool = true) -> some View {
         return modifier(SensitivityModifier(sensitive: sensitive))
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-Sensitivity+UIView.swift
@@ -21,9 +21,24 @@ import UIKit
 
 public extension UIView {
 
-    /// Element sensitivity for the specified `UIView` instance.
+    /// A Boolean value that controls whether this view and its subviews are masked during Session Replay recordings.
     ///
-    /// Assigning `nil` removes previously assigned explicit sensitivity.
+    /// This property has three states:
+    /// - `true`: Masks the view, treating it as sensitive.
+    /// - `false`: Unmasks the view, treating it as not sensitive. This can override a parent's sensitive setting.
+    /// - `nil`: The view inherits its sensitivity from its parent. Setting this property to `nil` reverts it to the default inherited behavior.
+    ///
+    /// ### Example ###
+    /// ```
+    /// // Mask a view containing sensitive user information
+    /// let userProfileView = UIView()
+    /// userProfileView.srSensitive = true
+    ///
+    /// // Unmask a specific public label within that sensitive view
+    /// let publicLabel = UILabel()
+    /// userProfileView.addSubview(publicLabel)
+    /// publicLabel.srSensitive = false
+    /// ```
     var srSensitive: Bool? {
         get {
             SplunkRum.shared.sessionReplay.sensitivity[self]

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModule.swift
@@ -17,70 +17,82 @@ limitations under the License.
 
 import Combine
 
-/// Defines a public API for the Session Replay module.
+/// An interface for controlling Session Replay recordings, including starting/stopping,
+/// managing view sensitivity, and setting preferences.
 public protocol SessionReplayModule: ObservableObject {
 
     // MARK: - Sensitivity
 
-    /// An object that holds and manages view elements sensitivity.
+    /// An object for managing the masking of sensitive views.
+    ///
+    /// See ``SessionReplayModuleSensitivity`` for more details.
     var sensitivity: SessionReplayModuleSensitivity { get }
 
 
     // MARK: - Custom id
 
-    /// An object that holds and manages view elements sensitivity.
+    /// An object for assigning custom identifiers to views for tracking and masking purposes.
+    ///
+    /// See ``SessionReplayModuleCustomId`` for more details.
     var customIdentifiers: SessionReplayModuleCustomId { get }
 
 
     // MARK: - State
 
-    /// An object that reflects the current state and settings used for the recording.
+    /// An object that provides read-only access to the current state of the Session Replay module.
+    ///
+    /// See ``SessionReplayModuleState`` for more details.
     var state: SessionReplayModuleState { get }
 
 
     // MARK: - Module preferences
 
-    /// An object that holds preferred settings for the recording.
+    /// The preferences that control the behavior of Session Replay recordings.
+    ///
+    /// See ``SessionReplayModulePreferences`` for available options.
     var preferences: SessionReplayModulePreferences { get set }
 
-    /// Sets preferred settings for the recording.
+    /// Sets the preferences for Session Replay recordings.
     ///
-    /// - Parameter preferences: The preferred settings for the recording.
-    ///
-    /// - Returns: The actual `SessionReplay` instance.
+    /// - Parameter preferences: The ``SessionReplayModulePreferences`` to apply.
+    /// - Returns: The `SessionReplayModule` instance to allow for chaining.
     @discardableResult func preferences(_ preferences: SessionReplayModulePreferences) -> any SessionReplayModule
 
 
     // MARK: - Recording management
 
-    /// Starts recording.
+    /// Starts a new Session Replay recording if one is not already in progress.
     ///
-    /// If the recording is already running, then it does nothing.
-    ///
-    /// - Returns: The actual `SessionReplay` instance.
+    /// ### Example ###
+    /// ```
+    /// SplunkRum.shared.sessionReplay.start()
+    /// ```
+    /// - Returns: The `SessionReplayModule` instance to allow for chaining.
     @discardableResult func start() -> any SessionReplayModule
 
-    /// Stops the currently running recording.
+    /// Stops the current Session Replay recording.
     ///
-    /// If the recording is not running, then it does nothing.
+    /// - Note: You do not need to call this method when the application is closed by the user;
+    ///         the module handles this automatically.
     ///
-    /// This method is primarily used to pause the recording and does not need to call
-    /// when the application exits. If the application is closed by the user,
-    /// the module itself will call it.
-    ///
-    /// - Returns: The actual `SessionReplay` instance.
+    /// ### Example ###
+    /// ```
+    /// SplunkRum.shared.sessionReplay.stop()
+    /// ```
+    /// - Returns: The `SessionReplayModule` instance to allow for chaining.
     @discardableResult func stop() -> any SessionReplayModule
 
 
     // MARK: - Recording masks
 
-    /// The recording mask, covers possibly sensitive areas.
+    /// A view that overlays the entire screen to mask sensitive content during recordings.
+    ///
+    /// See ``RecordingMask`` for more details.
     var recordingMask: RecordingMask? { get set }
 
-    /// Sets a recording mask that covers possibly sensitive areas.
+    /// Sets a custom view to overlay the screen and mask sensitive content.
     ///
-    /// - Parameter recordingMask: The predefined recording mask for recording.
-    ///
-    /// - Returns: The actual `SessionReplay` instance.
+    /// - Parameter recordingMask: A ``RecordingMask`` to apply. Pass `nil` to remove the mask.
+    /// - Returns: The `SessionReplayModule` instance to allow for chaining.
     @discardableResult func recordingMask(_ recordingMask: RecordingMask?) -> any SessionReplayModule
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleCustomId.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleCustomId.swift
@@ -3,6 +3,7 @@ Copyright 2024 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
@@ -16,28 +17,36 @@ limitations under the License.
 
 import UIKit
 
-/// Defines a public API for the view element's custom id's.
+/// An interface for managing custom identifiers for `UIView` instances.
+///
+/// Use this API to assign unique, human-readable IDs to your views. These identifiers
+/// can be used to reference specific views for tracking or masking in Session Replay.
+///
+/// ### Example ###
+/// ```
+/// let loginButton = UIButton()
+/// SplunkRum.shared.sessionReplay.customIdentifiers[loginButton] = "login-button"
+/// ```
 public protocol SessionReplayModuleCustomId: AnyObject {
 
     // MARK: - View customId
 
-    /// Retrieves or adds an element CustomId for the specified `UIView` instance.
+    /// Retrieves or sets a custom identifier for a specific `UIView`.
     ///
-    /// Assigning `nil` removes previously assigned value.
+    /// Setting a value to `nil` removes any previously assigned identifier for the view.
     ///
-    /// - Parameter view: A view instance to add or remove custom id.
-    ///
-    /// - Returns: The view custom id
+    /// - Parameter view: The `UIView` instance to identify.
+    /// - Returns: The custom identifier as a `String`, or `nil` if none is set.
     subscript(view: UIView) -> String? { get set }
 
-    /// Sets element custom id for the specified `UIView` instance.
+    /// Sets a custom identifier for a specific `UIView` instance.
     ///
-    /// Assigning `nil` removes previously assigned custom id.
+    /// - Note: This method provides the same functionality as the subscript and is included
+    ///   for chaining convenience.
     ///
     /// - Parameters:
-    ///   - view: A view instance to add or remove sensitivity preferences.
-    ///   - customId: A new custom id.
-    ///
-    /// - Returns: The updated object.
+    ///   - view: The `UIView` instance to identify.
+    ///   - customId: The custom identifier to assign. Pass `nil` to remove an existing identifier.
+    /// - Returns: The updated `SessionReplayModuleCustomId` object to allow for chaining.
     @discardableResult func set(_ view: UIView, _ customId: String?) -> any SessionReplayModuleCustomId
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferences.swift
@@ -15,29 +15,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a public API for the user's preferred settings.
+/// An interface for configuring Session Replay settings, such as the video rendering mode.
 public protocol SessionReplayModulePreferences {
 
     // MARK: - Rendering
 
-    /// The video rendering mode for captured data.
+    /// The rendering mode used for Session Replay videos.
+    ///
+    /// See ``RenderingMode`` for available options. Setting this property to `nil`
+    /// restores the default rendering mode.
     var renderingMode: RenderingMode? { get set }
 
-    /// Sets video rendering mode for captured data.
+    /// Sets the rendering mode for Session Replay videos.
     ///
-    /// - Parameter renderingMode: The required rendering mode.
-    ///
-    /// - Returns: The updated preferences object.
+    /// - Parameter renderingMode: The ``RenderingMode`` to apply. Pass `nil` to restore the default behavior.
+    /// - Returns: The updated preferences object to allow for chaining.
     @discardableResult func renderingMode(_ renderingMode: RenderingMode?) -> any SessionReplayModulePreferences
 
 
     // MARK: - Convenience init
 
-    /// Initializes new preferences object with preconfigured values.
+    /// Initializes a new preferences object with a specific rendering mode.
     ///
-    /// - Parameters:
-    ///   - renderingMode: The required rendering mode.
+    /// - Parameter renderingMode: The ``RenderingMode`` to use for recordings.
     ///
-    /// - Returns: A newly initialized `Preferences` object.
+    /// ### Example ###
+    /// ```
+    /// // Create preferences to use the screen-based rendering mode
+    /// let srPrefs = ConcreteSessionReplayPreferences(renderingMode: .screen)
+    /// SplunkRum.shared.sessionReplay.preferences(srPrefs)
+    /// ```
     init(renderingMode: RenderingMode)
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleSensitivity.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleSensitivity.swift
@@ -18,70 +18,71 @@ limitations under the License.
 
 import UIKit
 
-/// Defines a public API for the view element's sensitivity.
+/// An interface for managing which UI elements are masked (`sensitive`) during Session Replay recordings.
 ///
-/// The resulting instance sensitivity consists of setting the sensitivity for the class
-/// or its ancestors and explicitly setting on the custom view instance.
+/// You can set sensitivity for individual view instances or for all instances of a specific `UIView` class.
+/// The sensitivity settings are evaluated with the following precedence:
+/// 1. **Instance Sensitivity:** A setting on a specific `UIView` instance always takes highest priority.
+/// 2. **Class Sensitivity:** If no instance sensitivity is set, the setting for the view's class is used.
 ///
-/// If multiple sensitivity settings have been applied to an instance, either directly
-/// or indirectly through inheritance, they are evaluated using the following
-/// sequence: `Instance`, `Class`. The setting for the instance always
-/// takes precedence over other methods.
+/// - Note: For convenience, some classes are sensitive by default: `UITextView`, `UITextField`, and `WKWebView`.
 ///
-/// - Note: For convenience, some classes are set sensitive by default:
-///      `UITextView`, `UITextField` and `WKWebView`.
+/// - Important: Sensitive elements are **masked locally** on the device. No sensitive data is ever
+///              transferred over the network or stored in your dashboard.
 ///
-/// - Important: Sensitive elements are **hidden locally** on the device.
-///     No sensitive data are transferred over the network and stored in the dashboard.
+/// ### Example ###
+/// ```
+/// // Mask all instances of a custom view class
+/// SplunkRum.shared.sessionReplay.sensitivity[MyCustomSensitiveView.self] = true
+///
+/// // Unmask a specific instance of that class
+/// let publicView = MyCustomSensitiveView()
+/// SplunkRum.shared.sessionReplay.sensitivity[publicView] = false
+/// ```
 public protocol SessionReplayModuleSensitivity: AnyObject {
 
     // MARK: - View sensitivity
 
-    /// Retrieves or adds an element sensitivity for the specified `UIView` instance.
+    /// Retrieves or sets the explicit sensitivity for a specific `UIView` instance.
     ///
-    /// Assigning `nil` removes previously assigned explicit sensitivity.
+    /// This setting overrides any class-level sensitivity.
     ///
-    /// - Parameter view: A view instance to add or remove sensitivity preferences.
-    ///
-    /// - Returns: The view sensitivity as combination of instance and class/protocol defined
-    ///     sensitivity. If the view is sensitive, then return `true`. If it is
-    ///     non-sensitive, then return `false`. In all other states, it returns `nil`.
+    /// - Parameter view: The `UIView` instance to configure.
+    /// - Returns: `true` if the instance is explicitly masked, `false` if explicitly unmasked,
+    ///            or `nil` if its sensitivity is inherited from its class.
     subscript(view: UIView) -> Bool? { get set }
 
-    /// Sets element sensitivity for the specified `UIView` instance.
+    /// Sets the explicit sensitivity for a specific `UIView` instance.
     ///
-    /// Assigning `nil` removes previously assigned explicit sensitivity.
+    /// - Note: This method provides the same functionality as the subscript and is included
+    ///   for chaining convenience.
     ///
     /// - Parameters:
-    ///   - view: A view instance to add or remove sensitivity preferences.
-    ///   - sensitive: A new state of view instance sensitivity.
-    ///
-    /// - Returns: The updated sensitivity object.
+    ///   - view: The `UIView` instance to configure.
+    ///   - sensitive: The sensitivity state to apply. Pass `true` to mask, `false` to unmask,
+    ///                or `nil` to revert to class-level sensitivity.
+    /// - Returns: The updated sensitivity object to allow for chaining.
     @discardableResult func set(_ view: UIView, _ sensitive: Bool?) -> any SessionReplayModuleSensitivity
 
 
     // MARK: - Class sensitivity
 
-    /// Retrieves or adds sensitivity for the specified member of `UIView` class.
+    /// Retrieves or sets the sensitivity for all instances of a given `UIView` class.
     ///
-    /// Assigning `nil` removes previously assigned explicit sensitivity.
-    ///
-    /// - Parameter viewClass: A view class to add or remove sensitivity preferences.
-    ///
-    /// - Returns: The view class sensitivity. If the class is explicitly marked
-    ///     as sensitive, then return `true`. If it is explicitly marked
-    ///     as non-sensitive, then return `false`. In all other states,
-    ///     it returns `nil`.
+    /// - Parameter viewClass: The `UIView` class to configure (e.g., `UILabel.self`).
+    /// - Returns: `true` if the class is explicitly masked, `false` if explicitly unmasked,
+    ///            or `nil` if no class-level rule is set.
     subscript(viewClass: UIView.Type) -> Bool? { get set }
 
-    /// Sets sensitivity for the specified member of `UIView` class.
+    /// Sets the sensitivity for all instances of a given `UIView` class.
     ///
-    /// Assigning `nil` removes previously assigned explicit sensitivity.
+    /// - Note: This method provides the same functionality as the subscript and is included
+    ///   for chaining convenience.
     ///
     /// - Parameters:
-    ///   - viewClass: A view class to add or remove sensitivity preferences.
-    ///   - sensitive: A new state of view class sensitivity.
-    ///
-    /// - Returns: The updated sensitivity object.
+    ///   - viewClass: The `UIView` class to configure.
+    ///   - sensitive: The sensitivity state to apply. Pass `true` to mask, `false` to unmask,
+    ///                or `nil` to remove the class-level rule.
+    /// - Returns: The updated sensitivity object to allow for chaining.
     @discardableResult func set(_ viewClass: UIView.Type, _ sensitive: Bool?) -> any SessionReplayModuleSensitivity
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleState.swift
@@ -15,28 +15,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a public API for the current state of the Session Replay.
+/// An interface that provides read-only access to the current state of the Session Replay module.
 ///
-/// The individual properties are a combination of:
-/// - Default settings.
-/// - Initial default configuration.
-/// - Settings retrieved from the backend.
-/// - Preferred behavior.
+/// The state properties reflect the final, effective settings being used by the module,
+/// which are a combination of:
+/// - Default SDK settings.
+/// - The initial module configuration.
+/// - Settings retrieved from a remote configuration source.
+/// - User-defined preferences.
 ///
-/// - Note: The states of individual properties in this class can
-///         and usually also change during the application's runtime.
+/// - Note: The values of these properties can change during the application's runtime.
+///
+/// ### Example ###
+/// ```
+/// if SplunkRum.shared.sessionReplay.state.isRecording {
+///     print("Session Replay is currently recording.")
+/// }
+/// ```
 public protocol SessionReplayModuleState {
 
     // MARK: - Recording
 
-    /// A `Status` of module recording.
+    /// The detailed recording status of the module.
     ///
-    /// The default value is `.notRecording(.notStarted)`.
+    /// See ``SessionReplayStatus`` for all possible states.
     var status: SessionReplayStatus { get }
 
-    /// Indicates whether module is recording.
+    /// A Boolean value indicating whether the module is currently recording.
     ///
-    /// For detailed info about status, see ``status``.
+    /// This is a convenience property. For more detailed information, check the ``status`` property.
     var isRecording: Bool { get }
 
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/Model/API-1.0-RenderingMode.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/Model/API-1.0-RenderingMode.swift
@@ -17,20 +17,33 @@ limitations under the License.
 
 import Foundation
 
-/// A video rendering mode for captured data.
+/// An enumeration that defines the visual style of Session Replay recordings.
+///
+/// You can set this mode in the ``SessionReplayModulePreferences`` to balance between
+/// visual fidelity and privacy.
+///
+/// ### Example ###
+/// ```
+/// var srPrefs = ConcreteSessionReplayPreferences()
+/// srPrefs.renderingMode = .wireframeOnly
+/// ```
 public enum RenderingMode: Equatable, Codable {
 
-    /// Render the video as the screen images and also
-    /// as a wireframe representation of screen data.
+    /// Records the session using a combination of screen captures and a wireframe overlay.
+    ///
+    /// This mode provides the highest visual fidelity by showing the actual screen content.
     case native
 
-    /// Render the video only as a wireframe representation of screen data.
+    /// Records the session using only a wireframe representation of the UI.
+    ///
+    /// This mode enhances privacy by not capturing actual screen images. Instead, it shows
+    /// a structural layout of UI elements, which can also result in smaller recording sizes.
     case wireframeOnly
 }
 
 
 public extension RenderingMode {
 
-    /// Default video rendering mode.
+    /// The default rendering mode, which is ``native``.
     static let `default` = RenderingMode.native
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/Model/API-1.0-SessionReplayStatus.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/Model/API-1.0-SessionReplayStatus.swift
@@ -17,37 +17,46 @@ limitations under the License.
 
 import Foundation
 
-/// A status of Session Replay recording.
+/// An enumeration that represents the detailed lifecycle status of a Session Replay recording.
 ///
-/// Describes the possible states for recording in which module can be during its lifecycle.
+/// You can check this status to understand the current state of the recording.
+///
+/// ### Example ###
+/// ```
+/// switch SplunkRum.shared.sessionReplay.state.status {
+/// case .recording:
+///     print("Session Replay is recording.")
+/// case .notRecording(let cause):
+///     print("Session Replay is not recording: \(cause)")
+/// }
+/// ```
 public enum SessionReplayStatus: Equatable {
 
-    /// Recording has been started and is currently in progress.
+    /// The Session Replay is actively recording.
     case recording
 
-    /// Recording is not in progress. A ``Cause`` determines the reason for this status.
+    /// The Session Replay is not recording. The associated `Cause` provides the specific reason.
     case notRecording(Cause)
 
 
-    /// The cause why the recording is currently not running.
+    /// The reason why the Session Replay status is `.notRecording`.
     public enum Cause {
-        /// During this application launch, the recording has not yet started.
+        /// The recording has not yet been started in the current application session.
         case notStarted
 
-        /// The user stopped the previous recording session.
+        /// The recording was explicitly stopped by a call to `stop()`.
         case stopped
 
-        /// It was impossible to start the recording because the internal
-        /// database could not be open, or another internal error occurred.
+        /// The recording could not be started or was interrupted due to an internal error, such as a database issue.
         case internalError
 
-        /// Custom preferences do not allow recording in the SwiftUI Preview context.
+        /// The recording is disabled because the application is running in a SwiftUI Preview.
         case swiftUIPreviewContext
 
-        /// Recording is not supported on the current platform.
+        /// Session Replay is not supported on the current operating system or platform.
         case unsupportedPlatform
 
-        /// Disk cache overreached its allowed size.
+        /// The recording was stopped because the on-disk storage limit was reached.
         case storageLimitReached
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/SlowFrameDetector/Public API/API-1.0-SlowFrameDetectorModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/SlowFrameDetector/Public API/API-1.0-SlowFrameDetectorModule.swift
@@ -15,8 +15,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Shared protocol for operational and non-operational implementations.
+/// An interface for the module that detects and reports slow and frozen frames in the user interface.
+///
+/// ### Example ###
+/// ```
+/// if SplunkRum.shared.slowFrames.state.isEnabled {
+///     print("Slow frame detection is active.")
+/// }
+/// ```
 public protocol SlowFrameDetectorModule {
-    /// An object that provides information about the current state of the module.
+    /// An object that provides read-only access to the current state of the slow frame detector.
+    ///
+    /// See ``SlowFrameDetectorModuleState`` for more details.
     var state: any SlowFrameDetectorModuleState { get }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/SlowFrameDetector/Public API/API-1.0-SlowFrameDetectorModuleState.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/SlowFrameDetector/Public API/API-1.0-SlowFrameDetectorModuleState.swift
@@ -15,8 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Defines a public API for the current state of the `SlowFrameDetector` module.
+/// An interface that provides read-only access to the current state of the `SlowFrameDetector` module.
+///
+/// ### Example ###
+/// ```
+/// if SplunkRum.shared.slowFrames.state.isEnabled {
+///     print("Slow and frozen frame detection is active.")
+/// }
+/// ```
 public protocol SlowFrameDetectorModuleState {
-    /// Indicates whether the slow and frozen frame detection feature is enabled.
+    /// A Boolean value indicating whether the slow and frozen frame detection feature is enabled.
     var isEnabled: Bool { get }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/WebViewInstrumentation/Public API/API-1.0-WebViewInstrumentationModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/WebViewInstrumentation/Public API/API-1.0-WebViewInstrumentationModule.swift
@@ -17,9 +17,23 @@ limitations under the License.
 
 import WebKit
 
-/// The public protocol defining the capabilities of the WebView Instrumentation module.
+/// An interface for integrating the native RUM agent with browser RUM running in a `WKWebView`.
+///
+/// This integration allows the browser RUM agent to access the native session ID,
+/// linking user sessions across both the native and web portions of your application.
+///
+/// ### Example ###
+/// ```
+/// let myWebView = WKWebView()
+/// SplunkRum.shared.webView.integrateWithBrowserRum(myWebView)
+/// ```
 public protocol WebViewInstrumentationModule {
-    /// Injects the necessary JavaScript bridge into a given WKWebView to enable
-    /// communication between the web content and the native RUM agent.
+    /// Integrates the native RUM agent with a browser RUM agent running in a given `WKWebView`.
+    ///
+    /// This method injects a JavaScript bridge into the web view, which exposes a `getNativeSessionId()`
+    /// function to the web content. The browser RUM agent can then use this function to retrieve
+    /// the native session ID.
+    ///
+    /// - Parameter view: The ``WKWebView`` instance to integrate with.
     func integrateWithBrowserRum(_ view: WKWebView)
 }


### PR DESCRIPTION
DEMRUM-1791: preview suggested updates for docc content.
 
The number of changes here is alarming. Please don't be alarmed. 
I plan to make a much smaller change set and propose that instead of this.

For now, only SplunkRum.swift and files matching the pattern API-1.0-* are
included, with the exception of files under Tests/ directories, which are not included.
