### PR TITLE
DEMRUM-1791: add docc comments to public apis that were missing them.

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-EndpointConfiguration.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-EndpointConfiguration.swift
@@ -95,6 +95,8 @@ public struct EndpointConfiguration: Codable, Equatable {
 
 
 extension EndpointConfiguration: CustomStringConvertible, CustomDebugStringConvertible {
+
+    /// A human-readable string representation of the `EndpointConfiguration` instance.
     public var description: String {
         return """
         Realm: \(realm ?? "nil"), \
@@ -104,6 +106,7 @@ extension EndpointConfiguration: CustomStringConvertible, CustomDebugStringConve
         """
     }
 
+    /// A string representation of the `EndpointConfiguration` instance intended for diagnostic output, identical to `description`.
     public var debugDescription: String {
         return description
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/Model/API-1.0-SplunkRumBuilder.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Deprecated/Model/API-1.0-SplunkRumBuilder.swift
@@ -23,6 +23,7 @@ internal import SplunkSlowFrameDetector
 
 import Foundation
 
+/// A deprecated builder for initializing the RUM agent.
 @available(*, deprecated, message:
     """
     The SplunkRumBuilder class is no longer supported and will be removed in a later version.
@@ -59,6 +60,7 @@ public class SplunkRumBuilder {
 
     // MARK: - Builder initialization
 
+    /// Initializes the builder with a beacon URL and RUM authentication token.
     @available(*, deprecated, message:
         """
         This initializer will be removed in a later version.
@@ -79,6 +81,7 @@ public class SplunkRumBuilder {
         endpointConfiguration = EndpointConfiguration(trace: traceUrl)
     }
 
+    /// Initializes the builder with a realm and RUM authentication token.
     @available(*, deprecated, message:
         """
         This initializer will be removed in a later version.
@@ -94,6 +97,7 @@ public class SplunkRumBuilder {
 
     // MARK: - Public configuration builder methods
 
+    /// Enables or disables debug logging.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -105,6 +109,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the deployment environment.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -116,6 +121,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the session sampling ratio.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -127,6 +133,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets the application name.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -138,6 +145,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// This method is a no-op and has no effect.
     @available(*, deprecated, message:
         """
         This builder method is a no-op and will be removed in a later version.
@@ -147,6 +155,7 @@ public class SplunkRumBuilder {
         return self
     }
 
+    /// Sets global attributes to be included in all spans.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.
@@ -254,6 +263,7 @@ public class SplunkRumBuilder {
 
     // MARK: - Build translation method
 
+    /// Translates the builder settings into the modern configuration and initializes the RUM agent.
     @available(*, deprecated, message:
         """
         This builder method will be removed in a later version.

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-AgentConfigurationError.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-AgentConfigurationError.swift
@@ -34,6 +34,8 @@ enum AgentConfigurationError: Error, Equatable {
 }
 
 extension AgentConfigurationError: CustomStringConvertible, CustomDebugStringConvertible {
+
+    /// A human-readable string representation of the `AgentConfigurationError` instance.
     var description: String {
         switch self {
         case let .invalidEndpoint(endpointConfiguration):
@@ -54,6 +56,7 @@ extension AgentConfigurationError: CustomStringConvertible, CustomDebugStringCon
         }
     }
 
+    /// A string representation of an `AgentConfigurationError` instance intended for diagnostic output, identical to `description`.
     public var debugDescription: String {
         return description
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
@@ -364,7 +364,7 @@ public extension MutableAttributes {
         return result
     }
 
-     var all: [String: Any] {
+    var all: [String: Any] {
         return getAllAsAny()
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Model/API-1.0-MutableAttributes.swift
@@ -18,28 +18,57 @@ limitations under the License.
 import Foundation
 import OpenTelemetryApi
 
+/// A thread-safe object that provides a mutable collection of attributes for enriching telemetry data.
+///
+/// This class offers a dictionary-like interface for managing attributes that conform to
+/// `OpenTelemetryApi.AttributeValue`. It is designed for safe use across multiple threads.
+///
+/// ### Usage
+///
+/// You can initialize an empty collection and add attributes using the typed subscripts.
+/// To remove an attribute, set its value to `nil`.
+///
+/// ```swift
+/// let attributes = MutableAttributes()
+/// attributes[string: "user.name"] = "Alice"
+/// attributes[int: "login.count"] = 5
+/// attributes[bool: "is.subscribed"] = true
+///
+/// // Removes the 'is.subscribed' attribute.
+/// attributes[bool: "is.subscribed"] = nil
+/// ```
 public class MutableAttributes {
 
     // MARK: - Private
 
+    // The underlying thread-safe storage for attributes.
     var attributes: ThreadSafeDictionary<String, AttributeValue>
 
 
     // MARK: - Initialize
 
+    /// Initializes an empty collection of attributes.
     public init() {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
     }
 
+    /// Initializes the collection with attributes from a given dictionary.
+    /// - Parameter dictionary: A dictionary of key-value pairs to add to the collection.
     public init(dictionary: [String: AttributeValue]) {
         attributes = ThreadSafeDictionary<String, AttributeValue>(dictionary: dictionary)
     }
 
+    /// Initializes the collection with attributes from a given `AttributeSet`.
+    /// - Parameter attributeSet: An ``AttributeSet`` whose labels will be added to the collection.
     public init(attributeSet: AttributeSet) {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
         addAttributeSet(attributeSet)
     }
 
+    /// Initializes the collection by decoding from a `Decoder`.
+    ///
+    /// This initializer is used to conform to the `Decodable` protocol.
+    /// - Throws: An error if decoding fails.
     public required init(from decoder: Decoder) throws {
         attributes = ThreadSafeDictionary<String, AttributeValue>()
         let container = try decoder.container(keyedBy: StringCodingKey.self)
@@ -335,7 +364,7 @@ public extension MutableAttributes {
         return result
     }
 
-    var all: [String: Any] {
+     var all: [String: Any] {
         return getAllAsAny()
     }
 }
@@ -344,6 +373,7 @@ extension MutableAttributes: CustomStringConvertible {
 
     // MARK: - Description
 
+    /// A human-readable description of the attributes, sorted by key.
     public var description: String {
         var result = "[\n"
 


### PR DESCRIPTION
Minimal set of updates adding docc comments to public APIs that were missing them.

This does not address all consistency issues in all docc in the codebase; it only fills in gaps.
