### PR TITLE
DEMRUM-2819: Fix opentelemetry-swift package dependency version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
-            branch: "main"
+            exact: "2.0.0"
         ),
         .package(
             url:"https://github.com/microsoft/plcrashreporter",

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/metric/OTLPBackgroundHTTPMetricExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/metric/OTLPBackgroundHTTPMetricExporter.swift
@@ -21,11 +21,11 @@ import OpenTelemetryProtocolExporterCommon
 import OpenTelemetrySdk
 
 
-public class OTLPBackgroundHTTPMetricExporter: OTLPBackgroundHTTPBaseExporter, StableMetricExporter {
+public class OTLPBackgroundHTTPMetricExporter: OTLPBackgroundHTTPBaseExporter, MetricExporter {
 
-    // MARK: - Implementation StableMetricExporter protocol
+    // MARK: - Implementation MetricExporter protocol
 
-    public func export(metrics: [StableMetricData]) -> ExportResult {
+    public func export(metrics: [MetricData]) -> ExportResult {
         let body = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with {
             $0.resourceMetrics = MetricsAdapter.toProtoResourceMetrics(metricData: metrics)
         }


### PR DESCRIPTION
This PR fixes (anchors) the opentelemtry-swift package dependency to the latest released version. The dependency had been anchored to `main` branch in order to support buildability to visionOS.