### PR TITLE
DEMRUM-2428: Update Network Span Attributes

### DIFF
--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -160,7 +160,7 @@ public class NetworkInstrumentation {
     }
 
     func createdRequest(URLRequest: URLRequest, span: Span) {
-        let key = SemanticAttributes.httpRequestContentLength
+        let key = SemanticAttributes.httpRequestBodySize
         let body = URLRequest.httpBody
         let length = body?.count ?? 0
         span.setAttribute(key: key, value: length)
@@ -236,7 +236,7 @@ public class NetworkInstrumentation {
     }
 
     func receivedResponse(URLResponse: URLResponse, dataOrFile: DataOrFile?, span: Span) {
-        let key = SemanticAttributes.httpResponseContentLength
+        let key = SemanticAttributes.httpResponseBodySize
         let response = URLResponse as? HTTPURLResponse
         let length = response?.expectedContentLength ?? 0
         span.setAttribute(key: key, value: Int(length))

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -273,7 +273,7 @@ public class NetworkInstrumentation {
         }
 
         // removes obsolete attributes
-        removeObsoleteAttributesFromSpan(span)
+        removeObsoleteAttributes(from: span)
 
         /* Save this until we add the feature into the Agent side API
         guard ((agentConfiguration?.appDCloudNetworkResponseCallback?(URLResponse)) == nil) else {
@@ -340,7 +340,7 @@ public class NetworkInstrumentation {
 
     /// Removes obsolete attributes from the span
     /// - Parameter span: The span to be modified
-    private func removeObsoleteAttributesFromSpan(_ span: Span) {
+    private func removeObsoleteAttributes(from span: Span) {
         // Attributes to be removed
         let attributesToRemove = [
             SemanticAttributes.httpUrl,
@@ -364,7 +364,7 @@ public class NetworkInstrumentation {
         span.setAttribute(key: SemanticAttributes.httpResponseStatusCode, value: HTTPStatus)
 
         // removes obsolete attributes
-        removeObsoleteAttributesFromSpan(span)
+        removeObsoleteAttributes(from: span)
 
         logger.log(level: .error) {
             "Error: \(error.localizedDescription), Status: \(HTTPStatus)"

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -15,14 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-internal import CiscoLogger
+import CiscoLogger
 import Foundation
-internal import OpenTelemetryApi
-internal import OpenTelemetrySdk
-internal import ResourceExtension
-internal import SignPostIntegration
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import ResourceExtension
+import SignPostIntegration
 import SplunkCommon
-internal import URLSessionInstrumentation
+import URLSessionInstrumentation
 
 public class NetworkInstrumentation {
 
@@ -70,7 +70,7 @@ public class NetworkInstrumentation {
         // Start the network instrumentation if it's enabled or if no configuration is provided.
         if config?.isEnabled ?? true {
 
-            if let ignoreURLsParameter  = config?.ignoreURLs {
+            if let ignoreURLsParameter = config?.ignoreURLs {
                 ignoreURLs = ignoreURLsParameter
             }
 

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -169,6 +169,8 @@ public class NetworkInstrumentation {
         span.setAttribute(key: "component", value: "http")
 
         if let url = URLRequest.url {
+            span.setAttribute(key: SemanticAttributes.urlPath, value: url.path)
+            span.setAttribute(key: SemanticAttributes.urlQuery, value: url.query ?? "")
             if let scheme = url.scheme {
                 span.setAttribute(key: SemanticAttributes.urlScheme, value: scheme)
             }
@@ -342,6 +344,7 @@ public class NetworkInstrumentation {
         // Attributes to be removed
         let attributesToRemove = [
             "http.url",
+            "http.target",
             "net.peer.name",
             "http.status_code",
             "http.method",

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -164,7 +164,7 @@ public class NetworkInstrumentation {
         let body = URLRequest.httpBody
         let length = body?.count ?? 0
         span.setAttribute(key: key, value: length)
-        let method = URLRequest.httpMethod ?? "unknown_method"
+        let method = URLRequest.httpMethod ?? "_OTHER"
         span.setAttribute(key: SemanticAttributes.httpRequestMethod, value: method)
         span.setAttribute(key: "component", value: "http")
 
@@ -343,17 +343,17 @@ public class NetworkInstrumentation {
     private func removeObsoleteAttributesFromSpan(_ span: Span) {
         // Attributes to be removed
         let attributesToRemove = [
-            "http.url",
-            "http.target",
-            "net.peer.name",
-            "http.status_code",
-            "http.method",
-            "http.scheme"
+            SemanticAttributes.httpUrl,
+            SemanticAttributes.httpTarget,
+            SemanticAttributes.netPeerName,
+            SemanticAttributes.httpStatusCode,
+            SemanticAttributes.httpMethod,
+            SemanticAttributes.httpScheme
         ]
 
         for key in attributesToRemove {
             // Setting the value to nil will remove the key
-            span.setAttribute(key: key, value: nil)
+            span.setAttribute(key: key.rawValue, value: nil)
         }
     }
 
@@ -362,6 +362,9 @@ public class NetworkInstrumentation {
         span.setAttribute(key: "error.message", value: error.localizedDescription)
         span.setAttribute(key: "error.type", value: String(describing: type(of: error)))
         span.setAttribute(key: SemanticAttributes.httpResponseStatusCode, value: HTTPStatus)
+
+        // removes obsolete attributes
+        removeObsoleteAttributesFromSpan(span)
 
         logger.log(level: .error) {
             "Error: \(error.localizedDescription), Status: \(HTTPStatus)"

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -338,8 +338,7 @@ public class NetworkInstrumentation {
         return false
     }
 
-    /// Removes obsolete attributes from the span
-    /// - Parameter span: The span to be modified
+    // Removes obsolete attributes from the span
     private func removeObsoleteAttributes(from span: Span) {
         // Attributes to be removed
         let attributesToRemove = [

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentationIgnoreURLs.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentationIgnoreURLs.swift
@@ -41,9 +41,9 @@ public class IgnoreURLs: Codable {
     /// - Parameter containing pattern: Optional NSRegularExpression for URL pattern matching
     public init(containing pattern: NSRegularExpression?) {
         if let pattern = pattern {
-            self.urlPatterns = [pattern]
+            urlPatterns = [pattern]
         } else {
-            self.urlPatterns = []
+            urlPatterns = []
         }
     }
 

--- a/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
@@ -15,11 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import XCTest
 import OpenTelemetryApi
 import OpenTelemetrySdk
-import URLSessionInstrumentation
 @testable import SplunkNetwork
+import URLSessionInstrumentation
+import XCTest
 
 final class SplunkNetworkTests: XCTestCase {
     var sut: NetworkInstrumentation!
@@ -38,14 +38,14 @@ final class SplunkNetworkTests: XCTestCase {
         var attributes: [String: AttributeValue] = [:]
         var events: [SpanData.Event] = []
         var links: [SpanData.Link] = []
-        var startTime: Date = Date()
+        var startTime = Date()
         var endTime: Date?
         var hasEnded: Bool = false
         var totalRecordedEvents: Int = 0
         var totalRecordedLinks: Int = 0
         var totalAttributeCount: Int = 0
         var parentSpanId: SpanId?
-        var instrumentationScopeInfo: InstrumentationScopeInfo = InstrumentationScopeInfo()
+        var instrumentationScopeInfo = InstrumentationScopeInfo()
 
         // Required SpanBase properties
         var kind: SpanKind { return .internal }
@@ -59,11 +59,12 @@ final class SplunkNetworkTests: XCTestCase {
             let spanId = SpanId.random()
             let traceFlags = TraceFlags()
             let traceState = TraceState()
-            self.context = SpanContext.create(
+            context = SpanContext.create(
                 traceId: traceId,
                 spanId: spanId,
                 traceFlags: traceFlags,
-                traceState: traceState)
+                traceState: traceState
+            )
         }
 
         func setAttribute(key: String, value: Any) {
@@ -200,7 +201,7 @@ final class SplunkNetworkTests: XCTestCase {
         // Then
         let attributeValue = mockSpan.attributes[SemanticAttributes.httpRequestBodySize.rawValue]
         XCTAssertNotNil(attributeValue)
-        if case .int(let value) = attributeValue {
+        if case let .int(value) = attributeValue {
             XCTAssertEqual(value, body.count)
         } else {
             XCTFail("Expected int attribute value")
@@ -240,7 +241,8 @@ final class SplunkNetworkTests: XCTestCase {
             statusCode: 200,
             httpVersion: nil,
             headerFields: [
-                "server-timing": "traceparent;desc='00-1234567890abcdef1234567890abcdef-1234567890abcdef-01'"]
+                "server-timing": "traceparent;desc='00-1234567890abcdef1234567890abcdef-1234567890abcdef-01'"
+            ]
         )!
 
         let mockSpan = MockSpan()
@@ -255,13 +257,13 @@ final class SplunkNetworkTests: XCTestCase {
         XCTAssertNotNil(traceIdValue)
         XCTAssertNotNil(spanIdValue)
 
-        if case .string(let traceId) = traceIdValue {
+        if case let .string(traceId) = traceIdValue {
             XCTAssertEqual(traceId, "1234567890abcdef1234567890abcdef")
         } else {
             XCTFail("Expected string attribute value for traceId")
         }
 
-        if case .string(let spanId) = spanIdValue {
+        if case let .string(spanId) = spanIdValue {
             XCTAssertEqual(spanId, "1234567890abcdef")
         } else {
             XCTFail("Expected string attribute value for spanId")

--- a/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
@@ -85,7 +85,7 @@ final class SplunkNetworkTests: XCTestCase {
             }
         }
 
-        func setAttributes(_ attributes: [String : OpenTelemetryApi.AttributeValue]) {
+        func setAttributes(_ attributes: [String: OpenTelemetryApi.AttributeValue]) {
             self.attributes = attributes
         }
 

--- a/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/SplunkNetworkTests.swift
@@ -198,7 +198,7 @@ final class SplunkNetworkTests: XCTestCase {
         sut.createdRequest(URLRequest: request, span: mockSpan)
 
         // Then
-        let attributeValue = mockSpan.attributes[SemanticAttributes.httpRequestContentLength.rawValue]
+        let attributeValue = mockSpan.attributes[SemanticAttributes.httpRequestBodySize.rawValue]
         XCTAssertNotNil(attributeValue)
         if case .int(let value) = attributeValue {
             XCTAssertEqual(value, body.count)
@@ -224,7 +224,7 @@ final class SplunkNetworkTests: XCTestCase {
         sut.receivedResponse(URLResponse: response, dataOrFile: nil, span: mockSpan)
 
         // Then
-        let attributeValue = mockSpan.attributes[SemanticAttributes.httpResponseContentLength.rawValue]
+        let attributeValue = mockSpan.attributes[SemanticAttributes.httpResponseBodySize.rawValue]
         XCTAssertNotNil(attributeValue)
         if case .int = attributeValue {
             // Success - we just want to verify it's an int value


### PR DESCRIPTION
Update Network Attributes to new semantics

- update content_length attributes
- update url attributes
- update scheme attribute
- add support to remove obsolete keys from OTel instrumentation
- update unit tests
