### PR TITLE
DEMRUM-2771: Fix session rotation

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Session/DefaultSession.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Session/DefaultSession.swift
@@ -334,6 +334,9 @@ extension DefaultSession {
                 // We need to mark the time of this transition
                 if self?.enterBackground != nil {
                     self?.leaveBackground = Date()
+
+                    // Refresh session immediately
+                    self?.refreshSession()
                 }
             }
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Session/DefaultSessionTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Session/DefaultSessionTests.swift
@@ -242,9 +242,8 @@ extension DefaultSessionTests {
 
         /* Going into the background for *too long* time */
         try simulateBackgroundStay(for: defaultSession, duration: 12)
-        simulateMainThreadWait(duration: 2)
-
-        // The current session should *not* be the same
+ 
+        // The current session should *not* be the same immediately
         XCTAssertNotEqual(lastSessionId, defaultSession.currentSessionId)
         XCTAssertNotNil(agent)
     }


### PR DESCRIPTION
Session rotation was not happening immediately after receiving the `willEnterForeground` notification. This caused some data (e.g. app start, session replay)  using session id from a previous session. This PR fixes this issue.

The PR also fixes an issue in the default session tests.