### PR TITLE
DEMRUM-2760: Enable focus interaction

### DIFF
--- a/SplunkInteractions/Sources/SplunkInteractions/Module/Interactions.swift
+++ b/SplunkInteractions/Sources/SplunkInteractions/Module/Interactions.swift
@@ -185,6 +185,9 @@ public final class Interactions: SplunkInteractionsModule {
         case .gestureRotation:
             "rotation"
 
+        case .focus:
+            "focus"
+
         case .softKeyboard:
             "soft_keyboard"
 

--- a/SplunkInteractions/Tests/SplunkInteractionsTests/SplunkInteractionsTests.swift
+++ b/SplunkInteractions/Tests/SplunkInteractionsTests/SplunkInteractionsTests.swift
@@ -34,6 +34,7 @@ final class SplunkInteractionsTests: XCTestCase {
             (.gestureRageTap, "rage_tap"),
             (.gesturePinch, "pinch"),
             (.gestureRotation, "rotation"),
+            (.focus, "focus"),
             (.softKeyboard, "soft_keyboard")
         ]
 


### PR DESCRIPTION
After retest and consultation with Pavel this re-enable focus interactions. Its working as expected.