### PR TITLE
DEMRUM-2793: Implement AppState module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ func generateMainTargets() -> [Target] {
                 .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
                 "SplunkAppStart",
+                "SplunkAppState",
                 "SplunkWebView",
                 "SplunkCustomTracking",
                 resolveDependency("logger")
@@ -314,6 +315,25 @@ func generateMainTargets() -> [Target] {
                 "SplunkAppStart"
             ],
             path: "SplunkAppStart/Tests"
+        ),
+
+
+        // MARK: - Splunk App State
+
+        .target(
+            name: "SplunkAppState",
+            dependencies: [
+                "SplunkCommon",
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift")
+            ],
+            path: "SplunkAppState/Sources"
+        ),
+        .testTarget(
+            name: "SplunkAppStateTests",
+            dependencies: [
+                "SplunkAppState"
+            ],
+            path: "SplunkAppState/Tests"
         ),
 
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/Pool/DefaultModulesPool.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/Pool/DefaultModulesPool.swift
@@ -21,6 +21,10 @@ internal import SplunkCommon
     internal import SplunkAppStart
 #endif
 
+#if canImport(SplunkAppState)
+    internal import SplunkAppState
+#endif
+
 #if canImport(SplunkCrashReports)
     internal import SplunkCrashReports
 #endif
@@ -75,6 +79,11 @@ class DefaultModulesPool: AgentModulesPool {
             knownModules.append(AppStart.self)
         #endif
 
+        // App Start
+        #if canImport(SplunkAppStart)
+            knownModules.append(AppStateModule.self)
+        #endif
+
         // Session Replay
         #if canImport(CiscoSessionReplay)
             knownModules.append(CiscoSessionReplay.SessionReplay.self)
@@ -97,7 +106,7 @@ class DefaultModulesPool: AgentModulesPool {
 
         // Slow Frame Detector
         #if canImport(SplunkSlowFrameDetector)
-        knownModules.append(SplunkSlowFrameDetector.SlowFrameDetector.self)
+            knownModules.append(SplunkSlowFrameDetector.SlowFrameDetector.self)
         #endif
 
         // Web View Instrumentation

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -18,6 +18,7 @@ limitations under the License.
 import Foundation
 internal import CiscoSessionReplay
 internal import SplunkAppStart
+internal import SplunkAppState
 internal import SplunkCustomTracking
 internal import SplunkNavigation
 internal import SplunkNetwork
@@ -62,6 +63,7 @@ extension SplunkRum {
         customizeNavigation()
         customizeNetwork()
         customizeAppStart()
+        customizeAppState()
         customizeNetworkMonitor()
         customizeCustomTracking()
         customizeInteractions()
@@ -163,6 +165,13 @@ extension SplunkRum {
         let appStartModule = modulesManager?.module(ofType: SplunkAppStart.AppStart.self)
 
         appStartModule?.sharedState = sharedState
+    }
+
+    /// Configure App state module with shared state.
+    private func customizeAppState() {
+        let appStateModule = modulesManager?.module(ofType: SplunkAppState.AppStateModule.self)
+
+        appStateModule?.sharedState = sharedState
     }
 
     /// Configure NetworkMonitor module

--- a/SplunkAppState/Sources/SplunkAppState/AppStateModule+Notifications.swift
+++ b/SplunkAppState/Sources/SplunkAppState/AppStateModule+Notifications.swift
@@ -1,0 +1,75 @@
+//
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+#if os(iOS) || os(tvOS) || os(visionOS)
+    import UIKit
+#endif
+
+extension AppStateModule {
+
+    // MARK: - Setup notifications
+
+    func setupNotifications() {
+        #if os(iOS) || os(tvOS) || os(visionOS)
+            removeNotifications()
+
+            addObserver(UIApplication.didBecomeActiveNotification) { [weak self] in
+                self?.processEvent(.active)
+            }
+
+            addObserver(UIApplication.didEnterBackgroundNotification) { [weak self] in
+                self?.processEvent(.background)
+            }
+
+            addObserver(UIApplication.willEnterForegroundNotification) { [weak self] in
+                self?.processEvent(.foreground)
+            }
+
+            addObserver(UIApplication.willResignActiveNotification) { [weak self] in
+                self?.processEvent(.inactive)
+            }
+
+            addObserver(UIApplication.willTerminateNotification) { [weak self] in
+                self?.processEvent(.terminate)
+            }
+        #endif
+    }
+
+    func removeNotifications() {
+        #if os(iOS) || os(tvOS) || os(visionOS)
+            let tokens = notificationObservers
+            notificationObservers.removeAll()
+            tokens.forEach { NotificationCenter.default.removeObserver($0) }
+        #endif
+    }
+
+
+    // MARK: - Private functions
+
+    private func addObserver(_ name: Notification.Name, handler: @escaping () -> Void) {
+        let token = NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { [weak self] _ in
+            guard self != nil else { return }
+            handler()
+        }
+        var tokens = notificationObservers
+        tokens.append(token)
+        notificationObservers = tokens
+    }
+}

--- a/SplunkAppState/Sources/SplunkAppState/AppStateModule.swift
+++ b/SplunkAppState/Sources/SplunkAppState/AppStateModule.swift
@@ -1,0 +1,59 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkCommon
+
+public final class AppStateModule {
+
+    // MARK: - Public properties
+
+    public unowned var sharedState: AgentSharedState?
+
+
+    // MARK: - Internal properties
+
+    var notificationObservers: [NSObjectProtocol] = []
+    var destination: AppStateDestination = OtelDestination()
+
+
+    // MARK: - Initialization
+
+    public required init() {}
+
+    deinit {
+        removeNotifications()
+    }
+
+
+    // MARK: - Start/Stop Detection
+
+    func startDetection() {
+        setupNotifications()
+    }
+
+    func stopDetection() {
+        removeNotifications()
+    }
+
+
+    // MARK: - Process events
+
+    func processEvent(_ event: AppStateType) {
+        destination.send(appState: event, time: Date(), sharedState: sharedState)
+    }
+}

--- a/SplunkAppState/Sources/SplunkAppState/Destination/AppStateDestination.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Destination/AppStateDestination.swift
@@ -1,0 +1,26 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkCommon
+
+/// Describes a destination into which the AppState module sends it's results.
+protocol AppStateDestination {
+
+    /// Sends results into a destination.
+    func send(appState: AppStateType, time: Date, sharedState: AgentSharedState?)
+}

--- a/SplunkAppState/Sources/SplunkAppState/Destination/OTelDestination.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Destination/OTelDestination.swift
@@ -1,0 +1,43 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import SplunkCommon
+
+/// Creates and sends an OpenTelemetry span from supplied app start data.
+class OtelDestination: AppStateDestination {
+
+    func send(appState: AppStateType, time: Date, sharedState: AgentSharedState?) {
+
+        let tracer = OpenTelemetry.instance
+            .tracerProvider
+            .get(
+                instrumentationName: "app-lifecycle",
+                instrumentationVersion: sharedState?.agentVersion
+            )
+
+        let appStateSpan = tracer.spanBuilder(spanName: "device.app.lifecycle")
+            .setStartTime(time: time)
+            .startSpan()
+
+        appStateSpan.setAttribute(key: "component", value: "ui")
+        appStateSpan.setAttribute(key: "ios.app.state", value: appState.rawValue)
+
+        appStateSpan.end(time: time)
+    }
+}

--- a/SplunkAppState/Sources/SplunkAppState/Model/AppStateType.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Model/AppStateType.swift
@@ -1,0 +1,36 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+enum AppStateType: String {
+
+    /// Application is active.
+    case active
+
+    /// Application is inactive.
+    case inactive
+
+    /// Application is in background.
+    case background
+
+    /// Application is in foreground.
+    case foreground
+
+    /// Application terminates.
+    case terminate
+}

--- a/SplunkAppState/Sources/SplunkAppState/Module/AppStateConfiguration.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Module/AppStateConfiguration.swift
@@ -1,0 +1,22 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkCommon
+
+/// AppState module configuration, minimal configuration for module conformance.
+public struct AppStateConfiguration: ModuleConfiguration {}

--- a/SplunkAppState/Sources/SplunkAppState/Module/AppStateModule+Module.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Module/AppStateModule+Module.swift
@@ -1,0 +1,49 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkCommon
+
+public struct AppStateData: ModuleEventData {}
+
+public struct AppStateMetadata: ModuleEventMetadata {
+    public var timestamp = Date()
+}
+
+extension AppStateModule: Module {
+
+    // MARK: - Module types
+
+    public typealias Configuration = AppStateConfiguration
+    public typealias RemoteConfiguration = AppStateRemoteConfiguration
+
+    public typealias EventMetadata = AppStateMetadata
+    public typealias EventData = AppStateData
+
+
+    // MARK: - Module methods
+
+    public func install(with configuration: (any ModuleConfiguration)?, remoteConfiguration: (any RemoteModuleConfiguration)?) {
+        startDetection()
+    }
+
+
+    // MARK: - Type transparency helpers
+
+    public func deleteData(for metadata: any ModuleEventMetadata) {}
+    public func onPublish(data: @escaping (AppStateMetadata, AppStateData) -> Void) {}
+}

--- a/SplunkAppState/Sources/SplunkAppState/Module/AppStateRemoteConfiguration.swift
+++ b/SplunkAppState/Sources/SplunkAppState/Module/AppStateRemoteConfiguration.swift
@@ -1,0 +1,29 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkCommon
+
+/// AppState remote configuration.
+public struct AppStateRemoteConfiguration: RemoteModuleConfiguration {
+
+    // MARK: - Protocol compliance
+
+    public var enabled: Bool = true
+
+    public init?(from data: Data) {}
+}

--- a/SplunkAppState/Tests/SplunkAppStateTests/AppStateModuleTests.swift
+++ b/SplunkAppState/Tests/SplunkAppStateTests/AppStateModuleTests.swift
@@ -1,0 +1,180 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import XCTest
+@testable import SplunkAppState
+
+final class AppStateModuleTests: XCTestCase {
+
+    // MARK: - Private properties
+
+#if os(iOS) || os(tvOS) || os(visionOS)
+    private let expectedObserverCount = 5
+#else
+    private let expectedObserverCount = 0
+#endif
+
+
+    // MARK: - Test functions
+
+    func testSetupNotificationsAddsExpectedNumberOfObservers() {
+        let module = AppStateModule()
+        module.setupNotifications()
+        XCTAssertEqual(module.notificationObservers.count, expectedObserverCount)
+    }
+
+    func testSetupNotificationsIsIdempotent() {
+        let module = AppStateModule()
+        module.setupNotifications()
+        module.setupNotifications()
+        XCTAssertEqual(module.notificationObservers.count, expectedObserverCount)
+    }
+
+    func testRemoveNotificationsClearsObservers() {
+        let module = AppStateModule()
+        module.setupNotifications()
+        module.removeNotifications()
+        XCTAssertEqual(module.notificationObservers.count, 0)
+    }
+
+    func testStartStopDetectionMirrorSetupRemove() {
+        let module = AppStateModule()
+        module.startDetection()
+        XCTAssertEqual(module.notificationObservers.count, expectedObserverCount)
+        module.stopDetection()
+        XCTAssertEqual(module.notificationObservers.count, 0)
+    }
+
+    func testPostingNotificationsDoesNotCrash() {
+        let module = AppStateModule()
+        module.setupNotifications()
+
+        #if os(iOS) || os(tvOS) || os(visionOS)
+            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+            NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+            NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+            NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+        #endif
+
+        XCTAssertEqual(module.notificationObservers.count, expectedObserverCount)
+    }
+
+    func testDeinitRemovesObservers() {
+        weak var weakModule: AppStateModule?
+        autoreleasepool {
+            let module = AppStateModule()
+            module.setupNotifications()
+            XCTAssertEqual(module.notificationObservers.count, expectedObserverCount)
+            weakModule = module
+        }
+        XCTAssertNil(weakModule)
+    }
+
+
+    #if os(iOS) || os(tvOS) || os(visionOS)
+
+    func testDidBecomeActiveSendsActive() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        expectEventCount(mock, count: 1)
+        XCTAssertEqual(mock.events.last?.state, .active)
+        module.removeNotifications()
+    }
+
+    func testDidEnterBackgroundSendsBackground() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        expectEventCount(mock, count: 1)
+        XCTAssertEqual(mock.events.last?.state, .background)
+        module.removeNotifications()
+    }
+
+    func testWillEnterForegroundSendsForeground() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        expectEventCount(mock, count: 1)
+        XCTAssertEqual(mock.events.last?.state, .foreground)
+        module.removeNotifications()
+    }
+
+    func testWillResignActiveSendsInactive() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        expectEventCount(mock, count: 1)
+        XCTAssertEqual(mock.events.last?.state, .inactive)
+        module.removeNotifications()
+    }
+
+    func testWillTerminateSendsTerminate() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+        expectEventCount(mock, count: 1)
+        XCTAssertEqual(mock.events.last?.state, .terminate)
+        module.removeNotifications()
+    }
+
+    func testSequenceOrderIsPreserved() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        expectEventCount(mock, count: 4)
+        XCTAssertEqual(mock.events.map(\.state), [.inactive, .background, .foreground, .active])
+        module.removeNotifications()
+    }
+
+    func testNoEventsAfterStopDetection() {
+        let mock = MockDestination()
+        let module = makeModule(with: mock)
+        module.stopDetection()
+        mock.reset()
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        XCTAssertTrue(mock.events.isEmpty)
+    }
+
+    #endif
+
+
+    // MARK: - Private helpers
+
+    private func makeModule(with mock: MockDestination) -> AppStateModule {
+        let m = AppStateModule()
+        m.sharedState = nil
+        m.destination = mock
+        m.setupNotifications()
+        return m
+    }
+
+    private func expectEventCount(_ mock: MockDestination, count: Int, timeout: TimeInterval = 1.0) {
+        let exp = expectation(description: "events \(count)")
+        mock.onSend = { [weak mock] in
+            if (mock?.events.count ?? 0) >= count { exp.fulfill() }
+        }
+        if mock.events.count >= count { exp.fulfill() }
+        wait(for: [exp], timeout: timeout)
+        mock.onSend = nil
+    }
+}

--- a/SplunkAppState/Tests/Support/MockDestination.swift
+++ b/SplunkAppState/Tests/Support/MockDestination.swift
@@ -1,0 +1,42 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+@testable import SplunkAppState
+@testable import SplunkCommon
+
+final class MockDestination: AppStateDestination {
+
+    private let lock = NSLock()
+    private(set) var events: [(state: AppStateType, time: Date, shared: AgentSharedState?)] = []
+
+    var onSend: (() -> Void)?
+
+    func send(appState: AppStateType, time: Date, sharedState: AgentSharedState?) {
+        lock.lock()
+        events.append((appState, time, sharedState))
+        let cb = onSend
+        lock.unlock()
+        cb?()
+    }
+
+    func reset() {
+        lock.lock()
+        events.removeAll()
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
This PR implements app state handling and sending otel event based on:
[ticket DEMRUM-2793]([DEMRUM-2793](https://splunk.atlassian.net/browse/DEMRUM-2793))
[DOC](https://splunk.atlassian.net/wiki/x/7h2SMfs)

legacy agent:
<img width="1186" height="529" alt="Screenshot 2025-08-11 at 12 21 25" src="https://github.com/user-attachments/assets/0e17b5d5-a037-4004-b72d-b61a80a3bdcf" />

new results:
<img width="1328" height="592" alt="Screenshot 2025-08-11 at 12 23 49" src="https://github.com/user-attachments/assets/d03b63b2-ac4b-46b8-afbf-e4a9568c82e4" />
<img width="606" height="822" alt="Screenshot 2025-08-11 at 12 23 59" src="https://github.com/user-attachments/assets/ec52c6e2-1d44-4621-871b-f054a096486f" />
