### PR TITLE
DEMRUM-782: Add unit testing support to SlowFrameDetector

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
@@ -20,6 +20,8 @@ import QuartzCore
 import SplunkCommon
 import UIKit
 
+// Note: This component is being updated to improve its testability.
+// The work is tracked in a central PR and will be merged incrementally.
 public final class SlowFrameDetector {
 
     // MARK: - Nested Types

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameLogic.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameLogic.swift
@@ -1,4 +1,4 @@
-//
+// SlowFrameLogic.swift
 /*
 Copyright 2025 Splunk Inc.
 
@@ -16,11 +16,6 @@ limitations under the License.
 */
 
 import Foundation
-@testable import SplunkSlowFrameDetector
-import XCTest
 
-final class SplunkSlowFrameDetectorTests: XCTestCase {
-    // Note: This file will be populated with a comprehensive suite of unit tests
-    // as part of the effort to improve the detector's testability.
-    // The new tests will use mock objects to verify behavior.
-}
+// Placeholder for the SlowFrameLogic actor. The goal is to isolate the
+// core business logic here to make it directly testable.

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
@@ -1,4 +1,4 @@
-//
+// SlowFrameTicker.swift
 /*
 Copyright 2025 Splunk Inc.
 
@@ -16,11 +16,6 @@ limitations under the License.
 */
 
 import Foundation
-@testable import SplunkSlowFrameDetector
-import XCTest
 
-final class SplunkSlowFrameDetectorTests: XCTestCase {
-    // Note: This file will be populated with a comprehensive suite of unit tests
-    // as part of the effort to improve the detector's testability.
-    // The new tests will use mock objects to verify behavior.
-}
+// Placeholder for the SlowFrameTicker protocol, an abstraction over
+// CADisplayLink to enable unit testing.


### PR DESCRIPTION
This is the main tracking pull request for adding unit test coverage to the `SlowFrameDetector` module.

This PR itself contains no functional changes and serves as the base for a series of incremental stacked PRs to make the updates easier to review.

The first few PRs make the structural changes needed to allow for testing. The rest of the PRs add the actual unit tests.
