### PR TITLE
DEMRUM-782: introduce test abstractions and mocks

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
@@ -1,4 +1,4 @@
-// SlowFrameTicker.swift
+//
 /*
 Copyright 2025 Splunk Inc.
 
@@ -17,5 +17,15 @@ limitations under the License.
 
 import Foundation
 
-// Placeholder for the SlowFrameTicker protocol, an abstraction over
-// CADisplayLink to enable unit testing.
+/// An abstraction for a timer that "ticks" on every frame refresh of the display.
+///
+/// This protocol provides a consistent interface for receiving frame updates,
+/// abstracting the underlying mechanism (like `CADisplayLink`) to allow for easier
+/// testing and dependency injection.
+internal protocol SlowFrameTicker {
+    var onFrame: ((_ timestamp: TimeInterval, _ duration: TimeInterval) -> Void)? { get set }
+    func start()
+    func stop()
+    func pause()
+    func resume()
+}

--- a/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
+++ b/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
@@ -18,9 +18,41 @@ limitations under the License.
 import Foundation
 @testable import SplunkSlowFrameDetector
 import XCTest
+import SplunkCommon
 
 final class SplunkSlowFrameDetectorTests: XCTestCase {
     // Note: This file will be populated with a comprehensive suite of unit tests
     // as part of the effort to improve the detector's testability.
     // The new tests will use mock objects to verify behavior.
+}
+
+// MARK: - Test Mocks
+
+final class MockTicker: SlowFrameTicker {
+    var onFrame: ((TimeInterval, TimeInterval) -> Void)?
+    var started = false
+    var stopped = false
+
+    func start() {
+        started = true
+    }
+
+    func stop() {
+        stopped = true
+    }
+
+    func pause() {}
+    func resume() {}
+
+    func simulateFrame(timestamp: TimeInterval, duration: TimeInterval) {
+        onFrame?(timestamp, duration)
+    }
+}
+
+final class MockDestination: SlowFrameDetectorDestination {
+    var onSend: ((String, Int) -> Void)?
+
+    func send(type: String, count: Int, sharedState: AgentSharedState?) {
+        onSend?(type, count)
+    }
 }


### PR DESCRIPTION
First of two PRs that are targeting the task/DEMRUM-782-sfd-tests-pr0 branch.

This adds the foundational pieces needed to unit test the SlowFrameDetector. This is a non-functional, additive change.

* Introduces the SlowFrameTicker protocol to abstract CADisplayLink.
* Adds a MockTicker for simulating frame events in tests.
* Adds a MockDestination for capturing reported data in tests.