### PR TITLE
DEMRUM-782: add slow frame tests

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/OTelDestination.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/OTelDestination.swift
@@ -21,11 +21,13 @@ import SplunkCommon
 
 // MARK: - OTelDestination for SlowFrameDetector data
 
-struct OTelDestination: SlowFrameDetectorDestination {
+public struct OTelDestination: SlowFrameDetectorDestination {
+
+    public init() {}
 
     // MARK: - Sending
 
-    func send(type: String, count: Int, sharedState: AgentSharedState?) {
+    public func send(type: String, count: Int, sharedState: AgentSharedState?) async {
 
         let tracer = OpenTelemetry.instance
             .tracerProvider

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/SlowFrameDetectorDestination.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/SlowFrameDetectorDestination.swift
@@ -19,8 +19,8 @@ import Foundation
 import SplunkCommon
 
 /// Describes a destination into which the SlowFrameDetector module sends its results.
-protocol SlowFrameDetectorDestination {
+public protocol SlowFrameDetectorDestination {
 
     /// Sends results into a destination.
-    func send(type: String, count: Int, sharedState: AgentSharedState?)
+    func send(type: String, count: Int, sharedState: AgentSharedState?) async
 }

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetectorState.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetectorState.swift
@@ -15,11 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A state object that is representation for the current state of the SlowFrameDetector module.
+/// A thread-safe representation of the current state of the `SlowFrameDetector` module.
 public final class SlowFrameDetectorState: Sendable {
 
-    /// Indicates whether the SlowFrameDetector feature is enabled.
-    ///
-    /// The default value is `false`.
+    /// Indicates whether the slow frame detection feature is currently enabled.
     public internal(set) nonisolated(unsafe) var isEnabled: Bool = false
 }

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
@@ -16,12 +16,17 @@ limitations under the License.
 */
 
 import Foundation
+import QuartzCore
+#if os(iOS) || os(tvOS) || os(visionOS)
+import UIKit
+#endif
+
+
+// MARK: - SlowFrameTicker for Testability
 
 /// An abstraction for a timer that "ticks" on every frame refresh of the display.
 ///
-/// This protocol provides a consistent interface for receiving frame updates,
-/// abstracting the underlying mechanism (like `CADisplayLink`) to allow for easier
-/// testing and dependency injection.
+/// This protocol provides a consistent interface for receiving frame updates via a regular signal, abstracting the underlying mechanism (like `CADisplayLink`) to allow for easier testing and dependency injection.
 internal protocol SlowFrameTicker {
     var onFrame: ((_ timestamp: TimeInterval, _ duration: TimeInterval) -> Void)? { get set }
     func start()
@@ -29,3 +34,37 @@ internal protocol SlowFrameTicker {
     func pause()
     func resume()
 }
+
+#if os(iOS) || os(tvOS) || os(visionOS)
+internal final class DisplayLinkTicker: SlowFrameTicker {
+    private var displayLink: CADisplayLink?
+    var onFrame: ((TimeInterval, TimeInterval) -> Void)?
+
+    func start() {
+        DispatchQueue.main.async {
+            guard self.displayLink == nil else { return }
+            self.displayLink = CADisplayLink(target: self, selector: #selector(self.displayLinkCallback(_:)))
+            self.displayLink?.add(to: .main, forMode: .common)
+        }
+    }
+
+    func stop() {
+        DispatchQueue.main.async {
+            self.displayLink?.invalidate()
+            self.displayLink = nil
+        }
+    }
+
+    func pause() {
+        DispatchQueue.main.async { self.displayLink?.isPaused = true }
+    }
+
+    func resume() {
+        DispatchQueue.main.async { self.displayLink?.isPaused = false }
+    }
+
+    @objc private func displayLinkCallback(_ link: CADisplayLink) {
+        onFrame?(link.timestamp, link.duration)
+    }
+}
+#endif // os(iOS) || os(tvOS) || os(visionOS)

--- a/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
+++ b/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
@@ -89,23 +89,78 @@ final class SlowFrameDetectorTests: XCTestCase {
         await fulfillment(of: [startExpectation], timeout: 1.0)
     }
 
+    func test_start_isIdempotent() async {
+        XCTAssertEqual(mockTicker.startCallCount, 0)
+
+        await awaitDetectorStart()
+        XCTAssertEqual(mockTicker.startCallCount, 1, "start() should be called on the ticker the first time.")
+
+        // Call start on the detector again.
+        detector.start()
+        await Task.yield() // Allow async logic to run.
+
+        // Assert that the ticker's start() was not called a second time.
+        XCTAssertEqual(mockTicker.startCallCount, 1, "Calling start() multiple times should not restart the ticker.")
+    }
+    
+    func test_stateIsReset_onAppDidBecomeActive() async {
+        mockDestination.onSend = { type, count in
+            XCTFail("No report should be sent after app becomes active, as state should be reset.")
+        }
+
+        await awaitDetectorStart()
+
+        // 1. Simulate a first frame to establish a baseline timestamp.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+
+        // 2. Simulate the app returning to the foreground. This should reset the logic.
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        await Task.yield() // Allow the async notification handler to run.
+
+        // 3. Simulate a second frame after a long delay. Without the reset, this would be a slow frame.
+        mockTicker.simulateFrame(timestamp: 10.0, duration: 1.0 / 60.0)
+
+        // 4. Manually flush to check for any pending reports.
+        await detector.flushBuffers()
+    }
+
+    func test_buffersAreFlushed_onAppWillResignActive() async {
+        let reportExpectation = XCTestExpectation(description: "Report is sent when app resigns active")
+        mockDestination.onSend = { type, count in
+            if type == "slowRenders" {
+                XCTAssertEqual(count, 1)
+                reportExpectation.fulfill()
+            }
+        }
+
+        await awaitDetectorStart()
+
+        // 1. Simulate a slow frame.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+        mockTicker.simulateFrame(timestamp: 0.1, duration: 1.0 / 60.0)
+        await Task.yield() // Allow the slow frame to be processed.
+
+        // 2. Simulate the app going to the background. This should trigger a flush.
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+
+        // Give things a second (well a 5th of a second) for the notification.
+        try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+
+        await fulfillment(of: [reportExpectation], timeout: 1.0)
+    }
+
     func test_firstFrame_doesNotTriggerReport() async {
-        // ARRANGE: The destination should not be called.
         mockDestination.onSend = { _, _ in
             XCTFail("The first frame should never trigger a slow frame report.")
         }
 
         await awaitDetectorStart()
 
-        // ACT: Simulate only one frame.
         mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
         await detector.flushBuffers()
-
-        // ASSERT: The test passes if XCTFail is not called.
     }
 
     func test_slowFrame_isDetected() async throws {
-        // ARRANGE
         let reportExpectation = XCTestExpectation(description: "Slow frame report received")
         mockDestination.onSend = { type, count in
             if type == "slowRenders" {
@@ -118,7 +173,6 @@ final class SlowFrameDetectorTests: XCTestCase {
 
         let normalFrameDuration: TimeInterval = 1.0 / 60.0 // ~16.7ms
 
-        // ACT
         // Frame 1: The baseline.
         mockTicker.simulateFrame(timestamp: 0.0, duration: normalFrameDuration)
 
@@ -129,12 +183,10 @@ final class SlowFrameDetectorTests: XCTestCase {
         await Task.yield()
         await detector.flushBuffers()
 
-        // ASSERT
         await fulfillment(of: [reportExpectation], timeout: 1.0)
     }
 
     func test_slowFrame_atBoundary_isDetected() async throws {
-        // ARRANGE
         let reportExpectation = XCTestExpectation(description: "Slow frame report at boundary received")
         mockDestination.onSend = { type, count in
             if type == "slowRenders" {
@@ -152,7 +204,6 @@ final class SlowFrameDetectorTests: XCTestCase {
         // 2. Calculate the exact threshold
         let slowFrameThreshold = expectedDuration + toleranceValue
 
-        // ACT
         // Frame 1: The baseline
         mockTicker.simulateFrame(timestamp: 0.0, duration: expectedDuration)
 
@@ -164,7 +215,6 @@ final class SlowFrameDetectorTests: XCTestCase {
         await Task.yield()
         await detector.flushBuffers()
 
-        // ASSERT
         await fulfillment(of: [reportExpectation], timeout: 1.0)
     }
 
@@ -178,6 +228,85 @@ final class SlowFrameDetectorTests: XCTestCase {
         mockTicker.simulateFrame(timestamp: expectedDuration, duration: expectedDuration)
         await detector.flushBuffers()
     }
-}
 
+    func test_frozenFrame_isDetected_whenFramesStop() async throws {
+        let reportExpectation = XCTestExpectation(description: "Frozen frame report received")
+        mockDestination.onSend = { type, count in
+            if type == "frozenRenders" {
+                XCTAssertGreaterThanOrEqual(count, 1)
+                reportExpectation.fulfill()
+            }
+        }
+
+        await awaitDetectorStart()
+
+        let hangTime = SlowFrameDetector.frozenFrameThreshold
+
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+        try await Task.sleep(nanoseconds: UInt64((hangTime + 0.1) * 1_000_000_000))
+        await detector.flushBuffers()
+
+        await fulfillment(of: [reportExpectation], timeout: 1.0)
+    }
+
+    func test_startAndStop_correctlyControlTicker() async {
+        XCTAssertFalse(mockTicker.started)
+        XCTAssertFalse(mockTicker.stopped)
+
+        await awaitDetectorStart()
+        XCTAssertTrue(mockTicker.started, "The ticker should be started.")
+
+        await detector.stop()
+
+        XCTAssertTrue(mockTicker.stopped, "The ticker should be stopped.")
+    }
+
+    func test_longFreeze_reportsMultipleEvents() async throws {
+        await awaitDetectorStart()
+
+        // 1. Simulate one frame to establish a heartbeat.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+        await Task.yield() // Ensure the heartbeat is set before sleeping.
+
+        // 2. Sleep for a period that allows the watchdog AND the automatic flush to run.
+        // We will sleep for ~2.5 seconds.
+        // Watchdog runs at: ~0.7s, ~1.4s, ~2.1s (3 times)
+        // Auto-flush runs at: ~1.0s, ~2.0s (2 times)
+        let hangTime = SlowFrameDetector.frozenFrameThreshold * 3.5 // ~2.45s
+        try await Task.sleep(nanoseconds: UInt64(hangTime * 1_000_000_000))
+
+        // 3. Manually flush any remaining counts at the end of the test.
+        await detector.flushBuffers()
+
+        // Check the final accumulated count in the mock destination.
+        // The watchdog should have fired 3 times.
+        let finalCount = mockDestination.reportedCounts["frozenRenders"]
+        XCTAssertEqual(finalCount, 3, "The total count of frozen events should be 3 after ~2.45s.")
+    }
+
+    func test_automaticFlush_reportsPendingFrames() async {
+        let reportExpectation = XCTestExpectation(description: "Automatic flush loop sends report")
+        mockDestination.onSend = { type, count in
+            if type == "slowRenders" {
+                XCTAssertEqual(count, 1)
+                reportExpectation.fulfill()
+            }
+        }
+        await awaitDetectorStart()
+
+        // 1. Simulate a slow frame.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+        mockTicker.simulateFrame(timestamp: 0.1, duration: 1.0 / 60.0)
+
+        await Task.yield()
+
+        // 2. Wait for longer than the automatic flush interval (1 second).
+        // DO NOT call flushBuffers() manually.
+        try? await Task.sleep(nanoseconds: 1_100_000_000)
+
+        // The expectation should be fulfilled by the automatic flush loop.
+        await fulfillment(of: [reportExpectation], timeout: 1.5)
+    }
+
+}
 #endif // os(iOS) || os(tvOS) || os(visionOS)

--- a/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
+++ b/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
@@ -15,32 +15,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Foundation
-@testable import SplunkSlowFrameDetector
-import XCTest
 import SplunkCommon
-
-final class SplunkSlowFrameDetectorTests: XCTestCase {
-    // Note: This file will be populated with a comprehensive suite of unit tests
-    // as part of the effort to improve the detector's testability.
-    // The new tests will use mock objects to verify behavior.
-}
-
-// MARK: - Test Mocks
+import XCTest
+#if os(iOS) || os(tvOS) || os(visionOS)
+@testable import SplunkSlowFrameDetector
+import UIKit
 
 final class MockTicker: SlowFrameTicker {
     var onFrame: ((TimeInterval, TimeInterval) -> Void)?
     var started = false
     var stopped = false
+    var startCallCount = 0
+
+    var onStart: (() -> Void)?
 
     func start() {
         started = true
+        startCallCount += 1
+        onStart?()
     }
-
-    func stop() {
-        stopped = true
-    }
-
+    func stop() { stopped = true }
     func pause() {}
     func resume() {}
 
@@ -49,10 +43,141 @@ final class MockTicker: SlowFrameTicker {
     }
 }
 
-final class MockDestination: SlowFrameDetectorDestination {
+private class MockDestination: SlowFrameDetectorDestination {
+    // This dictionary will store the accumulated counts.
+    var reportedCounts: [String: Int] = [:]
     var onSend: ((String, Int) -> Void)?
 
-    func send(type: String, count: Int, sharedState: AgentSharedState?) {
+    func send(type: String, count: Int, sharedState: AgentSharedState?) async {
+        // Accumulate the count for the given type.
+        reportedCounts[type, default: 0] += count
+        // Call the optional closure for tests that still need it.
         onSend?(type, count)
     }
 }
+
+final class SlowFrameDetectorTests: XCTestCase {
+
+    private var mockTicker: MockTicker!
+    private var detector: SlowFrameDetector!
+    private var mockDestination: MockDestination!
+
+    override func setUp() {
+        super.setUp()
+        mockTicker = MockTicker()
+        mockDestination = MockDestination()
+        detector = SlowFrameDetector(ticker: mockTicker, destinationFactory: { self.mockDestination })
+    }
+
+    override func tearDown() async throws {
+        await detector.stop()
+
+        detector = nil
+        mockDestination = nil
+        mockTicker = nil
+
+        try await super.tearDown()
+    }
+
+    // Helper function to wait for the detector to start up.
+    private func awaitDetectorStart() async {
+        let startExpectation = XCTestExpectation(description: "Detector has started")
+        mockTicker.onStart = {
+            startExpectation.fulfill()
+        }
+        detector.start()
+        await fulfillment(of: [startExpectation], timeout: 1.0)
+    }
+
+    func test_firstFrame_doesNotTriggerReport() async {
+        // ARRANGE: The destination should not be called.
+        mockDestination.onSend = { _, _ in
+            XCTFail("The first frame should never trigger a slow frame report.")
+        }
+
+        await awaitDetectorStart()
+
+        // ACT: Simulate only one frame.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: 1.0 / 60.0)
+        await detector.flushBuffers()
+
+        // ASSERT: The test passes if XCTFail is not called.
+    }
+
+    func test_slowFrame_isDetected() async throws {
+        // ARRANGE
+        let reportExpectation = XCTestExpectation(description: "Slow frame report received")
+        mockDestination.onSend = { type, count in
+            if type == "slowRenders" {
+                XCTAssertEqual(count, 1)
+                reportExpectation.fulfill()
+            }
+        }
+
+        await awaitDetectorStart()
+
+        let normalFrameDuration: TimeInterval = 1.0 / 60.0 // ~16.7ms
+
+        // ACT
+        // Frame 1: The baseline.
+        mockTicker.simulateFrame(timestamp: 0.0, duration: normalFrameDuration)
+
+        // Frame 2: An unambiguously slow frame.
+        mockTicker.simulateFrame(timestamp: 0.100, duration: normalFrameDuration)
+
+        // Let the async tasks complete, then flush the buffers to trigger the report.
+        await Task.yield()
+        await detector.flushBuffers()
+
+        // ASSERT
+        await fulfillment(of: [reportExpectation], timeout: 1.0)
+    }
+
+    func test_slowFrame_atBoundary_isDetected() async throws {
+        // ARRANGE
+        let reportExpectation = XCTestExpectation(description: "Slow frame report at boundary received")
+        mockDestination.onSend = { type, count in
+            if type == "slowRenders" {
+                XCTAssertEqual(count, 1)
+                reportExpectation.fulfill()
+            }
+        }
+
+        await awaitDetectorStart()
+
+        // 1. Define the parameters clearly
+        let expectedDuration: TimeInterval = 1.0 / 60.0
+        let toleranceValue = expectedDuration * (SlowFrameDetector.slowFrameTolerancePercentage / 100.0)
+
+        // 2. Calculate the exact threshold
+        let slowFrameThreshold = expectedDuration + toleranceValue
+
+        // ACT
+        // Frame 1: The baseline
+        mockTicker.simulateFrame(timestamp: 0.0, duration: expectedDuration)
+
+        // Frame 2: Simulate a frame that took exactly the threshold amount of time.
+        // Since our logic is >=, this should be detected as a slow frame.
+        mockTicker.simulateFrame(timestamp: slowFrameThreshold, duration: expectedDuration)
+
+        // Let the async tasks complete, then flush.
+        await Task.yield()
+        await detector.flushBuffers()
+
+        // ASSERT
+        await fulfillment(of: [reportExpectation], timeout: 1.0)
+    }
+
+    func test_noReports_whenFramesAreNormal() async throws {
+        mockDestination.onSend = { _, _ in XCTFail("No reports should be sent for normal frames.") }
+
+        await awaitDetectorStart()
+
+        let expectedDuration: TimeInterval = 1.0 / 60.0
+        mockTicker.simulateFrame(timestamp: 0.0, duration: expectedDuration)
+        mockTicker.simulateFrame(timestamp: expectedDuration, duration: expectedDuration)
+        await detector.flushBuffers()
+    }
+}
+
+#endif // os(iOS) || os(tvOS) || os(visionOS)


### PR DESCRIPTION
* Adds unit tests for slow frame detection.
* Includes tests for:
  - Correctly identifying a slow frame.
  - Correctly identifying a slow frame at the boundary.
  - Ignoring normal-speed frames.
  - Ignoring the very first frame.
* Adds `MockTicker` and `MockDestination` to the test suite.