### PR TITLE
DEMRUM-782: add lifecycle and edge-case tests

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/OTelDestination.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/OTelDestination.swift
@@ -21,11 +21,13 @@ import SplunkCommon
 
 // MARK: - OTelDestination for SlowFrameDetector data
 
-struct OTelDestination: SlowFrameDetectorDestination {
+public struct OTelDestination: SlowFrameDetectorDestination {
+
+    public init() {}
 
     // MARK: - Sending
 
-    func send(type: String, count: Int, sharedState: AgentSharedState?) {
+    public func send(type: String, count: Int, sharedState: AgentSharedState?) async {
 
         let tracer = OpenTelemetry.instance
             .tracerProvider

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/SlowFrameDetectorDestination.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/Destination/SlowFrameDetectorDestination.swift
@@ -19,8 +19,8 @@ import Foundation
 import SplunkCommon
 
 /// Describes a destination into which the SlowFrameDetector module sends its results.
-protocol SlowFrameDetectorDestination {
+public protocol SlowFrameDetectorDestination {
 
     /// Sends results into a destination.
-    func send(type: String, count: Int, sharedState: AgentSharedState?)
+    func send(type: String, count: Int, sharedState: AgentSharedState?) async
 }

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetectorState.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetectorState.swift
@@ -15,11 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// A state object that is representation for the current state of the SlowFrameDetector module.
+/// A thread-safe representation of the current state of the `SlowFrameDetector` module.
 public final class SlowFrameDetectorState: Sendable {
 
-    /// Indicates whether the SlowFrameDetector feature is enabled.
-    ///
-    /// The default value is `false`.
+    /// Indicates whether the slow frame detection feature is currently enabled.
     public internal(set) nonisolated(unsafe) var isEnabled: Bool = false
 }

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameTicker.swift
@@ -16,12 +16,17 @@ limitations under the License.
 */
 
 import Foundation
+import QuartzCore
+#if os(iOS) || os(tvOS) || os(visionOS)
+import UIKit
+#endif
+
+
+// MARK: - SlowFrameTicker for Testability
 
 /// An abstraction for a timer that "ticks" on every frame refresh of the display.
 ///
-/// This protocol provides a consistent interface for receiving frame updates,
-/// abstracting the underlying mechanism (like `CADisplayLink`) to allow for easier
-/// testing and dependency injection.
+/// This protocol provides a consistent interface for receiving frame updates via a regular signal, abstracting the underlying mechanism (like `CADisplayLink`) to allow for easier testing and dependency injection.
 internal protocol SlowFrameTicker {
     var onFrame: ((_ timestamp: TimeInterval, _ duration: TimeInterval) -> Void)? { get set }
     func start()
@@ -29,3 +34,37 @@ internal protocol SlowFrameTicker {
     func pause()
     func resume()
 }
+
+#if os(iOS) || os(tvOS) || os(visionOS)
+internal final class DisplayLinkTicker: SlowFrameTicker {
+    private var displayLink: CADisplayLink?
+    var onFrame: ((TimeInterval, TimeInterval) -> Void)?
+
+    func start() {
+        DispatchQueue.main.async {
+            guard self.displayLink == nil else { return }
+            self.displayLink = CADisplayLink(target: self, selector: #selector(self.displayLinkCallback(_:)))
+            self.displayLink?.add(to: .main, forMode: .common)
+        }
+    }
+
+    func stop() {
+        DispatchQueue.main.async {
+            self.displayLink?.invalidate()
+            self.displayLink = nil
+        }
+    }
+
+    func pause() {
+        DispatchQueue.main.async { self.displayLink?.isPaused = true }
+    }
+
+    func resume() {
+        DispatchQueue.main.async { self.displayLink?.isPaused = false }
+    }
+
+    @objc private func displayLinkCallback(_ link: CADisplayLink) {
+        onFrame?(link.timestamp, link.duration)
+    }
+}
+#endif // os(iOS) || os(tvOS) || os(visionOS)

--- a/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
+++ b/SplunkSlowFrameDetector/Tests/SplunkSlowFrameDetectorTests/SplunkSlowFrameDetectorTests.swift
@@ -188,7 +188,7 @@ final class SlowFrameDetectorTests: XCTestCase {
 
     func test_slowFrame_atBoundary_isDetected() async throws {
         let reportExpectation = XCTestExpectation(description: "Slow frame report at boundary received")
-         mockDestination.onSend = { type, count in
+        mockDestination.onSend = { type, count in
             if type == "slowRenders" {
                 XCTAssertEqual(count, 1)
                 reportExpectation.fulfill()


### PR DESCRIPTION
* Adds test to ensure start() is idempotent.
* Adds test to verify start() and stop() correctly control the ticker.
* Adds test for buffer flushing when the app resigns active.
* Adds test for state reset when the app becomes active.