### PR TITLE
DEMRUM-3131: Update scriptInstanceId parameter

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -42,7 +42,6 @@ class DefaultEventManager: AgentEventManager {
     // Session Replay processor
     var sessionReplayProcessor: LogEventProcessor?
     var sessionReplayIndexer: EventIndexer
-    let scriptInstanceId: String
 
     // Trace processor
     var traceProcessor: TraceProcessor
@@ -99,7 +98,6 @@ class DefaultEventManager: AgentEventManager {
         )
 
         // Initialize session replay processor (optional)
-        scriptInstanceId = .uniqueHexIdentifier(ofLength: 16)
         sessionReplayProcessor = OTLPSessionReplayEventProcessor(
             with: configuration.endpoint.sessionReplayEndpoint,
             resources: resources,
@@ -177,6 +175,9 @@ class DefaultEventManager: AgentEventManager {
 
                 return
             }
+
+            // Use scriptInstanceId as a 16 character substring of a sessionId
+            let scriptInstanceId = String(sessionId.prefix(upTo: sessionId.index(sessionId.startIndex, offsetBy: 16)))
 
             let event = SessionReplayDataEvent(
                 metadata: metadata,

--- a/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Testing Support/Builders/SessionReplayTestBuilder.swift
@@ -47,6 +47,7 @@ final class SessionReplayTestBuilder {
         let sampleVideoData = try Self.sampleVideoData()
 
         let sessionId = UUID().uuidString
+        let scriptInstanceId = String(sessionId.prefix(upTo: sessionId.index(sessionId.startIndex, offsetBy: 16)))
         let timestamp = Date()
         let endTimestamp = Date()
 
@@ -60,7 +61,7 @@ final class SessionReplayTestBuilder {
             data: sampleVideoData,
             index: 1,
             sessionId: sessionId,
-            scriptInstanceId: UUID().uuidString
+            scriptInstanceId: scriptInstanceId
         )
 
         return event


### PR DESCRIPTION
This PR updates the scriptInstanceId parameter, which is used in a session replay data event as a required attribute. This PR updates the attribute so that it's based on a sessionId, by making it a 16 character substring of a sessionId.