### PR TITLE
NO-TICKET: update fix threshold value

### DIFF
--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
@@ -199,7 +199,7 @@ public final class SlowFrameDetector {
         // Set up the expectation
         let expectedDuration = targetTimestamp - actualTimestamp
 
-        // Threshold for extra duration above which a frame is considered slow.
+        // Tolerance for extra duration above which a frame is considered slow.
         let tolerance = expectedDuration * (tolerancePercentage / 100.0)
 
         // Duration is too long... slow frame

--- a/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
+++ b/SplunkSlowFrameDetector/Sources/SplunkSlowFrameDetector/SlowFrameDetector.swift
@@ -199,8 +199,8 @@ public final class SlowFrameDetector {
         // Set up the expectation
         let expectedDuration = targetTimestamp - actualTimestamp
 
-        // `tolerancePercentage` percent of the expected duration, used for slow frames
-        let tolerance = expectedDuration * tolerancePercentage
+        // Threshold for extra duration above which a frame is considered slow.
+        let tolerance = expectedDuration * (tolerancePercentage / 100.0)
 
         // Duration is too long... slow frame
         let isSlow = actualDuration > expectedDuration + tolerance


### PR DESCRIPTION
The previous code had some incorrect math which would lead to far fewer detections of slow frames than intended, by a factor of approximately 14.

This was previously fixed in another series of changes (task/DEMRUM-782-sfd-tests-pr0), but now should be fixed in this branch since we are not merging those changes yet and staying with this approach for now.
