### PR TITLE
NO-TICKET: Fix OpenTelemetryApi import in SplunkCommon target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -182,7 +182,8 @@ func generateMainTargets() -> [Target] {
             name: "SplunkCommon",
             dependencies: [
                 resolveDependency("diskStorage"),
-                resolveDependency("encryptor")
+                resolveDependency("encryptor"),
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift")
             ],
             path: "SplunkCommon/Sources"
         ),


### PR DESCRIPTION
This PR fixes a bug in Package manifest, where the SplunkCommon target did not import OpenTelemetryApi. This caused all tests to fail to build.