### PR TITLE
DEMRUM-3129: Update traces and session replay api endpoints.

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-EndpointConfiguration.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-EndpointConfiguration.swift
@@ -49,8 +49,8 @@ public struct EndpointConfiguration: Codable, Equatable {
         self.realm = realm
         self.rumAccessToken = rumAccessToken
 
-        let traceUrl = Self.realmUrl(for: realm, path: "/v1/rumotlp")
-        let sessionReplayUrl = Self.realmUrl(for: realm, path: "/v1/rumreplay")
+        let traceUrl = Self.realmUrl(for: realm, path: "/v1/traces")
+        let sessionReplayUrl = Self.realmUrl(for: realm, path: "/v1/logs")
 
         // Authenticate trace url
         if let traceUrl {

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-ConfigurationObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-ConfigurationObjCTests.m
@@ -45,7 +45,7 @@ limitations under the License.
 
     XCTAssertTrue([urlComponents.scheme isEqualToString:@"https"]);
     XCTAssertTrue([urlComponents.host isEqualToString:expectedHost]);
-    XCTAssertTrue([urlComponents.path isEqualToString:@"/v1/rumotlp"]);
+    XCTAssertTrue([urlComponents.path isEqualToString:@"/v1/traces"]);
 
 
     // Authentication

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-ConfigurationTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-ConfigurationTests.swift
@@ -126,7 +126,7 @@ final class API10ConfigurationTests: XCTestCase {
 
         XCTAssertEqual(urlComponents.scheme, "https")
         XCTAssertEqual(urlComponents.host, "rum-ingest.\(realm).signalfx.com")
-        XCTAssertEqual(urlComponents.path, "/v1/rumotlp")
+        XCTAssertEqual(urlComponents.path, "/v1/traces")
 
         let queryItems = try XCTUnwrap(urlComponents.queryItems)
         let authQuery = try XCTUnwrap(queryItems.first)

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Deprecated/API-1.0-SplunkRumBuilderTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Deprecated/API-1.0-SplunkRumBuilderTests.swift
@@ -195,7 +195,7 @@ final class API10SplunkRumBuilderTests: XCTestCase {
 
         XCTAssertEqual(comps.scheme, "https")
         XCTAssertEqual(comps.host, "rum-ingest.\(realm).signalfx.com")
-        XCTAssertEqual(comps.path, "/v1/rumotlp")
+        XCTAssertEqual(comps.path, "/v1/traces")
 
         let authItem = comps.queryItems?.first { $0.name == "auth" }
         XCTAssertEqual(authItem?.value, token)


### PR DESCRIPTION
## Update API endpoints

### Description

This PR updates default RUM API endpoints to the new `v1/traces` and `v1/logs`. 

New api endpoints should behave identically to the old ones.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] (If applicable) I have added unit tests for my changes.
- [x] (If applicable) I have updated the sample app for integration testing.
- [x] (If applicable) I have updated any relevant documentation.

### How to Test These Changes

Any sessions recorded on any realm should appear identical as if recorded with previous API endpoints.