### PR TITLE
DEMRUM-3349: Fix UIViewController transition tracking

### DIFF
--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
@@ -257,14 +257,16 @@ public final class Navigation: Sendable {
     }
 
     private func transitionEvent(for presentationObject: Any?, type eventType: NavigationActionEventType) async -> AutomatedNavigationEvent? {
+        let presentationController = presentationObject as? UIViewController
+        let presentedController = await presentationController?.presentedViewController
+
         guard
             await shouldProcessEvent(),
-            let presentationController = presentationObject as? UIPresentationController
+            let visibleController = presentedController ?? presentationController
         else {
             return nil
         }
 
-        let visibleController = await presentationController.presentedViewController
         let controllerTypeName = NSStringFromClass(type(of: visibleController))
         let screenName = await preferredScreenName(for: controllerTypeName)
 


### PR DESCRIPTION
## Title: Fix UIViewController transition tracking

### Description

This PR fixes #431 by falling back to tracking a UIViewController instead of a UIViewController's `.presentedViewController` in case the `.presentedViewController` is `nil`.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] (If applicable) I have added unit tests for my changes.
- [ ] (If applicable) I have updated the sample app for integration testing.
- [ ] (If applicable) I have updated any relevant documentation.
