### PR TITLE
DEMRUM-2996: add app.installation.id to runtime attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add the `app.installation.id` attribute to all signals to uniquely identify each application installation.
+
 ## [2.0.0]
 
 This is a first major stable release of the new Splunk OpenTelemetry Agent.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Runtime Attributes/DefaultRuntimeAttributes.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Runtime Attributes/DefaultRuntimeAttributes.swift
@@ -32,6 +32,9 @@ final class DefaultRuntimeAttributes: AgentRuntimeAttributes {
     /// Internal value store for custom attributes.
     private var customValue: [String: Any]
 
+    /// The persistent, unique identifier for this application installation.
+    private let appInstallationId: String
+
 
     // MARK: - RuntimeAttributes protocol
 
@@ -46,6 +49,7 @@ final class DefaultRuntimeAttributes: AgentRuntimeAttributes {
         var systemAttributes: [String: Any] = [:]
         systemAttributes["user.anonymous_id"] = userIdentifier()
         systemAttributes["session.id"] = sessionIdentifier()
+        systemAttributes["app.installation.id"] = installationIdentifier()
         allAttributes = systemAttributes
 
 
@@ -91,6 +95,19 @@ final class DefaultRuntimeAttributes: AgentRuntimeAttributes {
 
         let queueName = PackageIdentifier.default(named: "runtimeAttributesAccess")
         accessQueue = DispatchQueue(label: queueName, qos: .userInitiated)
+
+        let storage = UserDefaultsStorage()
+        let storageKeyForAppInstallationId = "app.installation.id"
+
+        // Retrieve or generate a persistent app installation ID
+        if let existingAppInstallationId: String = try? storage.read(forKey: storageKeyForAppInstallationId), !existingAppInstallationId.isEmpty {
+            appInstallationId = existingAppInstallationId
+        }
+        else {
+            let newId = UUID().uuidString
+            try? storage.update(newId, forKey: storageKeyForAppInstallationId)
+            appInstallationId = newId
+        }
     }
 
 
@@ -107,5 +124,9 @@ final class DefaultRuntimeAttributes: AgentRuntimeAttributes {
 
     private func sessionIdentifier() -> String? {
         owner.currentSession.currentSessionId
+    }
+
+    private func installationIdentifier() -> String {
+        appInstallationId
     }
 }


### PR DESCRIPTION
## Add app.installation.id to runtime attributes

### Description

* Add app.installation.id property
* Do check for existing ID; if not found, create new one using UUID()
* Store using existing UserDefaultsStorage facility in SplunkAgent
* Update unit tests to cover new property
* Update property counts in existing unit tests to account for added property
* Added entry to CHANGELOG for future version use

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Build and run one of the test apps (`DevelApp` or `AgentTestApp`) after invoking `Reset Package Caches` in Xcode, then inspect spans in the Xcode Console to confirm that spans include the key `app.installation.id` populated with a UUID that varies from app to app but stays the same between different runs of the same installed app.
