### PR TITLE
DEMRUM-3669: Update SwiftLint and SwiftFormat Integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,24 +33,6 @@ let package = Package(
         .package(
             url: "https://github.com/microsoft/plcrashreporter",
             from: "1.12.0"
-        ),
-
-        // SwiftLint (realm)
-        .package(
-            url: "https://github.com/SimplyDanny/SwiftLintPlugins",
-            from: "0.59.1"
-        ),
-
-        // swift-format (swiftlang)
-        .package(
-            url: "https://github.com/StarLard/SwiftFormatPlugins",
-            from: "1.1.0"
-        ),
-
-        // SwiftFormat (nicklockwood)
-        .package(
-            url: "https://github.com/nicklockwood/SwiftFormat",
-            from: "0.57.2"
         )
     ],
     targets: []
@@ -61,6 +43,10 @@ let package = Package(
 package.targets.append(contentsOf: generateBinaryTargets())
 package.targets.append(contentsOf: generateWrapperTargets())
 package.targets.append(contentsOf: generateMainTargets())
+
+// Conditionally add all required plugin dependencies
+
+package.dependencies.append(contentsOf: pluginDependencies())
 
 // Conditionally add Session Replay as a repository dependency
 resolveSessionReplayRepositoryDependency()
@@ -99,10 +85,7 @@ func generateMainTargets() -> [Target] {
                 .copy("../../Resources/PrivacyInfo.xcprivacy"),
                 .copy("../../Resources/NOTICES")
             ],
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
-                .plugin(name: "Lint", package: "SwiftFormatPlugins")
-            ]
+            plugins: lintMainTargetPlugins()
         ),
         .testTarget(
             name: "SplunkAgentTests",
@@ -117,10 +100,7 @@ func generateMainTargets() -> [Target] {
             swiftSettings: [
                 .define("SPM_TESTS")
             ],
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
-                .plugin(name: "Lint", package: "SwiftFormatPlugins")
-            ]
+            plugins: lintMainTargetPlugins()
         ),
 
 
@@ -141,10 +121,7 @@ func generateMainTargets() -> [Target] {
                 .copy("../../Resources/PrivacyInfo.xcprivacy"),
                 .copy("../../Resources/NOTICES")
             ],
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
-                .plugin(name: "Lint", package: "SwiftFormatPlugins")
-            ]
+            plugins: lintMainTargetPlugins()
         ),
         .testTarget(
             name: "SplunkAgentObjCTests",
@@ -540,9 +517,68 @@ func generateBinaryWrapperTargets() -> [Target] {
 
 // MARK: - Target plugins
 
+/// Determines whether to use development plugins as a repository dependency.
+///
+/// This is the main switch for enabling linter and formaters plugins.
+func shouldUseDevelopmentPlugins() -> Bool {
+    // Check the ENV first
+    if let envValue = ProcessInfo.processInfo.environment["USE_DEVELOPMENT_PLUGINS"],
+        let boolValue = Bool(envValue)
+    {
+        return boolValue
+    }
+
+    // Default to *not use any plugins*
+    return false
+}
+
+/// List of used plugin dependencies.
+func pluginDependencies() -> [Package.Dependency] {
+    guard shouldUseDevelopmentPlugins() else {
+        return []
+    }
+
+    return [
+        // SwiftLint (realm)
+        .package(
+            url: "https://github.com/SimplyDanny/SwiftLintPlugins",
+            from: "0.59.1"
+        ),
+
+        // swift-format (swiftlang)
+        .package(
+            url: "https://github.com/StarLard/SwiftFormatPlugins",
+            from: "1.1.0"
+        ),
+
+        // SwiftFormat (nicklockwood)
+        .package(
+            url: "https://github.com/nicklockwood/SwiftFormat",
+            from: "0.57.2"
+        )
+    ]
+}
+
+/// List of used lint plugins in main targets.
+func lintMainTargetPlugins() -> [Target.PluginUsage] {
+    guard shouldUseDevelopmentPlugins() else {
+        return []
+    }
+
+    return [
+        .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
+        .plugin(name: "Lint", package: "SwiftFormatPlugins")
+    ]
+}
+
 /// List of used lint plugins in every target.
 func lintTargetPlugins() -> [Target.PluginUsage] {
-    [
+    guard shouldUseDevelopmentPlugins() else {
+        return []
+    }
+
+    return [
+        .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins"),
         .plugin(name: "Lint", package: "SwiftFormatPlugins")
     ]
 }

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Network/Model Conversions/NetworkInstrumentationConfigurationObjC+Conversions.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Network/Model Conversions/NetworkInstrumentationConfigurationObjC+Conversions.swift
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 import Foundation
-
 internal import SplunkCommon
 internal import SplunkNetwork
 


### PR DESCRIPTION
## Title: Update SwiftLint and SwiftFormat Integration

### Description

It changes the Swift Package configuration so that the package does not require any additional plug-ins. Therefore, there is no need to enable them on the customer's side. Fixes #454.

**Changes:**
- By default, all plugins are disabled due to the settings in the `shouldUseDevelopmentPlugins` method.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [x] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

**When the client uses the SDK:**
1. Clear your local caches.
```bash
rm -rf ~/Library/org.swift.swiftpm 
rm -rf ~/Library/Caches/org.swift.swiftpm
rm -rf ~/Library/Developer/Xcode/DerivedData/*
```

2. Open a sample app and add the SPM dependency to this branch.

3. Check downloaded dependencies in Xcode.
-> There are no plug-ins among the dependencies.
-> Xcode will not want to authorize any plugins.

**When SDK is  actively developed:**
1. Get this branch.

2. Go to Package.swift and set the method `shouldUseDevelopmentPlugins` return value to `true`.

3. Xcode downloads all dependent packages
-> and should enable menus with format commands.
-> Xcode will **want to** authorize plugins like `SwiftLint`.