### PR TITLE
DEMRUM-3394: POC - Research HTTP breakdown metrics - DO NOT MERGE

### DIFF
--- a/SplunkNetwork/Sources/SplunkNetwork/Module/NetworkInstrumentationConfiguration.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/Module/NetworkInstrumentationConfiguration.swift
@@ -39,6 +39,17 @@ public struct NetworkInstrumentationConfiguration: ModuleConfiguration {
     /// Default value is `true`.
     public var injectTraceHeaders: Bool = true
 
+    /// Indicates whether network timing breakdown data should be collected.
+    ///
+    /// When enabled, `URLSessionTaskTransactionMetrics` are captured for each instrumented
+    /// HTTP request and emitted as a log record with timing attributes (DNS, connect, TLS,
+    /// request, and response phases).
+    ///
+    /// Requires iOS 15+ at runtime. On earlier versions this setting has no effect.
+    ///
+    /// Default value is `true`.
+    public var collectNetworkTiming: Bool = true
+
     // MARK: init()
 
     /// Initializes new module configuration with preconfigured values.
@@ -47,9 +58,16 @@ public struct NetworkInstrumentationConfiguration: ModuleConfiguration {
     ///   - isEnabled: A `Boolean` value sets whether the module is enabled.
     ///   - ignoreURLs: If present, the module will not report on these URLs.
     ///   - injectTraceHeaders: If `true` (default), W3C trace context headers are injected into requests.
-    public init(isEnabled: Bool = true, ignoreURLs: IgnoreURLs? = nil, injectTraceHeaders: Bool = true) {
+    ///   - collectNetworkTiming: If `true` (default), network timing breakdowns are captured for HTTP requests (iOS 15+ only).
+    public init(
+        isEnabled: Bool = true,
+        ignoreURLs: IgnoreURLs? = nil,
+        injectTraceHeaders: Bool = true,
+        collectNetworkTiming: Bool = true
+    ) {
         self.isEnabled = isEnabled
         self.ignoreURLs = ignoreURLs
         self.injectTraceHeaders = injectTraceHeaders
+        self.collectNetworkTiming = collectNetworkTiming
     }
 }

--- a/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/NetworkInstrumentation.swift
@@ -28,6 +28,9 @@ public class NetworkInstrumentation {
     /// Indicates whether trace header injection is enabled.
     private var traceHeaderInjectionEnabled = true
 
+    /// Indicates whether network timing collection is enabled.
+    private var networkTimingEnabled = false
+
 
     // MARK: - Public
 
@@ -42,6 +45,11 @@ public class NetworkInstrumentation {
     /// Indicates whether W3C trace context header injection is enabled.
     public var isTraceHeaderInjectionEnabled: Bool {
         traceHeaderInjectionEnabled
+    }
+
+    /// Indicates whether network timing collection is enabled (iOS 15+ only).
+    public var isNetworkTimingEnabled: Bool {
+        networkTimingEnabled
     }
 
     public required init() {}
@@ -74,6 +82,7 @@ public class NetworkInstrumentation {
             }
 
             traceHeaderInjectionEnabled = config?.injectTraceHeaders ?? true
+            networkTimingEnabled = config?.collectNetworkTiming ?? true
 
             NetworkInstrumentationManager.shared.initialize(with: self)
         }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
@@ -80,6 +80,7 @@ func swizzleDownloadTaskWithURL() {
         let task = castedRequestIMP(session, requestSelector, instrumentedRequest)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -124,6 +125,7 @@ func swizzleDownloadTaskWithRequestAndCompletion() {
         let task = castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -181,6 +183,7 @@ func swizzleDownloadTaskWithURLAndCompletion() {
         let task = castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -222,6 +225,7 @@ func swizzleDownloadTaskWithResumeData() {
 
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -263,6 +267,7 @@ func swizzleDownloadTaskWithResumeDataAndCompletion() {
 
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
@@ -41,8 +41,9 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
 
     // MARK: - URLSessionTaskDelegate
 
-    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        guard let transaction = metrics.transactionMetrics.last else {
+    func urlSession(_: URLSession, task _: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        guard let transaction = metrics.transactionMetrics.last
+        else {
             return
         }
 
@@ -76,6 +77,7 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
     ///
     /// Only non-nil dates produce attributes; phases that did not occur (e.g. DNS on a
     /// reused connection, TLS on plain HTTP) are omitted.
+    // swiftlint:disable:next function_parameter_count
     func buildTimingAttributes(
         fetchStart: Date?,
         domainLookupStart: Date?,
@@ -119,8 +121,12 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
     }
 
     private func setIfPresent(_ attrs: inout [String: AttributeValue], key: String, date: Date?) {
-        guard let date else { return }
-        let epochMillis = Int(date.timeIntervalSince1970 * 1000)
+        guard let date
+        else {
+            return
+        }
+
+        let epochMillis = Int(date.timeIntervalSince1970 * 1_000)
         attrs[key] = .int(epochMillis)
     }
 
@@ -158,11 +164,13 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
 /// for the duration of the task's lifetime, and set as the task's per-task delegate to
 /// receive `didFinishCollecting` metrics.
 func attachTimingCollectorIfEnabled(to task: URLSessionTask, spanContext: SpanContext) {
-    guard #available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *) else {
+    guard #available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
+    else {
         return
     }
 
-    guard NetworkInstrumentationManager.shared.getModule()?.isNetworkTimingEnabled == true else {
+    guard NetworkInstrumentationManager.shared.getModule()?.isNetworkTimingEnabled == true
+    else {
         return
     }
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
@@ -73,11 +73,11 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
     /// Builds timing attributes from individual date values.
     ///
     /// Only non-nil dates produce attributes; phases that did not occur (e.g. DNS on a
     /// reused connection, TLS on plain HTTP) are omitted.
-    // swiftlint:disable:next function_parameter_count
     func buildTimingAttributes(
         fetchStart: Date?,
         domainLookupStart: Date?,

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
@@ -73,11 +73,11 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
         )
     }
 
+    // swiftlint:disable function_parameter_count
     /// Builds timing attributes from individual date values.
     ///
     /// Only non-nil dates produce attributes; phases that did not occur (e.g. DNS on a
     /// reused connection, TLS on plain HTTP) are omitted.
-    // swiftlint:disable function_parameter_count
     func buildTimingAttributes(
         fetchStart: Date?,
         domainLookupStart: Date?,

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
@@ -73,11 +73,11 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
         )
     }
 
-    // swiftlint:disable:next function_parameter_count
     /// Builds timing attributes from individual date values.
     ///
     /// Only non-nil dates produce attributes; phases that did not occur (e.g. DNS on a
     /// reused connection, TLS on plain HTTP) are omitted.
+    // swiftlint:disable function_parameter_count
     func buildTimingAttributes(
         fetchStart: Date?,
         domainLookupStart: Date?,
@@ -91,6 +91,7 @@ final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
         responseStart: Date?,
         responseEnd: Date?
     ) -> [String: AttributeValue] {
+        // swiftlint:enable function_parameter_count
         var attrs: [String: AttributeValue] = [:]
 
         setIfPresent(&attrs, key: "http.call.start_time", date: fetchStart)

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+NetworkTiming.swift
@@ -1,0 +1,173 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+
+// MARK: - Associated Object Key
+
+private var associatedKeyTimingCollector: UInt8 = 0
+
+// MARK: - NetworkTimingCollector
+
+/// Collects `URLSessionTaskTransactionMetrics` for an instrumented HTTP task and emits
+/// a network timing log record linked to the original HTTP span.
+///
+/// Instances are set as the per-task delegate (`task.delegate`, iOS 15+) so they receive
+/// the `urlSession(_:task:didFinishCollecting:)` callback after the task completes.
+@available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
+final class NetworkTimingCollector: NSObject, URLSessionTaskDelegate {
+
+    private let spanContext: SpanContext
+
+    init(spanContext: SpanContext) {
+        self.spanContext = spanContext
+        super.init()
+    }
+
+    // MARK: - URLSessionTaskDelegate
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        guard let transaction = metrics.transactionMetrics.last else {
+            return
+        }
+
+        let attributes = buildTimingAttributes(from: transaction)
+
+        emitTimingLog(attributes: attributes, redirectCount: metrics.redirectCount)
+    }
+
+    // MARK: - Attribute Building
+
+    /// Converts `URLSessionTaskTransactionMetrics` dates into epoch-millisecond attributes.
+    private func buildTimingAttributes(
+        from transaction: URLSessionTaskTransactionMetrics
+    ) -> [String: AttributeValue] {
+        buildTimingAttributes(
+            fetchStart: transaction.fetchStartDate,
+            domainLookupStart: transaction.domainLookupStartDate,
+            domainLookupEnd: transaction.domainLookupEndDate,
+            connectStart: transaction.connectStartDate,
+            connectEnd: transaction.connectEndDate,
+            secureConnectionStart: transaction.secureConnectionStartDate,
+            secureConnectionEnd: transaction.secureConnectionEndDate,
+            requestStart: transaction.requestStartDate,
+            requestEnd: transaction.requestEndDate,
+            responseStart: transaction.responseStartDate,
+            responseEnd: transaction.responseEndDate
+        )
+    }
+
+    /// Builds timing attributes from individual date values.
+    ///
+    /// Only non-nil dates produce attributes; phases that did not occur (e.g. DNS on a
+    /// reused connection, TLS on plain HTTP) are omitted.
+    func buildTimingAttributes(
+        fetchStart: Date?,
+        domainLookupStart: Date?,
+        domainLookupEnd: Date?,
+        connectStart: Date?,
+        connectEnd: Date?,
+        secureConnectionStart: Date?,
+        secureConnectionEnd: Date?,
+        requestStart: Date?,
+        requestEnd: Date?,
+        responseStart: Date?,
+        responseEnd: Date?
+    ) -> [String: AttributeValue] {
+        var attrs: [String: AttributeValue] = [:]
+
+        setIfPresent(&attrs, key: "http.call.start_time", date: fetchStart)
+        setIfPresent(&attrs, key: "http.call.end_time", date: responseEnd)
+
+        setIfPresent(&attrs, key: "http.dns.start_time", date: domainLookupStart)
+        setIfPresent(&attrs, key: "http.dns.end_time", date: domainLookupEnd)
+
+        setIfPresent(&attrs, key: "http.connect.start_time", date: connectStart)
+        setIfPresent(&attrs, key: "http.connect.end_time", date: connectEnd)
+
+        setIfPresent(&attrs, key: "http.secure_connect.start_time", date: secureConnectionStart)
+        setIfPresent(&attrs, key: "http.secure_connect.end_time", date: secureConnectionEnd)
+
+        // Apple does not separate request headers from body; requestStartDate covers both.
+        setIfPresent(&attrs, key: "http.request.headers.start_time", date: requestStart)
+        setIfPresent(&attrs, key: "http.request.headers.end_time", date: requestStart)
+        setIfPresent(&attrs, key: "http.request.body.start_time", date: requestStart)
+        setIfPresent(&attrs, key: "http.request.body.end_time", date: requestEnd)
+
+        // responseStartDate marks the first byte after response headers are parsed.
+        setIfPresent(&attrs, key: "http.response.headers.start_time", date: responseStart)
+        setIfPresent(&attrs, key: "http.response.headers.end_time", date: responseStart)
+        setIfPresent(&attrs, key: "http.response.body.start_time", date: responseStart)
+        setIfPresent(&attrs, key: "http.response.body.end_time", date: responseEnd)
+
+        return attrs
+    }
+
+    private func setIfPresent(_ attrs: inout [String: AttributeValue], key: String, date: Date?) {
+        guard let date else { return }
+        let epochMillis = Int(date.timeIntervalSince1970 * 1000)
+        attrs[key] = .int(epochMillis)
+    }
+
+    // MARK: - Log Emission
+
+    private func emitTimingLog(attributes: [String: AttributeValue], redirectCount: Int) {
+        var allAttributes = attributes
+
+        allAttributes["event.name"] = .string("http.client.network_timing")
+
+        if redirectCount > 0 {
+            allAttributes["http.redirect_count"] = .int(redirectCount)
+        }
+
+        let logger = OpenTelemetry.instance
+            .loggerProvider
+            .get(instrumentationScopeName: "NetworkInstrumentation")
+
+        logger
+            .logRecordBuilder()
+            .setSpanContext(spanContext)
+            .setSeverity(.info)
+            .setEventName("http.client.network_timing")
+            .setTimestamp(Date())
+            .setAttributes(allAttributes)
+            .emit()
+    }
+}
+
+// MARK: - Attach Helper
+
+/// Attaches a `NetworkTimingCollector` to the task if network timing is enabled.
+///
+/// The collector is stored as an associated object on the task to ensure it is retained
+/// for the duration of the task's lifetime, and set as the task's per-task delegate to
+/// receive `didFinishCollecting` metrics.
+func attachTimingCollectorIfEnabled(to task: URLSessionTask, spanContext: SpanContext) {
+    guard #available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *) else {
+        return
+    }
+
+    guard NetworkInstrumentationManager.shared.getModule()?.isNetworkTimingEnabled == true else {
+        return
+    }
+
+    let collector = NetworkTimingCollector(spanContext: spanContext)
+
+    objc_setAssociatedObject(task, &associatedKeyTimingCollector, collector, .OBJC_ASSOCIATION_RETAIN)
+    task.delegate = collector
+}

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -179,6 +179,7 @@ func createInstrumentedDataTask(
     let task = originalIMP(session, selector, instrumentedRequest)
     objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
     objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+    attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
     return task
 }
 
@@ -204,6 +205,7 @@ func createInstrumentedDownloadTask(
     let task = originalIMP(session, selector, instrumentedRequest)
     objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
     objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+    attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
     return task
 }
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
@@ -361,8 +361,6 @@ func swizzleUploadTaskWithRequestFromFileAndCompletion() {
     method_setImplementation(original, swizzledIMP)
 }
 
-// MARK: - Streamed Upload Task Swizzling
-
 func swizzleUploadTaskWithStreamedRequest() {
     let selector = #selector(URLSession.uploadTask(withStreamedRequest:))
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
@@ -80,6 +80,7 @@ func swizzleDataTaskWithURL() {
         let task = castedRequestIMP(session, requestSelector, instrumentedRequest)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -122,6 +123,7 @@ func swizzleDataTaskWithRequestAndCompletion() {
         let task = castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -183,6 +185,7 @@ func swizzleDataTaskWithURLAndCompletion() {
         let task = castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -223,6 +226,7 @@ func swizzleUploadTaskWithRequestFromData() {
         let task = castedIMP(session, selector, instrumentedRequest, data)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -261,6 +265,7 @@ func swizzleUploadTaskWithRequestFromFile() {
         let task = castedIMP(session, selector, instrumentedRequest, fileURL)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -304,6 +309,7 @@ func swizzleUploadTaskWithRequestFromDataAndCompletion() {
         let task = castedIMP(session, selector, instrumentedRequest, data, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -347,6 +353,7 @@ func swizzleUploadTaskWithRequestFromFileAndCompletion() {
         let task = castedIMP(session, selector, instrumentedRequest, fileURL, wrappedCompletion)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 
@@ -386,6 +393,7 @@ func swizzleUploadTaskWithStreamedRequest() {
         let task = castedIMP(session, selector, instrumentedRequest)
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
+        attachTimingCollectorIfEnabled(to: task, spanContext: span.context)
         return task
     }
 

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingCollectorTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingCollectorTests.swift
@@ -21,68 +21,6 @@ import XCTest
 
 @testable import SplunkNetwork
 
-
-// MARK: - Configuration Tests
-
-final class NetworkTimingConfigurationTests: XCTestCase {
-
-    func testDefaultConfigHasTimingEnabled() {
-        let config = NetworkInstrumentationConfiguration()
-
-        XCTAssertTrue(config.collectNetworkTiming)
-    }
-
-    func testConfigWithTimingDisabled() {
-        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: false)
-
-        XCTAssertFalse(config.collectNetworkTiming)
-        XCTAssertTrue(config.isEnabled)
-        XCTAssertTrue(config.injectTraceHeaders)
-    }
-
-    func testFullConfigPreservesAllParameters() throws {
-        let ignoreURLs = try IgnoreURLs(patterns: Set([".*\\.png$"]))
-
-        let config = NetworkInstrumentationConfiguration(
-            isEnabled: false,
-            ignoreURLs: ignoreURLs,
-            injectTraceHeaders: false,
-            collectNetworkTiming: false
-        )
-
-        XCTAssertFalse(config.isEnabled)
-        XCTAssertNotNil(config.ignoreURLs)
-        XCTAssertFalse(config.injectTraceHeaders)
-        XCTAssertFalse(config.collectNetworkTiming)
-    }
-
-    func testModuleStoresTimingFlag() {
-        let module = NetworkInstrumentation()
-
-        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: true)
-        module.install(with: config, remoteConfiguration: nil)
-
-        XCTAssertTrue(module.isNetworkTimingEnabled)
-
-        addTeardownBlock {
-            module.uninstall()
-        }
-    }
-
-    func testModuleDefaultsTimingToEnabled() {
-        let module = NetworkInstrumentation()
-
-        module.install(with: nil, remoteConfiguration: nil)
-
-        XCTAssertTrue(module.isNetworkTimingEnabled)
-
-        addTeardownBlock {
-            module.uninstall()
-        }
-    }
-}
-
-
 // MARK: - NetworkTimingCollector Tests
 
 @available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
@@ -238,7 +176,6 @@ final class NetworkTimingCollectorTests: XCTestCase {
     }
 }
 
-
 // MARK: - Test Support
 
 /// Holds timing dates for test-driven attribute building without requiring
@@ -256,7 +193,6 @@ struct TimingDates {
     let responseStart: Date?
     let responseEnd: Date?
 }
-
 
 @available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
 extension NetworkTimingCollector {

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingConfigurationTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingConfigurationTests.swift
@@ -1,0 +1,81 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import XCTest
+
+@testable import SplunkNetwork
+
+// MARK: - Configuration Tests
+
+final class NetworkTimingConfigurationTests: XCTestCase {
+
+    func testDefaultConfigHasTimingEnabled() {
+        let config = NetworkInstrumentationConfiguration()
+
+        XCTAssertTrue(config.collectNetworkTiming)
+    }
+
+    func testConfigWithTimingDisabled() {
+        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: false)
+
+        XCTAssertFalse(config.collectNetworkTiming)
+        XCTAssertTrue(config.isEnabled)
+        XCTAssertTrue(config.injectTraceHeaders)
+    }
+
+    func testFullConfigPreservesAllParameters() throws {
+        let ignoreURLs = try IgnoreURLs(patterns: Set([".*\\.png$"]))
+
+        let config = NetworkInstrumentationConfiguration(
+            isEnabled: false,
+            ignoreURLs: ignoreURLs,
+            injectTraceHeaders: false,
+            collectNetworkTiming: false
+        )
+
+        XCTAssertFalse(config.isEnabled)
+        XCTAssertNotNil(config.ignoreURLs)
+        XCTAssertFalse(config.injectTraceHeaders)
+        XCTAssertFalse(config.collectNetworkTiming)
+    }
+
+    func testModuleStoresTimingFlag() {
+        let module = NetworkInstrumentation()
+
+        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: true)
+        module.install(with: config, remoteConfiguration: nil)
+
+        XCTAssertTrue(module.isNetworkTimingEnabled)
+
+        addTeardownBlock {
+            module.uninstall()
+        }
+    }
+
+    func testModuleDefaultsTimingToEnabled() {
+        let module = NetworkInstrumentation()
+
+        module.install(with: nil, remoteConfiguration: nil)
+
+        XCTAssertTrue(module.isNetworkTimingEnabled)
+
+        addTeardownBlock {
+            module.uninstall()
+        }
+    }
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkTimingTests.swift
@@ -1,0 +1,280 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import XCTest
+
+@testable import SplunkNetwork
+
+
+// MARK: - Configuration Tests
+
+final class NetworkTimingConfigurationTests: XCTestCase {
+
+    func testDefaultConfigHasTimingEnabled() {
+        let config = NetworkInstrumentationConfiguration()
+
+        XCTAssertTrue(config.collectNetworkTiming)
+    }
+
+    func testConfigWithTimingDisabled() {
+        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: false)
+
+        XCTAssertFalse(config.collectNetworkTiming)
+        XCTAssertTrue(config.isEnabled)
+        XCTAssertTrue(config.injectTraceHeaders)
+    }
+
+    func testFullConfigPreservesAllParameters() throws {
+        let ignoreURLs = try IgnoreURLs(patterns: Set([".*\\.png$"]))
+
+        let config = NetworkInstrumentationConfiguration(
+            isEnabled: false,
+            ignoreURLs: ignoreURLs,
+            injectTraceHeaders: false,
+            collectNetworkTiming: false
+        )
+
+        XCTAssertFalse(config.isEnabled)
+        XCTAssertNotNil(config.ignoreURLs)
+        XCTAssertFalse(config.injectTraceHeaders)
+        XCTAssertFalse(config.collectNetworkTiming)
+    }
+
+    func testModuleStoresTimingFlag() {
+        let module = NetworkInstrumentation()
+
+        let config = NetworkInstrumentationConfiguration(collectNetworkTiming: true)
+        module.install(with: config, remoteConfiguration: nil)
+
+        XCTAssertTrue(module.isNetworkTimingEnabled)
+
+        addTeardownBlock {
+            module.uninstall()
+        }
+    }
+
+    func testModuleDefaultsTimingToEnabled() {
+        let module = NetworkInstrumentation()
+
+        module.install(with: nil, remoteConfiguration: nil)
+
+        XCTAssertTrue(module.isNetworkTimingEnabled)
+
+        addTeardownBlock {
+            module.uninstall()
+        }
+    }
+}
+
+
+// MARK: - NetworkTimingCollector Tests
+
+@available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
+final class NetworkTimingCollectorTests: XCTestCase {
+
+    // MARK: - Attribute Building Tests
+
+    func testBuildTimingAttributes_AllDatesPresent() {
+        let spanContext = SpanContext.create(
+            traceId: TraceId.random(),
+            spanId: SpanId.random(),
+            traceFlags: TraceFlags(),
+            traceState: TraceState()
+        )
+        let collector = NetworkTimingCollector(spanContext: spanContext)
+
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let dates = TimingDates(
+            fetchStart: baseDate,
+            domainLookupStart: baseDate.addingTimeInterval(0.010),
+            domainLookupEnd: baseDate.addingTimeInterval(0.050),
+            connectStart: baseDate.addingTimeInterval(0.050),
+            connectEnd: baseDate.addingTimeInterval(0.120),
+            secureConnectionStart: baseDate.addingTimeInterval(0.060),
+            secureConnectionEnd: baseDate.addingTimeInterval(0.110),
+            requestStart: baseDate.addingTimeInterval(0.120),
+            requestEnd: baseDate.addingTimeInterval(0.130),
+            responseStart: baseDate.addingTimeInterval(0.200),
+            responseEnd: baseDate.addingTimeInterval(0.500)
+        )
+
+        let attrs = collector.testBuildTimingAttributes(dates: dates)
+
+        XCTAssertEqual(attrs["http.call.start_time"], .int(1_700_000_000_000))
+        XCTAssertEqual(attrs["http.call.end_time"], .int(1_700_000_000_500))
+
+        XCTAssertEqual(attrs["http.dns.start_time"], .int(1_700_000_000_010))
+        XCTAssertEqual(attrs["http.dns.end_time"], .int(1_700_000_000_050))
+
+        XCTAssertEqual(attrs["http.connect.start_time"], .int(1_700_000_000_050))
+        XCTAssertEqual(attrs["http.connect.end_time"], .int(1_700_000_000_120))
+
+        XCTAssertEqual(attrs["http.secure_connect.start_time"], .int(1_700_000_000_060))
+        XCTAssertEqual(attrs["http.secure_connect.end_time"], .int(1_700_000_000_110))
+
+        XCTAssertEqual(attrs["http.request.headers.start_time"], .int(1_700_000_000_120))
+        XCTAssertEqual(attrs["http.request.body.end_time"], .int(1_700_000_000_130))
+
+        XCTAssertEqual(attrs["http.response.headers.start_time"], .int(1_700_000_000_200))
+        XCTAssertEqual(attrs["http.response.body.end_time"], .int(1_700_000_000_500))
+    }
+
+    func testBuildTimingAttributes_NilDatesOmitted() {
+        let spanContext = SpanContext.create(
+            traceId: TraceId.random(),
+            spanId: SpanId.random(),
+            traceFlags: TraceFlags(),
+            traceState: TraceState()
+        )
+        let collector = NetworkTimingCollector(spanContext: spanContext)
+
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let dates = TimingDates(
+            fetchStart: baseDate,
+            domainLookupStart: nil,
+            domainLookupEnd: nil,
+            connectStart: nil,
+            connectEnd: nil,
+            secureConnectionStart: nil,
+            secureConnectionEnd: nil,
+            requestStart: baseDate.addingTimeInterval(0.010),
+            requestEnd: baseDate.addingTimeInterval(0.020),
+            responseStart: baseDate.addingTimeInterval(0.100),
+            responseEnd: baseDate.addingTimeInterval(0.200)
+        )
+
+        let attrs = collector.testBuildTimingAttributes(dates: dates)
+
+        XCTAssertEqual(attrs["http.call.start_time"], .int(1_700_000_000_000))
+        XCTAssertNotNil(attrs["http.request.headers.start_time"])
+        XCTAssertNotNil(attrs["http.response.body.end_time"])
+
+        XCTAssertNil(attrs["http.dns.start_time"])
+        XCTAssertNil(attrs["http.dns.end_time"])
+        XCTAssertNil(attrs["http.connect.start_time"])
+        XCTAssertNil(attrs["http.connect.end_time"])
+        XCTAssertNil(attrs["http.secure_connect.start_time"])
+        XCTAssertNil(attrs["http.secure_connect.end_time"])
+    }
+
+    func testBuildTimingAttributes_ConnectionError_PartialData() {
+        let spanContext = SpanContext.create(
+            traceId: TraceId.random(),
+            spanId: SpanId.random(),
+            traceFlags: TraceFlags(),
+            traceState: TraceState()
+        )
+        let collector = NetworkTimingCollector(spanContext: spanContext)
+
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let dates = TimingDates(
+            fetchStart: baseDate,
+            domainLookupStart: baseDate.addingTimeInterval(0.010),
+            domainLookupEnd: baseDate.addingTimeInterval(0.050),
+            connectStart: baseDate.addingTimeInterval(0.050),
+            connectEnd: nil,
+            secureConnectionStart: nil,
+            secureConnectionEnd: nil,
+            requestStart: nil,
+            requestEnd: nil,
+            responseStart: nil,
+            responseEnd: nil
+        )
+
+        let attrs = collector.testBuildTimingAttributes(dates: dates)
+
+        XCTAssertEqual(attrs["http.call.start_time"], .int(1_700_000_000_000))
+        XCTAssertNil(attrs["http.call.end_time"])
+        XCTAssertEqual(attrs["http.dns.start_time"], .int(1_700_000_000_010))
+        XCTAssertEqual(attrs["http.dns.end_time"], .int(1_700_000_000_050))
+        XCTAssertEqual(attrs["http.connect.start_time"], .int(1_700_000_000_050))
+        XCTAssertNil(attrs["http.connect.end_time"])
+        XCTAssertNil(attrs["http.request.headers.start_time"])
+        XCTAssertNil(attrs["http.response.headers.start_time"])
+    }
+
+    func testBuildTimingAttributes_AllNilDates() {
+        let spanContext = SpanContext.create(
+            traceId: TraceId.random(),
+            spanId: SpanId.random(),
+            traceFlags: TraceFlags(),
+            traceState: TraceState()
+        )
+        let collector = NetworkTimingCollector(spanContext: spanContext)
+
+        let dates = TimingDates(
+            fetchStart: nil,
+            domainLookupStart: nil,
+            domainLookupEnd: nil,
+            connectStart: nil,
+            connectEnd: nil,
+            secureConnectionStart: nil,
+            secureConnectionEnd: nil,
+            requestStart: nil,
+            requestEnd: nil,
+            responseStart: nil,
+            responseEnd: nil
+        )
+
+        let attrs = collector.testBuildTimingAttributes(dates: dates)
+
+        XCTAssertTrue(attrs.isEmpty)
+    }
+}
+
+
+// MARK: - Test Support
+
+/// Holds timing dates for test-driven attribute building without requiring
+/// a real `URLSessionTaskTransactionMetrics` instance.
+struct TimingDates {
+    let fetchStart: Date?
+    let domainLookupStart: Date?
+    let domainLookupEnd: Date?
+    let connectStart: Date?
+    let connectEnd: Date?
+    let secureConnectionStart: Date?
+    let secureConnectionEnd: Date?
+    let requestStart: Date?
+    let requestEnd: Date?
+    let responseStart: Date?
+    let responseEnd: Date?
+}
+
+
+@available(iOS 15, tvOS 15, macCatalyst 15, visionOS 1, *)
+extension NetworkTimingCollector {
+
+    /// Test-only entry point into the attribute building logic.
+    func testBuildTimingAttributes(dates: TimingDates) -> [String: AttributeValue] {
+        buildTimingAttributes(
+            fetchStart: dates.fetchStart,
+            domainLookupStart: dates.domainLookupStart,
+            domainLookupEnd: dates.domainLookupEnd,
+            connectStart: dates.connectStart,
+            connectEnd: dates.connectEnd,
+            secureConnectionStart: dates.secureConnectionStart,
+            secureConnectionEnd: dates.secureConnectionEnd,
+            requestStart: dates.requestStart,
+            requestEnd: dates.requestEnd,
+            responseStart: dates.responseStart,
+            responseEnd: dates.responseEnd
+        )
+    }
+}


### PR DESCRIPTION
## Research HTTP breakdown metrics POC

## DO NOT MERGE - Sample POC only

### Description

- Emit a [standalone log record](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.52.0/specification/logs/data-model.md) containing following top level fields and attributes:

- Top Level Fields:
  - EventName = “http.client.network_timing“
  - SpanContext = context from the original Http client span
  - Severity = INFO


- The same InstrumentationScope as the original HTTP span
  - AttributeKey.longKey("http.call.start_time"),
  - AttributeKey.longKey("http.call.end_time"),
  - AttributeKey.longKey("http.dns.start_time"),
  - AttributeKey.longKey("http.dns.end_time"),
  - AttributeKey.longKey("http.connect.start_time"),
  - AttributeKey.longKey("http.connect.end_time"),
  - AttributeKey.longKey("http.secure_connect.start_time"),
  - AttributeKey.longKey("http.secure_connect.end_time"),
  - AttributeKey.longKey("http.request.headers.start_time"),
  - AttributeKey.longKey("http.request.headers.end_time"),
  - AttributeKey.longKey("http.request.body.start_time"),
  - AttributeKey.longKey("http.request.body.end_time"),
  - AttributeKey.longKey("http.response.headers.start_time"),
  - AttributeKey.longKey("http.response.headers.end_time"),
  - AttributeKey.longKey("http.response.body.start_time"),
  - AttributeKey.longKey("http.response.body.end_time"));

- Boolean configuration to replicate all original Http span attributes to this log record so backend can use just this one signal to generate metrics. 

- Edge cases to also cater to:
  - In case of connection error also, this log is emitted with whatever available data is present (connection related timestamps). 
  - [If needed - if not a rare scenario] Prevent log record from leaking in some potential scenarios where the callbacks emitting the log record might not be called for some reason - indefinite hangs during response reading, http client not closed / concluded proactively, abrupt crashes/app terminations, improper setup of the http client leading to leaking of this signal etc.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [ ] I have performed a self-review of my code.
- [ ] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

