### PR TITLE
DEMRUM-4982: Fix XCFramework build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,8 @@ brew install swiftlint
 2. Implement the `Module` protocol in `<ModuleName>+Module.swift`
 3. Create configuration types implementing `ModuleConfiguration` and `RemoteModuleConfiguration`
 4. Add target to `Package.swift` in `generateMainTargets()`
-5. Add test target with builders and mocks
+5. Update `tools/xcframework/Project.swift` to keep the xcframework target graph, platform settings, and dependencies in sync with `Package.swift`
+6. Add test target with builders and mocks
 
 ### Adding a Public API Method
 
@@ -192,6 +193,8 @@ brew install swiftlint
 - During PR review, call out missing CHANGELOG.md updates whenever a change is client-visible
 - Client-visible changes include public API changes and significant behavior changes that affect client applications
 - If such a change is present without a corresponding changelog entry, flag it explicitly in the review and request an update
+- During PR review, when `Package.swift` changes targets, products, supported platforms, or module dependencies, verify that `tools/xcframework/Project.swift` is updated to stay in sync, and vice versa
+- If one manifest changes without the corresponding update in the other manifest, flag it explicitly as a likely xcframework build drift issue
 
 ## Dependencies
 

--- a/tools/xcframework/Project.swift
+++ b/tools/xcframework/Project.swift
@@ -345,6 +345,9 @@ let project = Project(
             product: .framework,
             bundleId: "com.splunk.rum.webview",
             sources: "\(repoRoot)/SplunkWebView/Sources/**",
+            resources: [
+                .glob(pattern: "\(repoRoot)/SplunkWebView/Resources/**")
+            ],
             dependencies: [
                 mod("SplunkCommon"),
                 dep("CiscoLogger")


### PR DESCRIPTION
## DEMRUM-4982: Fix XCFramework build

### Description

The PR fixes an agent Project.swift drift away from Package.swift. Project.swift is used to generate an Xcode project to build agent xcframeworks. Atm there is no sync mechanism, so the drift happened in earlier PR updating Package.swift. 

The PR does not bring any sync mechanism. For now It just updates agents.md in order let llms catch a potential drift.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

`make clean build validate smoke-test` in `tools/xcframework`.

### Future Considerations (Optional)

We should implement a better Project.swift and Package.swift syncing mechanism in the future.