### PR TITLE
DEMRUM-3468: Present session id notifications publicly

### DIFF
--- a/Applications/DevelApp/DevelApp/AgentDataSource.swift
+++ b/Applications/DevelApp/DevelApp/AgentDataSource.swift
@@ -42,7 +42,7 @@ class AgentDataSource: ObservableObject {
     // MARK: - Session publisher for handling session resets
 
     private let sessionPublisher = NotificationCenter.default
-        .publisher(for: NSNotification.Name("com.splunk.rum.session-did-reset"))
+        .publisher(for: Session.sessionDidResetNotification)
         .receive(on: DispatchQueue.main)
 
     private var cancellables: Set<AnyCancellable> = []

--- a/Applications/DevelApp/DevelApp/SessionReplayDemoView.swift
+++ b/Applications/DevelApp/DevelApp/SessionReplayDemoView.swift
@@ -38,9 +38,7 @@ struct SessionReplayDemoView: View {
     private var agentStatus = SplunkRum.shared.state.status
 
     let sessionPublisher = NotificationCenter.default
-        .publisher(
-            for: NSNotification.Name("com.splunk.rum.session-did-reset")
-        )
+        .publisher(for: Session.sessionDidResetNotification)
         .receive(on: DispatchQueue.main)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* Added public references to sessionWillResetNotification and sessionDidResetNotification
+
 ## [2.2.1] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-<<<<<<< DEMRUM-3468-Expose-Session-Change-Notification
 * Added public references to sessionWillResetNotification and sessionDidResetNotification
-=======
 * Updated endpoint from signalfx.com to observability.splunkcloud.com
->>>>>>> develop
 * Added optional support to capture network headers.
 
 ## [2.2.1] - 2026-03-19

--- a/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/API-1.0-Session.swift
@@ -85,6 +85,52 @@ extension Session {
 
 extension Session {
 
+    // MARK: - Notifications
+
+    /// Posted before the current session is reset.
+    ///
+    /// The notification `object` is a `String` containing the session ID that is about to be closed.
+    /// There is no `userInfo` dictionary.
+    ///
+    /// This notification is posted when the session is rotated due to inactivity timeout or
+    /// maximum session length being exceeded. It is **not** posted when the initial session is
+    /// created at startup or when the app terminates.
+    ///
+    /// ```swift
+    /// NotificationCenter.default.addObserver(
+    ///     forName: Session.sessionWillResetNotification,
+    ///     object: nil,
+    ///     queue: nil
+    /// ) { notification in
+    ///     let closingSessionId = notification.object as? String
+    /// }
+    /// ```
+    public static let sessionWillResetNotification = DefaultSession.sessionWillResetNotification
+
+    /// Posted after the current session has been reset.
+    ///
+    /// The notification `object` is a `String` containing the session ID of the new session.
+    /// There is no `userInfo` dictionary.
+    ///
+    /// This notification is posted when the session is rotated due to inactivity timeout or
+    /// maximum session length being exceeded. It is **not** posted when the initial session is
+    /// created at startup or when the app terminates.
+    ///
+    /// ```swift
+    /// NotificationCenter.default.addObserver(
+    ///     forName: Session.sessionDidResetNotification,
+    ///     object: nil,
+    ///     queue: nil
+    /// ) { notification in
+    ///     let newSessionId = notification.object as? String
+    /// }
+    /// ```
+    public static let sessionDidResetNotification = DefaultSession.sessionDidResetNotification
+}
+
+
+extension Session {
+
     // MARK: - Identifier
 
     /// Identification of recorded session in given time.


### PR DESCRIPTION
## Title: Expose existing session id change notifications to users

### Description

- Added an extension on the Session class for the two notifications.
- Updated DevelApp to use the new extension rather than hard coded strings 

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Confirm that notifications are received correctly with DevelApp
