### PR TITLE
DEMRUM-5173: Repair Session Replay Start with deferred endpoint confi…

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager+Endpoint.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager+Endpoint.swift
@@ -41,24 +41,13 @@ extension DefaultEventManager {
         concreteTraceProcessor.setEndpoint(traceUrl, accessToken: endpoint.rumAccessToken)
 
         // Replace semantics: the new config fully replaces the old one.
-        // If a session replay URL is provided, update or create the processor.
-        // If omitted, clear the existing processor so it stops sending to the old endpoint.
+        // If a session replay URL is provided, activate the processor (also flushes pending data).
+        // If omitted, switch the processor to pending mode so cached data can be sent later.
         if let sessionReplayUrl = endpoint.sessionReplayEndpoint {
-            if let sessionReplayProcessor {
-                sessionReplayProcessor.setEndpoint(sessionReplayUrl, accessToken: endpoint.rumAccessToken)
-            }
-            else {
-                sessionReplayProcessor = Self.createSessionReplayProcessor(
-                    sessionReplayUrl: sessionReplayUrl,
-                    accessToken: endpoint.rumAccessToken,
-                    configuration: configuration,
-                    agent: agent
-                )
-            }
+            sessionReplayProcessor.setEndpoint(sessionReplayUrl, accessToken: endpoint.rumAccessToken)
         }
-        else if sessionReplayProcessor != nil {
-            sessionReplayProcessor?.clearEndpoint()
-            sessionReplayProcessor = nil
+        else {
+            sessionReplayProcessor.clearEndpoint()
         }
 
         logger.log(level: .info, isPrivate: false) {
@@ -71,7 +60,7 @@ extension DefaultEventManager {
     /// Data is cached to pending storage for later sending when a new endpoint is configured.
     func disableEndpoint() {
         concreteTraceProcessor.clearEndpoint()
-        sessionReplayProcessor?.clearEndpoint()
+        sessionReplayProcessor.clearEndpoint()
 
         logger.log(level: .info, isPrivate: false) {
             "Endpoint disabled. Spans will be cached and sent when endpoint is configured."
@@ -84,11 +73,11 @@ extension DefaultEventManager {
 extension DefaultEventManager {
 
     static func createSessionReplayProcessor(
-        sessionReplayUrl: URL,
+        sessionReplayUrl: URL?,
         accessToken: String?,
         configuration: any AgentConfigurationProtocol,
         agent: SplunkRum
-    ) -> OTLPSessionReplayEventProcessor? {
+    ) -> OTLPSessionReplayEventProcessor {
         let resources = buildResources(configuration: configuration)
 
         return OTLPSessionReplayEventProcessor(
@@ -118,7 +107,7 @@ extension DefaultEventManager {
             debugEnabled: configuration.enableDebugLogging
         )
 
-        // Initialize session replay processor (optional - requires endpoint)
+        // Initialize session replay processor (operates in pending mode when endpoint is nil)
         let replayProcessor = OTLPSessionReplayEventProcessor(
             with: sessionReplayUrl,
             resources: resources,

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -36,7 +36,7 @@ class DefaultEventManager: AgentEventManager {
     /// Container for event processors.
     struct Processors {
         let logEventProcessor: LogEventProcessor
-        let sessionReplayProcessor: OTLPSessionReplayEventProcessor?
+        let sessionReplayProcessor: OTLPSessionReplayEventProcessor
         let traceProcessor: OTLPTraceProcessor
     }
 
@@ -51,7 +51,8 @@ class DefaultEventManager: AgentEventManager {
     private let storedLogEventProcessor: LogEventProcessor
 
     /// Session Replay processor (stored as concrete type for endpoint updates).
-    private var storedSessionReplayProcessor: OTLPSessionReplayEventProcessor?
+    /// Always created at init — operates in pending mode when no endpoint is configured.
+    private var storedSessionReplayProcessor: OTLPSessionReplayEventProcessor
 
     /// Trace processor (stored as concrete type for endpoint updates).
     private let storedTraceProcessor: OTLPTraceProcessor
@@ -71,9 +72,8 @@ class DefaultEventManager: AgentEventManager {
     // MARK: - Internal properties
 
     /// Session Replay processor accessor for endpoint updates.
-    var sessionReplayProcessor: OTLPSessionReplayEventProcessor? {
-        get { storedSessionReplayProcessor }
-        set { storedSessionReplayProcessor = newValue }
+    var sessionReplayProcessor: OTLPSessionReplayEventProcessor {
+        storedSessionReplayProcessor
     }
 
     var sessionReplayIndexer: EventIndexer
@@ -167,9 +167,7 @@ class DefaultEventManager: AgentEventManager {
     }
 
     private func publishSessionReplay(data: Data, metadata: Metadata, completion: @escaping (Bool) -> Void) {
-        guard
-            let sessionReplayProcessor,
-            let sessionId = agent.session.sessionId(for: metadata.timestamp)
+        guard let sessionId = agent.session.sessionId(for: metadata.timestamp)
         else {
             completion(false)
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager.swift
@@ -51,6 +51,7 @@ class DefaultEventManager: AgentEventManager {
     private let storedLogEventProcessor: LogEventProcessor
 
     /// Session Replay processor (stored as concrete type for endpoint updates).
+    ///
     /// Always created at init — operates in pending mode when no endpoint is configured.
     private var storedSessionReplayProcessor: OTLPSessionReplayEventProcessor
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -74,21 +74,13 @@ extension SplunkRum {
 
     // MARK: - Session Replay
 
-    /// Perform operations specific to the SessionReplay module.
+    /// Evaluates Session Replay configuration and sampling, then sets the appropriate proxy.
     ///
     /// The proxy is always created based on config/sampling — endpoint availability
     /// does not gate this decision. When the endpoint is deferred, the underlying
     /// exporter caches replay chunks to disk and flushes them once an endpoint is
     /// provided via ``updateEndpoint(_:)``.
     private func customizeSessionReplay() {
-        initializeSessionReplayProxy()
-    }
-
-    /// Evaluates Session Replay configuration and sampling, then sets the appropriate proxy.
-    ///
-    /// Called once per agent lifecycle — either at startup (if an endpoint is available)
-    /// or when the first endpoint update provides a Session Replay URL.
-    private func initializeSessionReplayProxy() {
         let moduleType = CiscoSessionReplay.SessionReplay.self
         guard let sessionReplayModule = modulesManager?.module(ofType: moduleType) else {
             logger.log(level: .warn, isPrivate: false) {

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -75,46 +75,13 @@ extension SplunkRum {
     // MARK: - Session Replay
 
     /// Perform operations specific to the SessionReplay module.
+    ///
+    /// The proxy is always created based on config/sampling — endpoint availability
+    /// does not gate this decision. When the endpoint is deferred, the underlying
+    /// exporter caches replay chunks to disk and flushes them once an endpoint is
+    /// provided via ``updateEndpoint(_:)``.
     private func customizeSessionReplay() {
-        guard agentConfiguration.endpoint?.sessionReplayEndpoint != nil else {
-            logger.log(level: .warn, isPrivate: false) {
-                """
-                Session Replay module was not installed (the valid URL for Session Replay \
-                endpoint is missing in the Agent configuration).
-                """
-            }
-
-            return
-        }
-
         initializeSessionReplayProxy()
-    }
-
-    /// Enables Session Replay when a valid endpoint becomes available.
-    ///
-    /// This is called from ``updateEndpoint(_:)`` to handle the case where the agent
-    /// started without an endpoint. The config/sampling decision is evaluated at most
-    /// once per agent lifecycle to match the startup path behavior.
-    ///
-    /// - Parameter endpoint: The endpoint configuration to check for Session Replay URL.
-    func enableSessionReplayIfNeeded(for endpoint: EndpointConfiguration) {
-        guard endpoint.sessionReplayEndpoint != nil else {
-            return
-        }
-
-        // The config/sampling decision is made once per agent lifecycle.
-        // If it was already evaluated (at startup or a previous endpoint update), skip.
-        guard !sessionReplayDecisionMade else {
-            return
-        }
-
-        initializeSessionReplayProxy()
-
-        if !(sessionReplayProxy is SessionReplayNonOperational) {
-            logger.log(level: .info, isPrivate: false) {
-                "Session Replay enabled after endpoint configuration."
-            }
-        }
     }
 
     /// Evaluates Session Replay configuration and sampling, then sets the appropriate proxy.

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum+Endpoint.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum+Endpoint.swift
@@ -50,7 +50,6 @@ extension SplunkRum {
 
             currentEndpoint = endpoint
             updateNetworkExclusionList(for: endpoint)
-            enableSessionReplayIfNeeded(for: endpoint)
 
             logger.log(level: .info, isPrivate: false) {
                 "Endpoint configuration updated successfully."

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Events/EventsTests.swift
@@ -56,7 +56,7 @@ final class EventsTests: XCTestCase {
         let requestExpectation = XCTestExpectation(description: "Send request")
 
         let eventManager = try XCTUnwrap(agent?.eventManager as? DefaultEventManager)
-        let sessionReplayProcessor = try XCTUnwrap(eventManager.sessionReplayProcessor as? OTLPSessionReplayEventProcessor)
+        let sessionReplayProcessor = eventManager.sessionReplayProcessor
 
         sessionReplayProcessor.sendEvent(
             event,
@@ -82,7 +82,7 @@ final class EventsTests: XCTestCase {
         let requestExpectation = XCTestExpectation(description: "Send request")
 
         let eventManager = try XCTUnwrap(agent?.eventManager as? DefaultEventManager)
-        let sessionReplayProcessor = try XCTUnwrap(eventManager.sessionReplayProcessor as? OTLPSessionReplayEventProcessor)
+        let sessionReplayProcessor = eventManager.sessionReplayProcessor
 
         sessionReplayProcessor.sendEvent(
             event: event,
@@ -103,7 +103,7 @@ final class EventsTests: XCTestCase {
         let requestExpectation = XCTestExpectation(description: "Send request")
 
         let eventManager = try XCTUnwrap(agent?.eventManager as? DefaultEventManager)
-        let sessionReplayProcessor = try XCTUnwrap(eventManager.sessionReplayProcessor as? OTLPSessionReplayEventProcessor)
+        let sessionReplayProcessor = eventManager.sessionReplayProcessor
 
         sessionReplayProcessor.sendEvent(
             event,

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0+DeferredEndpointTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0+DeferredEndpointTests.swift
@@ -38,9 +38,27 @@ final class API10DeferredEndpointTests: XCTestCase {
     }
 
 
-    // MARK: - Deferred Session Replay
+    // MARK: - Session Replay with Deferred Endpoint
 
-    func testSessionReplayStaysNonOperationalWhenDisabledByConfiguration() throws {
+    func testSessionReplayOperationalAtInstallEvenWithoutEndpoint() throws {
+        let configuration = buildConfigurationWithoutEndpoint()
+        let moduleConfigurations: [Any] = [
+            SessionReplayConfiguration(enabled: true, samplingRate: 1.0)
+        ]
+
+        let installedAgent = try SplunkRum.install(
+            with: configuration,
+            moduleConfigurations: moduleConfigurations
+        )
+
+        XCTAssertTrue(
+            installedAgent.sessionReplayProxy is SessionReplay,
+            "Proxy should be operational at install even without an endpoint"
+        )
+        XCTAssertTrue(installedAgent.sessionReplayDecisionMade)
+    }
+
+    func testSessionReplayNonOperationalWhenDisabledByConfiguration() throws {
         let configuration = buildConfigurationWithoutEndpoint()
         let moduleConfigurations: [Any] = [
             SessionReplayConfiguration(enabled: false, samplingRate: 1.0)
@@ -52,6 +70,7 @@ final class API10DeferredEndpointTests: XCTestCase {
         )
 
         XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
+        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.notStarted))
 
         let endpoint = EndpointConfiguration(
             realm: ConfigurationTestBuilder.realm,
@@ -59,11 +78,13 @@ final class API10DeferredEndpointTests: XCTestCase {
         )
         try installedAgent.updateEndpoint(endpoint)
 
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.notStarted))
+        XCTAssertTrue(
+            installedAgent.sessionReplayProxy is SessionReplayNonOperational,
+            "Endpoint update must not re-evaluate a disabled configuration"
+        )
     }
 
-    func testSessionReplayStaysNonOperationalWhenSampledOut() throws {
+    func testSessionReplayNonOperationalWhenSampledOut() throws {
         let configuration = buildConfigurationWithoutEndpoint()
         let moduleConfigurations: [Any] = [
             SessionReplayConfiguration(enabled: true, samplingRate: 0.0)
@@ -75,6 +96,7 @@ final class API10DeferredEndpointTests: XCTestCase {
         )
 
         XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
+        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.disabledBySampling))
 
         let endpoint = EndpointConfiguration(
             realm: ConfigurationTestBuilder.realm,
@@ -82,11 +104,13 @@ final class API10DeferredEndpointTests: XCTestCase {
         )
         try installedAgent.updateEndpoint(endpoint)
 
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.disabledBySampling))
+        XCTAssertTrue(
+            installedAgent.sessionReplayProxy is SessionReplayNonOperational,
+            "Endpoint update must not re-evaluate a sampled-out decision"
+        )
     }
 
-    func testSessionReplayBecomesOperationalWhenEnabledAndSampledIn() throws {
+    func testSessionReplayRemainsOperationalAfterEndpointUpdate() throws {
         let configuration = buildConfigurationWithoutEndpoint()
         let moduleConfigurations: [Any] = [
             SessionReplayConfiguration(enabled: true, samplingRate: 1.0)
@@ -96,28 +120,8 @@ final class API10DeferredEndpointTests: XCTestCase {
             with: configuration,
             moduleConfigurations: moduleConfigurations
         )
-
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-
-        let endpoint = EndpointConfiguration(
-            realm: ConfigurationTestBuilder.realm,
-            rumAccessToken: ConfigurationTestBuilder.rumAccessToken
-        )
-        try installedAgent.updateEndpoint(endpoint)
 
         XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplay)
-    }
-
-    func testSessionReplayDecisionIsNotReEvaluatedOnSubsequentUpdates() throws {
-        let configuration = buildConfigurationWithoutEndpoint()
-        let moduleConfigurations: [Any] = [
-            SessionReplayConfiguration(enabled: true, samplingRate: 0.0)
-        ]
-
-        let installedAgent = try SplunkRum.install(
-            with: configuration,
-            moduleConfigurations: moduleConfigurations
-        )
 
         let endpoint = EndpointConfiguration(
             realm: ConfigurationTestBuilder.realm,
@@ -125,21 +129,13 @@ final class API10DeferredEndpointTests: XCTestCase {
         )
         try installedAgent.updateEndpoint(endpoint)
 
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.disabledBySampling))
-
-        // A second endpoint update must not re-evaluate the sampling decision
-        let secondEndpoint = EndpointConfiguration(
-            realm: "us1",
-            rumAccessToken: ConfigurationTestBuilder.rumAccessToken
+        XCTAssertTrue(
+            installedAgent.sessionReplayProxy is SessionReplay,
+            "Proxy must stay operational after endpoint is provided"
         )
-        try installedAgent.updateEndpoint(secondEndpoint)
-
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-        XCTAssertEqual(installedAgent.sessionReplay.state.status, .notRecording(.disabledBySampling))
     }
 
-    func testWithoutReplayUrlDoesNotPreventLaterEvaluation() throws {
+    func testSessionReplayRemainsOperationalWithTraceOnlyEndpoint() throws {
         let configuration = buildConfigurationWithoutEndpoint()
         let moduleConfigurations: [Any] = [
             SessionReplayConfiguration(enabled: true, samplingRate: 1.0)
@@ -150,24 +146,16 @@ final class API10DeferredEndpointTests: XCTestCase {
             moduleConfigurations: moduleConfigurations
         )
 
-        // First endpoint has trace only — no session replay URL
+        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplay)
+
         let traceUrl = try ConfigurationTestBuilder.customUrl(for: ConfigurationTestBuilder.customTraceAddress)
         let traceOnlyEndpoint = EndpointConfiguration(trace: traceUrl)
         try installedAgent.updateEndpoint(traceOnlyEndpoint)
 
-        // Decision should NOT have been made yet (no replay URL to trigger it)
-        XCTAssertFalse(installedAgent.sessionReplayDecisionMade)
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplayNonOperational)
-
-        // Second endpoint includes a session replay URL — should now evaluate
-        let fullEndpoint = EndpointConfiguration(
-            realm: ConfigurationTestBuilder.realm,
-            rumAccessToken: ConfigurationTestBuilder.rumAccessToken
+        XCTAssertTrue(
+            installedAgent.sessionReplayProxy is SessionReplay,
+            "Trace-only endpoint must not affect the already-operational proxy"
         )
-        try installedAgent.updateEndpoint(fullEndpoint)
-
-        XCTAssertTrue(installedAgent.sessionReplayDecisionMade)
-        XCTAssertTrue(installedAgent.sessionReplayProxy is SessionReplay)
     }
 
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
@@ -62,7 +62,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
 
     // MARK: - Initialization
 
-    public required init?(
+    public required init(
         with sessionReplayEndpoint: URL?,
         resources: AgentResources,
         runtimeAttributes: RuntimeAttributes,
@@ -70,12 +70,6 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         debugEnabled: Bool,
         accessToken: String? = nil
     ) {
-        // Session replay requires an endpoint - return nil if not provided
-        // (unlike traces, session replay data shouldn't be cached indefinitely)
-        guard let sessionReplayEndpoint else {
-            return nil
-        }
-
         let configuration = OTLPExporterConfiguration()
         let envVarHeaders: [(String, String)] = []
         var headers: [String: String] = [:]
@@ -84,7 +78,8 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
             headers["X-SF-Token"] = accessToken
         }
 
-        // Initialize background exporter
+        // When sessionReplayEndpoint is nil the exporter operates in pending
+        // mode — data is cached to disk and flushed once setEndpoint() is called.
         backgroundLogExporter = OTLPBackgroundHTTPLogExporterBinary(
             endpoint: sessionReplayEndpoint,
             config: configuration,


### PR DESCRIPTION
…guration

## Title: Repair Session Replay Start with deferred endpoint configuration

### Description

- Session Replay no longer waits on operational endpoint
- Session Replay processor is always created, even with nil endpoint
- Session Replay publish no longer drops events prior to processor running

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Re perform the test(s) described in the ticket