### PR TITLE
DEMRUM-4779: Integrate navigation module in SplunkAgent proxy and ObjC surfaces

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Module/Navigation.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Module/Navigation.swift
@@ -27,7 +27,15 @@ final class Navigation: NavigationModule {
 
     // MARK: - Preferences
 
-    var preferences: any NavigationModulePreferences
+    var preferences: any NavigationModulePreferences {
+        didSet {
+            // Link preferences with module instance
+            (preferences as? NavigationPreferences)?.module = module
+
+            // Pass changes into the module
+            module.preferences.enableAutomatedTracking = preferences.enableAutomatedTracking
+        }
+    }
 
     @discardableResult
     func preferences(_ preferences: any NavigationModulePreferences) -> any NavigationModule {

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Non-Operational/NavigationNonOperational.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Non-Operational/NavigationNonOperational.swift
@@ -63,7 +63,7 @@ final class NavigationNonOperational: NavigationModule {
     init() {
         logger = DefaultLogAgent(
             poolName: PackageIdentifier.nonOperationalInstance(),
-            category: "SessionReplay"
+            category: "Navigation"
         )
 
         // Build "dummy" Navigation module

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationConfigurationObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationConfigurationObjCTests.m
@@ -41,6 +41,13 @@ limitations under the License.
     XCTAssertNotNil(fullConfiguration);
 }
 
+- (void)testDefaultValues {
+    SPLKNavigationConfiguration *configuration = [[SPLKNavigationConfiguration alloc] init];
+
+    XCTAssertTrue(configuration.isEnabled);
+    XCTAssertFalse(configuration.enableAutomatedTracking);
+}
+
 - (void)testProperties {
     SPLKNavigationConfiguration *configuration = [[SPLKNavigationConfiguration alloc] init];
 

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
@@ -34,6 +34,10 @@ limitations under the License.
     SPLKNavigationModulePreferences *preferences = [[SPLKNavigationModulePreferences alloc] initWithEnableAutomatedTracking:NO];
     agent.navigation.preferences = preferences;
     XCTAssertFalse(agent.navigation.preferences.enableAutomatedTracking);
+
+    SPLKNavigationModulePreferences *enabledPreferences = [[SPLKNavigationModulePreferences alloc] initWithEnableAutomatedTracking:YES];
+    agent.navigation.preferences = enabledPreferences;
+    XCTAssertTrue(agent.navigation.preferences.enableAutomatedTracking);
 }
 
 - (void)testState {
@@ -41,11 +45,6 @@ limitations under the License.
     SPLKNavigationModuleState *state = agent.navigation.state;
     XCTAssertNotNil(state);
     XCTAssertFalse(state.isAutomatedTrackingEnabled);
-}
-
-- (void)testDefaultState {
-    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
-    XCTAssertFalse(agent.navigation.state.isAutomatedTrackingEnabled);
 }
 
 - (void)testTracking {
@@ -57,16 +56,6 @@ limitations under the License.
     SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
     SPLKNavigationModule *result = [agent.navigation trackScreen:@"ScreenA"];
     XCTAssertNotNil(result);
-}
-
-- (void)testPreferencesRoundTrip {
-    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
-
-    SPLKNavigationModulePreferences *preferences = [[SPLKNavigationModulePreferences alloc] initWithEnableAutomatedTracking:YES];
-    agent.navigation.preferences = preferences;
-
-    XCTAssertNotNil(agent.navigation.preferences);
-    XCTAssertTrue(agent.navigation.preferences.enableAutomatedTracking);
 }
 
 @end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
@@ -43,9 +43,30 @@ limitations under the License.
     XCTAssertFalse(state.isAutomatedTrackingEnabled);
 }
 
+- (void)testDefaultState {
+    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
+    XCTAssertFalse(agent.navigation.state.isAutomatedTrackingEnabled);
+}
+
 - (void)testTracking {
     SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
     XCTAssertNoThrow([agent.navigation trackScreen:@"Test"]);
+}
+
+- (void)testTrackingChaining {
+    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
+    SPLKNavigationModule *result = [agent.navigation trackScreen:@"ScreenA"];
+    XCTAssertNotNil(result);
+}
+
+- (void)testPreferencesRoundTrip {
+    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
+
+    SPLKNavigationModulePreferences *preferences = [[SPLKNavigationModulePreferences alloc] initWithEnableAutomatedTracking:YES];
+    agent.navigation.preferences = preferences;
+
+    XCTAssertNotNil(agent.navigation.preferences);
+    XCTAssertTrue(agent.navigation.preferences.enableAutomatedTracking);
 }
 
 @end

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
@@ -80,7 +80,6 @@ final class NavigationAPI10ModuleProxyTests: XCTestCase {
         XCTAssertTrue(result as AnyObject === moduleProxy)
     }
 
-
     // MARK: - State
 
     func testState() throws {

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
@@ -73,6 +73,14 @@ final class NavigationAPI10ModuleProxyTests: XCTestCase {
     }
 
 
+    func testPreferencesChainingReturnsSelf() throws {
+        let moduleProxy = try XCTUnwrap(moduleProxy)
+        let preferences = NavigationPreferences()
+        let result = moduleProxy.preferences(preferences)
+        XCTAssertTrue(result as AnyObject === moduleProxy)
+    }
+
+
     // MARK: - State
 
     func testState() throws {
@@ -85,11 +93,24 @@ final class NavigationAPI10ModuleProxyTests: XCTestCase {
         XCTAssertFalse(defaultAutomatedTracking)
     }
 
+    func testStateReflectsPreferencesChange() throws {
+        let moduleProxy = try XCTUnwrap(moduleProxy)
+        moduleProxy.preferences = NavigationPreferences()
+            .enableAutomatedTracking(true)
+        XCTAssertTrue(moduleProxy.state.isAutomatedTrackingEnabled)
+    }
+
 
     // MARK: - Manual detection
 
     func testTracking() throws {
         let moduleProxy = try XCTUnwrap(moduleProxy)
         XCTAssertNotNil(moduleProxy.track(screen: "Test"))
+    }
+
+    func testTrackingReturnsSelf() throws {
+        let moduleProxy = try XCTUnwrap(moduleProxy)
+        let result = moduleProxy.track(screen: "Test")
+        XCTAssertTrue(result as AnyObject === moduleProxy)
     }
 }

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
@@ -48,7 +48,6 @@ final class NavigationAPI10NoOpProxyTests: XCTestCase {
         }
     }
 
-
     func testPreferencesSetterIsNoOp() {
         let preferences = NavigationPreferences()
             .enableAutomatedTracking(true)

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
@@ -49,6 +49,23 @@ final class NavigationAPI10NoOpProxyTests: XCTestCase {
     }
 
 
+    func testPreferencesSetterIsNoOp() {
+        let preferences = NavigationPreferences()
+            .enableAutomatedTracking(true)
+
+        moduleProxy.preferences = preferences
+
+        let readBack = moduleProxy.preferences
+        XCTAssertNil(readBack.enableAutomatedTracking)
+    }
+
+    func testPreferencesChainingReturnsSelf() {
+        let preferences = NavigationPreferences()
+        let result = moduleProxy.preferences(preferences)
+        XCTAssertTrue(result as AnyObject === moduleProxy)
+    }
+
+
     // MARK: - State
 
     func testState() {
@@ -65,5 +82,10 @@ final class NavigationAPI10NoOpProxyTests: XCTestCase {
 
     func testTracking() {
         XCTAssertNotNil(moduleProxy.track(screen: "Test"))
+    }
+
+    func testTrackingReturnsSelf() {
+        let result = moduleProxy.track(screen: "Test")
+        XCTAssertTrue(result as AnyObject === moduleProxy)
     }
 }


### PR DESCRIPTION
### Title: Integrate navigation module in SplunkAgent proxy and ObjC surfaces

### Description

* Wire up Navigation proxy preferences setter to forward enableAutomatedTracking to the underlying module and link the module instance
* Fix NavigationNonOperational logger category from "SessionReplay" to "Navigation"
* Add Swift proxy tests: preferences chaining, state reflects preference changes, tracking returns self
* Add non-operational proxy tests: preferences setter is no-op, chaining returns self, tracking returns self
* Add ObjC tests: default configuration values, default state, tracking chaining, preferences round-trip

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### Testing

Added unit tests:

NavigationAPI10ModuleProxyTests — preferences chaining, state reflection, tracking identity
NavigationAPI10NoOpProxyTests — no-op preferences, chaining, tracking identity
API-1.0-NavigationConfigurationObjCTests — default values
API-1.0-NavigationModuleObjCTests — default state, tracking chaining, preferences round-trip
