### PR TITLE
DEMRUM-4657: add SwiftUI .trackScreen view modifier

### DIFF
--- a/Applications/DevelApp/DevelApp.xcodeproj/project.pbxproj
+++ b/Applications/DevelApp/DevelApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		522DB6CA2DC135920047FBCD /* SessionReplayDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522DB6C92DC135920047FBCD /* SessionReplayDemoView.swift */; };
 		522DB6CC2DC135BC0047FBCD /* TemplateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522DB6CB2DC135BC0047FBCD /* TemplateView.swift */; };
 		5238CC822DFB6AD400206F6C /* ObjCExceptionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5238CC812DFB6AD400206F6C /* ObjCExceptionHelper.m */; };
+		523B33F62F910612008BEA1B /* NavigationTrackingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523B33F52F910612008BEA1B /* NavigationTrackingDemoView.swift */; };
 		524479292DE7EEA200E93C77 /* CustomTrackingDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524479282DE7EE9C00E93C77 /* CustomTrackingDemoView.swift */; };
 		524EA8C62F3E87C0004650AF /* WebViewSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524EA8C42F3E87C0004650AF /* WebViewSectionView.swift */; };
 		524EA8C72F3E87C0004650AF /* WebDemoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524EA8C22F3E87C0004650AF /* WebDemoButton.swift */; };
@@ -46,6 +47,7 @@
 		5238CC812DFB6AD400206F6C /* ObjCExceptionHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionHelper.m; sourceTree = "<group>"; };
 		5238CC832DFB6AD600206F6C /* DevelApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DevelApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		5238CC842DFB6AF700206F6C /* ObjCExceptionHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionHelper.h; sourceTree = "<group>"; };
+		523B33F52F910612008BEA1B /* NavigationTrackingDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTrackingDemoView.swift; sourceTree = "<group>"; };
 		524479282DE7EE9C00E93C77 /* CustomTrackingDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTrackingDemoView.swift; sourceTree = "<group>"; };
 		524EA8C12F3E87C0004650AF /* PlaceholderSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderSectionView.swift; sourceTree = "<group>"; };
 		524EA8C22F3E87C0004650AF /* WebDemoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDemoButton.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				527070DF2DC147AB00EDD390 /* AgentDataSource.swift */,
 				527070DD2DC1468100EDD390 /* CrashDemoView.swift */,
 				3384F2892AC8795800512D79 /* DevelAppApp.swift */,
+				523B33F52F910612008BEA1B /* NavigationTrackingDemoView.swift */,
 				522DB6C72DC134C70047FBCD /* RoutingView.swift */,
 				522DB6C92DC135920047FBCD /* SessionReplayDemoView.swift */,
 				522DB6CB2DC135BC0047FBCD /* TemplateView.swift */,
@@ -281,6 +284,7 @@
 				524EA8D32F3E8A13004650AF /* FeatureButton.swift in Sources */,
 				524EA8D12F3E8A11004650AF /* FeatureSection.swift in Sources */,
 				E44D52F72E8AC39B00F5DD9E /* WebViewDemoView.swift in Sources */,
+				523B33F62F910612008BEA1B /* NavigationTrackingDemoView.swift in Sources */,
 				522DB6CC2DC135BC0047FBCD /* TemplateView.swift in Sources */,
 				524EA8C62F3E87C0004650AF /* WebViewSectionView.swift in Sources */,
 				524EA8C72F3E87C0004650AF /* WebDemoButton.swift in Sources */,

--- a/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
+++ b/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
@@ -1,0 +1,70 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SplunkAgent
+import SwiftUI
+
+struct NavigationTrackingDemoView: View {
+
+    var body: some View {
+        List {
+            NavigationLink(destination: BasicTrackingView()) {
+                Text("Basic (no attributes)")
+            }
+            NavigationLink(destination: AttributesTrackingView()) {
+                Text("With custom attributes")
+            }
+        }
+        .navigationTitle("Navigation Tracking")
+        .trackScreen("NavigationTrackingDemo")
+    }
+}
+
+
+// MARK: - Demo screens
+
+private struct BasicTrackingView: View {
+
+    var body: some View {
+        VStack {
+            DemoHeaderView()
+            Text("This screen uses .trackScreen without attributes.")
+            Spacer()
+        }
+        .navigationTitle("Basic Tracking")
+        .trackScreen("BasicTracking")
+    }
+}
+
+private struct AttributesTrackingView: View {
+
+    var body: some View {
+        VStack {
+            DemoHeaderView()
+            Text("This screen uses .trackScreen with custom attributes.")
+            Spacer()
+        }
+        .navigationTitle("Attributes Tracking")
+        .trackScreen(
+            "AttributesTracking",
+            attributes: [
+                "demo.feature": "trackScreen",
+                "demo.attributes": true
+            ]
+        )
+    }
+}

--- a/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
+++ b/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
@@ -35,16 +35,36 @@ struct NavigationTrackingDemoView: View {
 }
 
 
+// MARK: - Code snippet
+
+private struct CodeSnippetView: View {
+
+    let code: String
+
+    var body: some View {
+        Text(code)
+            .font(.system(.caption, design: .monospaced))
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(8)
+    }
+}
+
+
 // MARK: - Demo screens
 
 private struct BasicTrackingView: View {
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             DemoHeaderView()
-            Text("This screen uses .trackScreen without attributes.")
+            CodeSnippetView(code: """
+                .trackScreen("BasicTracking")
+                """)
             Spacer()
         }
+        .padding()
         .navigationTitle("Basic Tracking")
         .trackScreen("BasicTracking")
     }
@@ -53,11 +73,20 @@ private struct BasicTrackingView: View {
 private struct AttributesTrackingView: View {
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             DemoHeaderView()
-            Text("This screen uses .trackScreen with custom attributes.")
+            CodeSnippetView(code: """
+                .trackScreen(
+                    "AttributesTracking",
+                    attributes: [
+                        "demo.feature": "trackScreen",
+                        "demo.attributes": true
+                    ]
+                )
+                """)
             Spacer()
         }
+        .padding()
         .navigationTitle("Attributes Tracking")
         .trackScreen(
             "AttributesTracking",

--- a/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
+++ b/Applications/DevelApp/DevelApp/NavigationTrackingDemoView.swift
@@ -59,9 +59,11 @@ private struct BasicTrackingView: View {
     var body: some View {
         VStack(spacing: 16) {
             DemoHeaderView()
-            CodeSnippetView(code: """
-                .trackScreen("BasicTracking")
-                """)
+            CodeSnippetView(
+                code: """
+                    .trackScreen("BasicTracking")
+                    """
+            )
             Spacer()
         }
         .padding()
@@ -75,15 +77,17 @@ private struct AttributesTrackingView: View {
     var body: some View {
         VStack(spacing: 16) {
             DemoHeaderView()
-            CodeSnippetView(code: """
-                .trackScreen(
-                    "AttributesTracking",
-                    attributes: [
-                        "demo.feature": "trackScreen",
-                        "demo.attributes": true
-                    ]
-                )
-                """)
+            CodeSnippetView(
+                code: """
+                    .trackScreen(
+                        "AttributesTracking",
+                        attributes: [
+                            "demo.feature": "trackScreen",
+                            "demo.attributes": true
+                        ]
+                    )
+                    """
+            )
             Spacer()
         }
         .padding()

--- a/Applications/DevelApp/DevelApp/RoutingView.swift
+++ b/Applications/DevelApp/DevelApp/RoutingView.swift
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import SplunkAgent
 import SwiftUI
 
 struct RoutingView: View {
@@ -38,6 +39,7 @@ struct RoutingView: View {
                 }
             }
             .navigationTitle("Demo Screens")
+            .trackScreen("DemoScreens")
         }
     }
 }

--- a/Applications/DevelApp/DevelApp/RoutingView.swift
+++ b/Applications/DevelApp/DevelApp/RoutingView.swift
@@ -34,6 +34,9 @@ struct RoutingView: View {
                 NavigationLink(destination: WebViewDemoView()) {
                     Text("WebViewNativeBridge Demo")
                 }
+                NavigationLink(destination: NavigationTrackingDemoView()) {
+                    Text("Navigation Tracking Demo")
+                }
                 NavigationLink(destination: TemplateView()) {
                     Text("Template for New Screens")
                 }

--- a/Applications/DevelApp/DevelApp/TemplateView.swift
+++ b/Applications/DevelApp/DevelApp/TemplateView.swift
@@ -29,7 +29,7 @@ struct TemplateView: View {
             Spacer()
         }
         .navigationTitle("Your title")
-        .trackScreen("Template", attributes: ["template.id": "demo"])
+        .trackScreen("Template")
         Spacer()
     }
 

--- a/Applications/DevelApp/DevelApp/TemplateView.swift
+++ b/Applications/DevelApp/DevelApp/TemplateView.swift
@@ -29,7 +29,7 @@ struct TemplateView: View {
             Spacer()
         }
         .navigationTitle("Your title")
-        .trackScreen("Template")
+        .trackScreen("Template", attributes: ["template.id": "demo"])
         Spacer()
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added public references to sessionWillResetNotification and sessionDidResetNotification
 * Added optional support to capture network headers.
 * Session Replay now captures text content in wireframes for UIKit applications.
+* Added `.trackScreen` SwiftUI view modifier for manual screen name tracking with optional custom attributes.
 
 ### Changed
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Internal/TrackScreenModifier.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Internal/TrackScreenModifier.swift
@@ -30,6 +30,10 @@ struct TrackScreenModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onAppear {
+                // .onAppear can fire multiple times during the SwiftUI view lifecycle
+                // (redraws, tab switches, etc.). Navigation.track(screen:) deduplicates
+                // by comparing against the current screen name, so repeated calls with
+                // the same name are no-ops and do not generate additional spans.
                 SplunkRum.shared.navigation.track(screen: screenName, attributes: attributes)
             }
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Internal/TrackScreenModifier.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Internal/TrackScreenModifier.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,25 +15,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import SplunkAgent
 import SwiftUI
 
-struct TemplateView: View {
-    var body: some View {
-        VStack {
-            DemoHeaderView()
-            Text("Clone this and add your content")
-            Button("Do something") {
-                doSomething()
-            }
-            Spacer()
-        }
-        .navigationTitle("Your title")
-        .trackScreen("Template")
-        Spacer()
-    }
+struct TrackScreenModifier: ViewModifier {
 
-    func doSomething() {
-        print("did something")
+    // MARK: - Properties
+
+    let screenName: String
+    let attributes: [String: Any]?
+
+
+    // MARK: - ViewModifier methods
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                SplunkRum.shared.navigation.track(screen: screenName, attributes: attributes)
+            }
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Module/Navigation+Tracking.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Module/Navigation+Tracking.swift
@@ -25,4 +25,11 @@ extension Navigation {
 
         return self
     }
+
+    @discardableResult
+    func track(screen name: String, attributes: [String: Any]?) -> any NavigationModule {
+        module.track(screen: name, attributes: attributes)
+
+        return self
+    }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Non-Operational/NavigationNonOperational+Tracking.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Proxies/Non-Operational/NavigationNonOperational+Tracking.swift
@@ -25,4 +25,11 @@ extension NavigationNonOperational {
 
         return self
     }
+
+    @discardableResult
+    func track(screen _: String, attributes _: [String: Any]?) -> any NavigationModule {
+        logAccess(toApi: #function)
+
+        return self
+    }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-Navigation+SwiftUI.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-Navigation+SwiftUI.swift
@@ -1,0 +1,68 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SwiftUI
+
+extension View {
+
+    // MARK: - Screen tracking (SwiftUI)
+
+    /// Tracks the screen name when this view appears.
+    ///
+    /// Use this modifier to manually set the current screen name for navigation tracking
+    /// in SwiftUI views. The screen name is reported each time the view appears.
+    ///
+    /// ```swift
+    /// struct ProductDetailView: View {
+    ///     var body: some View {
+    ///         VStack { ... }
+    ///             .trackScreen("ProductDetail")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter name: The screen name to track.
+    ///
+    /// - Returns: The `View` with screen tracking applied.
+    public func trackScreen(_ name: String) -> some View {
+        modifier(TrackScreenModifier(screenName: name, attributes: nil))
+    }
+
+    /// Tracks the screen name with additional attributes when this view appears.
+    ///
+    /// ```swift
+    /// struct ProductDetailView: View {
+    ///     let productId: String
+    ///
+    ///     var body: some View {
+    ///         VStack { ... }
+    ///             .trackScreen("ProductDetail", attributes: [
+    ///                 "product.id": productId
+    ///             ])
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - name: The screen name to track.
+    ///   - attributes: Optional attributes associated with the screen tracking event.
+    ///
+    /// - Returns: The `View` with screen tracking applied.
+    public func trackScreen(_ name: String, attributes: [String: Any]?) -> some View {
+        modifier(TrackScreenModifier(screenName: name, attributes: attributes))
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-Navigation+SwiftUI.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-Navigation+SwiftUI.swift
@@ -60,6 +60,8 @@ extension View {
     /// - Parameters:
     ///   - name: The screen name to track.
     ///   - attributes: Optional attributes associated with the screen tracking event.
+    ///     Supported value types: `String`, `Int`, `Double`, `Bool`, and arrays of those types.
+    ///     Other types are converted to their string representation.
     ///
     /// - Returns: The `View` with screen tracking applied.
     public func trackScreen(_ name: String, attributes: [String: Any]?) -> some View {

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
@@ -51,4 +51,16 @@ public protocol NavigationModule: ObservableObject {
     /// - Note: The set value is not linked to any specific UI element.
     @discardableResult
     func track(screen name: String) -> any NavigationModule
+
+    /// Sets a manual screen name with custom attributes. This setting is valid until a new name is set.
+    ///
+    /// - Parameters:
+    ///   - name: The name to be tracked as the screen name until being changed.
+    ///   - attributes: Optional custom key-value pairs to attach to the navigation span.
+    ///
+    /// - Returns: The actual ``NavigationModule`` instance.
+    ///
+    /// - Note: The set value is not linked to any specific UI element.
+    @discardableResult
+    func track(screen name: String, attributes: [String: Any]?) -> any NavigationModule
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Public API/API-1.0-NavigationModule.swift
@@ -57,6 +57,8 @@ public protocol NavigationModule: ObservableObject {
     /// - Parameters:
     ///   - name: The name to be tracked as the screen name until being changed.
     ///   - attributes: Optional custom key-value pairs to attach to the navigation span.
+    ///     Supported value types: `String`, `Int`, `Double`, `Bool`, and arrays of those types.
+    ///     Other types are converted to their string representation.
     ///
     /// - Returns: The actual ``NavigationModule`` instance.
     ///

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationModuleObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationModuleObjC.swift
@@ -71,6 +71,23 @@ public final class NavigationModuleObjC: NSObject {
         return self
     }
 
+    /// Sets a manual screen name with custom attributes (setting is valid until a new name is set).
+    ///
+    /// - Parameters:
+    ///   - name: The name to be tracked as the screen name until being changed.
+    ///   - attributes: Optional custom key-value pairs to attach to the navigation span.
+    ///
+    /// - Returns: The actual ``NavigationModuleObjC`` instance.
+    ///
+    /// - Note: The set value is not linked to any specific UI element.
+    @discardableResult
+    @objc(trackScreen:attributes:)
+    public func track(screen name: String, attributes: NSDictionary?) -> NavigationModuleObjC {
+        owner.agent.navigation.track(screen: name, attributes: attributes as? [String: Any])
+
+        return self
+    }
+
 
     // MARK: - Initialization
 

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationModuleObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationModuleObjC.swift
@@ -76,6 +76,8 @@ public final class NavigationModuleObjC: NSObject {
     /// - Parameters:
     ///   - name: The name to be tracked as the screen name until being changed.
     ///   - attributes: Optional custom key-value pairs to attach to the navigation span.
+    ///     Supported value types: `NSString`, `NSNumber` (integer, double, boolean), and arrays of those types.
+    ///     Other types are converted to their string representation.
     ///
     /// - Returns: The actual ``NavigationModuleObjC`` instance.
     ///
@@ -87,7 +89,6 @@ public final class NavigationModuleObjC: NSObject {
 
         return self
     }
-
 
     // MARK: - Initialization
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-Navigation+SwiftUITests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-Navigation+SwiftUITests.swift
@@ -1,0 +1,56 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SwiftUI
+import XCTest
+
+@testable import SplunkAgent
+
+final class NavigationSwiftUITests: XCTestCase {
+
+    func testTrackScreenModifierProducesView() {
+        let view = Text("Hello")
+            .trackScreen("TestScreen")
+
+        XCTAssertNotNil(view)
+    }
+
+    func testTrackScreenModifierAcceptsDifferentViews() {
+        let textView = Text("Screen A").trackScreen("ScreenA")
+        let stackView = VStack { Text("Screen B") }.trackScreen("ScreenB")
+
+        XCTAssertNotNil(textView)
+        XCTAssertNotNil(stackView)
+    }
+
+    func testTrackScreenModifierAcceptsAttributes() {
+        let view = Text("Hello")
+            .trackScreen("TestScreen", attributes: [
+                "product.id": "A-1234",
+                "product.category": "electronics"
+            ])
+
+        XCTAssertNotNil(view)
+    }
+
+    func testTrackScreenModifierAcceptsNilAttributes() {
+        let view = Text("Hello")
+            .trackScreen("TestScreen", attributes: nil)
+
+        XCTAssertNotNil(view)
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-Navigation+SwiftUITests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-Navigation+SwiftUITests.swift
@@ -38,11 +38,13 @@ final class NavigationSwiftUITests: XCTestCase {
     }
 
     func testTrackScreenModifierAcceptsAttributes() {
+        let attributes: [String: Any] = [
+            "product.id": "A-1234",
+            "product.category": "electronics"
+        ]
+
         let view = Text("Hello")
-            .trackScreen("TestScreen", attributes: [
-                "product.id": "A-1234",
-                "product.category": "electronics"
-            ])
+            .trackScreen("TestScreen", attributes: attributes)
 
         XCTAssertNotNil(view)
     }

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationModuleProxyTests.swift
@@ -92,4 +92,14 @@ final class NavigationAPI10ModuleProxyTests: XCTestCase {
         let moduleProxy = try XCTUnwrap(moduleProxy)
         XCTAssertNotNil(moduleProxy.track(screen: "Test"))
     }
+
+    func testTrackingWithAttributes() throws {
+        let moduleProxy = try XCTUnwrap(moduleProxy)
+        XCTAssertNotNil(moduleProxy.track(screen: "Test", attributes: ["product.id": "A-1234"]))
+    }
+
+    func testTrackingWithNilAttributes() throws {
+        let moduleProxy = try XCTUnwrap(moduleProxy)
+        XCTAssertNotNil(moduleProxy.track(screen: "Test", attributes: nil))
+    }
 }

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/Navigation/API-1.0-NavigationNonOperationalProxyTests.swift
@@ -66,4 +66,12 @@ final class NavigationAPI10NoOpProxyTests: XCTestCase {
     func testTracking() {
         XCTAssertNotNil(moduleProxy.track(screen: "Test"))
     }
+
+    func testTrackingWithAttributes() {
+        XCTAssertNotNil(moduleProxy.track(screen: "Test", attributes: ["product.id": "A-1234"]))
+    }
+
+    func testTrackingWithNilAttributes() {
+        XCTAssertNotNil(moduleProxy.track(screen: "Test", attributes: nil))
+    }
 }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -65,7 +65,7 @@ extension Navigation {
         navigationSpan.end(time: navigationEnd)
     }
 
-    func send(screenName: String, lastScreenName: String, start: Date) {
+    func send(screenName: String, lastScreenName: String, start: Date, attributes: [String: Any]? = nil) {
         // A new zero length span for change screen name event
         let screenNameSpan =
             tracer
@@ -76,6 +76,12 @@ extension Navigation {
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
         screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
+
+        if let attributes {
+            for (key, value) in attributes {
+                screenNameSpan.clearAndSetAttribute(key: key, value: value)
+            }
+        }
 
         screenNameSpan.end(time: start)
     }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Tracking.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Tracking.swift
@@ -22,6 +22,10 @@ extension Navigation {
     // MARK: - Manual detection
 
     public func track(screen name: String) {
+        track(screen: name, attributes: nil)
+    }
+
+    public func track(screen name: String, attributes: [String: Any]?) {
         let start = Date()
 
         Task {
@@ -43,7 +47,7 @@ extension Navigation {
             continuation.yield(name)
 
             // Send corresponding span
-            send(screenName: name, lastScreenName: lastScreenName, start: start)
+            send(screenName: name, lastScreenName: lastScreenName, start: start, attributes: attributes)
         }
     }
 }


### PR DESCRIPTION
## Title: Add SwiftUI .trackScreen view modifier

### Description

* Add a `.trackScreen(_:)` SwiftUI `View` modifier for manual screen name tracking, with an optional `attributes:` overload for attaching custom metadata.                                                 
* Internally backed by `TrackScreenModifier`, which reports the screen name via `SplunkRum.shared.navigation.track(screen:attributes:)` on each `onAppear`.
* Add example usage in DevelApp (`RoutingView`, `NavigationTrackingDemoView`) and unit tests.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Includes unit tests
