### PR TITLE
DEMRUM-5282: Add navigation.name attribute to navigation spans

### DIFF
--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -27,6 +27,7 @@ extension Navigation {
     private static let componentKey = "component"
     private static let navigationSpanName = "app.ui.navigation"
 
+    private static let navigationNameKey = "navigation.name"
     private static let screenNameKey = "screen.name"
     private static let lastScreenNameKey = "last.screen.name"
 
@@ -58,6 +59,7 @@ extension Navigation {
         navigationSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
 
         let screenName = navigation.screenName
+        navigationSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
         navigationSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: screenName)
         navigationSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 
@@ -74,6 +76,7 @@ extension Navigation {
             .startSpan()
 
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
+        screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
         screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -59,7 +59,6 @@ extension Navigation {
         navigationSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
 
         let screenName = navigation.screenName
-        navigationSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
         navigationSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: screenName)
         navigationSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 


### PR DESCRIPTION
## Title: Add navigation.name attribute to navigation spans

###  Description:

Add `navigation.name` attribute to `app.ui.navigation` spans, matching the app.ui.* spec and Android
behavior. The value is the same as `screen.name`, set on both duration spans and zero-length screen
change spans.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

For this iteration we will rely on inspection of the session data received in the back end UI as part of the scheduled test ticket DEMRUM-5120.
