### PR TITLE
DEMRUM-5307: Move Navigation ObjC interop from SplunkNavigation to SplunkAgentObjC

### DIFF
--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavigationConfigurationObjC+Conversions.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavigationConfigurationObjC+Conversions.swift
@@ -16,17 +16,22 @@ limitations under the License.
 */
 
 internal import SplunkCommon
-import SplunkNavigation
+internal import SplunkNavigation
 
 extension NavigationConfigurationObjC: ModuleConfigurationSwift {
 
     // MARK: - Swift variant
 
     var moduleConfiguration: any SplunkCommon.ModuleConfiguration {
-        NavigationConfiguration(
+        // Wrap the ObjC processor in an adapter if provided
+        let swiftProcessor: (any NavigationEventProcessor)? =
+            navigationEventProcessor
+            .map { NavigationEventProcessorAdapter(wrapping: $0) }
+
+        return NavigationConfiguration(
             isEnabled: isEnabled,
             enableAutomatedTracking: enableAutomatedTracking,
-            navigationEventProcessor: navigationEventProcessor
+            navigationEventProcessor: swiftProcessor
         )
     }
 }

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavigationEventProcessorObjC+Adapter.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavigationEventProcessorObjC+Adapter.swift
@@ -1,0 +1,49 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+internal import SplunkNavigation
+
+/// Adapts an Objective-C ``NavigationEventProcessorObjC`` to the Swift
+/// ``NavigationEventProcessor`` protocol used by the navigation engine.
+final class NavigationEventProcessorAdapter: NavigationEventProcessor {
+
+    // MARK: - Private
+
+    private let objcProcessor: any NavigationEventProcessorObjC
+
+
+    // MARK: - Initialization
+
+    init(wrapping objcProcessor: any NavigationEventProcessorObjC) {
+        self.objcProcessor = objcProcessor
+    }
+
+
+    // MARK: - NavigationEventProcessor
+
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent? {
+        guard let objcEvent = objcProcessor.onViewController(typeName: typeName, controllerIdentity: controllerIdentity) else {
+            return nil
+        }
+
+        return NavigationEvent(
+            name: objcEvent.name,
+            controllerIdentity: objcEvent.controllerIdentity,
+            attributes: objcEvent.attributes as? [String: Any]
+        )
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-DefaultNavigationEventProcessorObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-DefaultNavigationEventProcessorObjC.swift
@@ -1,0 +1,46 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// The default processor that passes navigation events through unchanged.
+///
+/// This processor returns the sanitized controller type name as the screen name
+/// with no additional attributes. It is used automatically when no custom
+/// ``NavigationEventProcessorObjC`` is configured.
+@objc(SPLKDefaultNavigationEventProcessor)
+public final class DefaultNavigationEventProcessorObjC: NSObject, NavigationEventProcessorObjC {
+
+    // MARK: - Initialization
+
+    @objc
+    override public init() {
+        super.init()
+    }
+
+
+    // MARK: - Processor methods
+
+    @objc(onViewControllerWithTypeName:controllerIdentity:)
+    public func onViewController(typeName: String, controllerIdentity: String) -> NavigationEventObjC? {
+        NavigationEventObjC(
+            name: typeName,
+            controllerIdentity: controllerIdentity,
+            attributes: nil
+        )
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationConfigurationObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationConfigurationObjC.swift
@@ -16,9 +16,12 @@ limitations under the License.
 */
 
 import Foundation
-import SplunkNavigation
 
-/// The class implements the Navigation module configuration.
+/// Objective-C configuration for the navigation module.
+///
+/// Use this class to enable automated navigation tracking and optionally
+/// configure a ``NavigationEventProcessorObjC`` to customize screen names,
+/// add span attributes, or suppress specific navigation events.
 @objc(SPLKNavigationConfiguration)
 @objcMembers
 public final class NavigationConfigurationObjC: ModuleConfigurationObjC {
@@ -30,8 +33,16 @@ public final class NavigationConfigurationObjC: ModuleConfigurationObjC {
     /// Default value is `NO`.
     public var enableAutomatedTracking: Bool = false
 
-    /// Processor used to transform automated navigation events before they produce spans.
-    public var navigationEventProcessor: NavigationEventProcessor?
+    /// Processor that intercepts automated navigation events before they produce spans.
+    ///
+    /// Set a custom ``NavigationEventProcessorObjC`` to rename screens, add span attributes,
+    /// or suppress specific events by returning `nil` from the processor method.
+    /// When `nil`, the default processor passes the controller type name through unchanged.
+    ///
+    /// - Important: The processor is retained strongly by the SDK for the lifetime
+    ///   of the agent. Avoid capturing references that transitively own `SplunkRum`;
+    ///   prefer stateless processors or weak captures where needed.
+    public var navigationEventProcessor: NavigationEventProcessorObjC?
 
 
     // MARK: - Initialization
@@ -72,7 +83,7 @@ public final class NavigationConfigurationObjC: ModuleConfigurationObjC {
     public init(
         isEnabled: Bool,
         enableAutomatedTracking: Bool,
-        navigationEventProcessor: NavigationEventProcessor?
+        navigationEventProcessor: NavigationEventProcessorObjC?
     ) {
         super.init()
 

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationEventProcessorObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/API-1.0-NavigationEventProcessorObjC.swift
@@ -1,0 +1,48 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// A processor that intercepts automated navigation events before they produce spans.
+///
+/// Implement this protocol to customize how detected `UIViewController` transitions
+/// are named, enriched, or filtered. The processor is called once per automated
+/// navigation event; manual ``NavigationModuleObjC/track(screen:)`` calls bypass it.
+///
+/// Assign your processor to
+/// ``NavigationConfigurationObjC/navigationEventProcessor`` before starting the agent.
+@objc(SPLKNavigationEventProcessor)
+public protocol NavigationEventProcessorObjC {
+
+    // MARK: - Processor methods
+
+    /// Called for each detected `UIViewController` navigation event.
+    ///
+    /// Return a ``NavigationEventObjC`` to allow the navigation — potentially with a
+    /// transformed name or additional attributes — or return `nil` to suppress it.
+    ///
+    /// - Parameters:
+    ///   - typeName: The view controller's class name. The SDK strips the
+    ///     application module prefix before invoking this method, so your
+    ///     callback will receive `"DetailViewController"` as the value of
+    ///     this parameter rather than `"MyApp.DetailViewController"`.
+    ///   - controllerIdentity: `NSString` representation of the controller's object identifier.
+    ///
+    /// - Returns: A navigation event describing the screen, or `nil` to suppress.
+    @objc(onViewControllerWithTypeName:controllerIdentity:)
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEventObjC?
+}

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/Models/API-1.0-NavigationEventObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Public API/Models/API-1.0-NavigationEventObjC.swift
@@ -19,35 +19,31 @@ import Foundation
 
 /// The result of processing an automated navigation event.
 ///
-/// Returned by ``NavigationEventProcessor/onViewController(typeName:controllerIdentity:)``
+/// Returned by ``NavigationEventProcessorObjC/onViewController(typeName:controllerIdentity:)``
 /// to describe how a detected screen transition should be recorded. The ``name`` becomes the
 /// `navigation.name` span attribute, and any ``attributes`` are added to the navigation span.
-public final class NavigationEvent {
+@objc(SPLKNavigationEvent)
+public final class NavigationEventObjC: NSObject {
 
     // MARK: - Public
 
     /// The screen name to use for this navigation event.
     ///
     /// This value is set as the `navigation.name` and `screen.name` span attributes.
+    @objc
     public let name: String
 
-    /// An opaque string that identifies the tracked view controller instance.
-    ///
-    /// The value is:
-    /// - **Opaque** — consumers must not parse it or derive the underlying controller.
-    /// - **Unique** among simultaneously live instances within a single process.
-    /// - **Stable** for the lifetime of the controller instance.
-    /// - **Reusable** — the same value may appear after the instance is deallocated.
-    /// - **Not persistent** across app launches.
-    ///
-    /// Use `==` (or `-isEqualToString:` from Objective-C) for comparison.
+    /// `NSString` representation of the tracked view controller identity.
+    @objc
     public let controllerIdentity: String
 
     /// Custom attributes to include in the navigation span.
     ///
     /// Use this to enrich navigation spans with application-specific metadata
     /// (e.g., content identifiers, feature flags, or section names).
-    public let attributes: [String: Any]?
+    /// Supported value types: `NSString`, `NSNumber` (integer, double, boolean), and arrays of those types.
+    @objc
+    public let attributes: NSDictionary?
 
 
     // MARK: - Initialization
@@ -56,12 +52,13 @@ public final class NavigationEvent {
     ///
     /// - Parameters:
     ///   - name: The screen name for this navigation event.
-    ///   - controllerIdentity: String representation of the view controller identity.
+    ///   - controllerIdentity: `NSString` representation of the view controller identity.
     ///   - attributes: Optional custom attributes to include in the navigation span.
+    @objc(initWithName:controllerIdentity:attributes:)
     public init(
         name: String,
         controllerIdentity: String,
-        attributes: [String: Any]? = nil
+        attributes: NSDictionary?
     ) {
         self.name = name
         self.controllerIdentity = controllerIdentity

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationConfigurationObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationConfigurationObjCTests.m
@@ -36,9 +36,13 @@ limitations under the License.
 
     SPLKNavigationConfiguration *fullConfiguration = [[SPLKNavigationConfiguration alloc] initWithEnabled:NO automatedTracking:NO];
 
+    SPLKDefaultNavigationEventProcessor *processor = [[SPLKDefaultNavigationEventProcessor alloc] init];
+    SPLKNavigationConfiguration *fullWithProcessor = [[SPLKNavigationConfiguration alloc] initWithEnabled:YES automatedTracking:YES navigationEventProcessor:processor];
+
     XCTAssertNotNil(defaultConfiguration);
     XCTAssertNotNil(minimalConfiguration);
     XCTAssertNotNil(fullConfiguration);
+    XCTAssertNotNil(fullWithProcessor);
 }
 
 - (void)testDefaultValues {
@@ -46,6 +50,7 @@ limitations under the License.
 
     XCTAssertTrue(configuration.isEnabled);
     XCTAssertFalse(configuration.enableAutomatedTracking);
+    XCTAssertNil(configuration.navigationEventProcessor);
 }
 
 - (void)testProperties {
@@ -65,6 +70,22 @@ limitations under the License.
 
     XCTAssertEqual(configuration.isEnabled, NO);
     XCTAssertEqual(configuration.enableAutomatedTracking, YES);
+}
+
+- (void)testNavigationEventProcessorProperty {
+    SPLKNavigationConfiguration *configuration = [[SPLKNavigationConfiguration alloc] init];
+
+    // Default is nil
+    XCTAssertNil(configuration.navigationEventProcessor);
+
+    // Assign a processor
+    SPLKDefaultNavigationEventProcessor *processor = [[SPLKDefaultNavigationEventProcessor alloc] init];
+    configuration.navigationEventProcessor = processor;
+    XCTAssertNotNil(configuration.navigationEventProcessor);
+
+    // Clear the processor
+    configuration.navigationEventProcessor = nil;
+    XCTAssertNil(configuration.navigationEventProcessor);
 }
 
 @end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationEventProcessorObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationEventProcessorObjCTests.m
@@ -1,0 +1,175 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#import <XCTest/XCTest.h>
+
+@import SplunkAgentObjC;
+
+
+// MARK: - Test processor that renames screens
+
+@interface PrefixingProcessor : NSObject <SPLKNavigationEventProcessor>
+
+@property (nonatomic, copy) NSString *prefix;
+
+@end
+
+
+@implementation PrefixingProcessor
+
+- (instancetype)initWithPrefix:(NSString *)prefix {
+    self = [super init];
+    if (self) {
+        _prefix = [prefix copy];
+    }
+    return self;
+}
+
+- (SPLKNavigationEvent * _Nullable)onViewControllerWithTypeName:(NSString *)typeName
+                                             controllerIdentity:(NSString *)controllerIdentity {
+    NSString *name = [NSString stringWithFormat:@"%@/%@", self.prefix, typeName];
+    return [[SPLKNavigationEvent alloc] initWithName:name
+                                  controllerIdentity:controllerIdentity
+                                          attributes:nil];
+}
+
+@end
+
+
+// MARK: - Test processor that suppresses all events
+
+@interface SuppressingProcessor : NSObject <SPLKNavigationEventProcessor>
+
+@end
+
+
+@implementation SuppressingProcessor
+
+- (SPLKNavigationEvent * _Nullable)onViewControllerWithTypeName:(NSString *)typeName
+                                             controllerIdentity:(NSString *)controllerIdentity {
+    return nil;
+}
+
+@end
+
+
+// MARK: - Tests
+
+@interface NavigationAPI10EventProcessorObjCTests : XCTestCase
+
+@end
+
+
+@implementation NavigationAPI10EventProcessorObjCTests
+
+// MARK: - NavigationEvent Tests
+
+- (void)testNavigationEventInitialization {
+    SPLKNavigationEvent *event = [[SPLKNavigationEvent alloc] initWithName:@"HomeScreen"
+                                                        controllerIdentity:@"0x12345"
+                                                                attributes:nil];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqualObjects(event.name, @"HomeScreen");
+    XCTAssertEqualObjects(event.controllerIdentity, @"0x12345");
+    XCTAssertNil(event.attributes);
+}
+
+- (void)testNavigationEventWithAttributes {
+    NSDictionary *attributes = @{@"app.section": @"settings", @"app.level": @42};
+
+    SPLKNavigationEvent *event = [[SPLKNavigationEvent alloc] initWithName:@"SettingsScreen"
+                                                        controllerIdentity:@"0xABCDE"
+                                                                attributes:attributes];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqualObjects(event.name, @"SettingsScreen");
+    XCTAssertEqualObjects(event.controllerIdentity, @"0xABCDE");
+    XCTAssertNotNil(event.attributes);
+    XCTAssertEqualObjects(event.attributes[@"app.section"], @"settings");
+    XCTAssertEqualObjects(event.attributes[@"app.level"], @42);
+}
+
+
+// MARK: - DefaultNavigationEventProcessor Tests
+
+- (void)testDefaultProcessorInitialization {
+    SPLKDefaultNavigationEventProcessor *processor = [[SPLKDefaultNavigationEventProcessor alloc] init];
+    XCTAssertNotNil(processor);
+}
+
+- (void)testDefaultProcessorPassesThrough {
+    SPLKDefaultNavigationEventProcessor *processor = [[SPLKDefaultNavigationEventProcessor alloc] init];
+
+    SPLKNavigationEvent *event = [processor onViewControllerWithTypeName:@"DetailViewController"
+                                                     controllerIdentity:@"0x99999"];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqualObjects(event.name, @"DetailViewController");
+    XCTAssertEqualObjects(event.controllerIdentity, @"0x99999");
+    XCTAssertNil(event.attributes);
+}
+
+
+// MARK: - Custom Processor Tests
+
+- (void)testCustomProcessorRenames {
+    PrefixingProcessor *processor = [[PrefixingProcessor alloc] initWithPrefix:@"MyApp"];
+
+    SPLKNavigationEvent *event = [processor onViewControllerWithTypeName:@"HomeVC"
+                                                     controllerIdentity:@"0x11111"];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqualObjects(event.name, @"MyApp/HomeVC");
+    XCTAssertEqualObjects(event.controllerIdentity, @"0x11111");
+}
+
+- (void)testCustomProcessorSuppresses {
+    SuppressingProcessor *processor = [[SuppressingProcessor alloc] init];
+
+    SPLKNavigationEvent *event = [processor onViewControllerWithTypeName:@"InternalVC"
+                                                     controllerIdentity:@"0x22222"];
+
+    XCTAssertNil(event);
+}
+
+
+// MARK: - Configuration Integration Tests
+
+- (void)testConfigurationWithCustomProcessor {
+    PrefixingProcessor *processor = [[PrefixingProcessor alloc] initWithPrefix:@"App"];
+
+    SPLKNavigationConfiguration *config = [[SPLKNavigationConfiguration alloc] initWithEnabled:YES
+                                                                            automatedTracking:YES
+                                                                     navigationEventProcessor:processor];
+
+    XCTAssertNotNil(config);
+    XCTAssertTrue(config.isEnabled);
+    XCTAssertTrue(config.enableAutomatedTracking);
+    XCTAssertNotNil(config.navigationEventProcessor);
+}
+
+- (void)testConfigurationWithNilProcessor {
+    SPLKNavigationConfiguration *config = [[SPLKNavigationConfiguration alloc] initWithEnabled:YES
+                                                                            automatedTracking:YES
+                                                                     navigationEventProcessor:nil];
+
+    XCTAssertNotNil(config);
+    XCTAssertNil(config.navigationEventProcessor);
+}
+
+@end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/Navigation/API-1.0-NavigationModuleObjCTests.m
@@ -58,4 +58,15 @@ limitations under the License.
     XCTAssertNotNil(result);
 }
 
+- (void)testTrackingWithAttributes {
+    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
+    NSDictionary *attributes = @{@"app.section": @"settings", @"app.level": @42};
+    XCTAssertNoThrow([agent.navigation trackScreen:@"Settings" attributes:attributes]);
+}
+
+- (void)testTrackingWithNilAttributes {
+    SPLKAgent *agent = [AgentTestBuilderObjC buildDefault];
+    XCTAssertNoThrow([agent.navigation trackScreen:@"Home" attributes:nil]);
+}
+
 @end

--- a/SplunkNavigation/Sources/SplunkNavigation/Module/NavigationConfiguration.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Module/NavigationConfiguration.swift
@@ -30,9 +30,17 @@ public struct NavigationConfiguration: ModuleConfiguration {
     /// A `Boolean` value determines whether the module should automatically detect navigation in the application.
     public var enableAutomatedTracking: Bool?
 
-    /// Processor used to transform automated navigation events before they produce spans.
+    /// Processor that intercepts automated navigation events before they produce spans.
+    ///
+    /// Set a custom ``NavigationEventProcessor`` to rename screens, add span attributes,
+    /// or suppress specific navigation events. When `nil`, the default processor
+    /// passes the sanitized controller type name through as the screen name.
     ///
     /// Manual ``Navigation/track(screen:)`` calls bypass the processor.
+    ///
+    /// - Important: The processor is retained strongly by the SDK for the lifetime
+    ///   of the agent. Avoid capturing references that transitively own `SplunkRum`;
+    ///   prefer stateless processors or weak captures where needed.
     public var navigationEventProcessor: (any NavigationEventProcessor)?
 
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+NavigationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+NavigationControllerTransitions.swift
@@ -29,10 +29,16 @@ extension Navigation {
 
         let typeName = event.controllerTypeName
         let controllerIdentifier = event.controllerIdentifier
-        let screenName = processAutomatedScreenName(
-            sanitize(typeName: typeName),
-            controllerIdentifier: controllerIdentifier
-        )
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: controllerIdentifier
+            )
+        else {
+            return
+        }
+
+        let screenName = navigationEvent.name
 
         let navigation = NavigationPair(
             type: .show,
@@ -55,7 +61,8 @@ extension Navigation {
         await updateCurrentScreen(
             screenName: screenName,
             lastScreenName: lastScreenName,
-            start: event.timestamp
+            start: event.timestamp,
+            attributes: navigationEvent.attributes
         )
     }
 
@@ -106,16 +113,22 @@ extension Navigation {
         await model.removePendingNavigationTarget(for: navigationControllerIdentifier)
         await model.removeManagedNavigationControllerTarget(pendingTargetIdentifier)
 
-        let screenName = processAutomatedScreenName(
-            sanitize(typeName: visibleControllerTypeName),
-            controllerIdentifier: visibleControllerIdentifier
-        )
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: visibleControllerTypeName),
+                controllerIdentifier: visibleControllerIdentifier
+            )
+        else {
+            return true
+        }
+
         let lastScreenName = await model.screenName
 
         await updateCurrentScreen(
-            screenName: screenName,
+            screenName: navigationEvent.name,
             lastScreenName: lastScreenName,
-            start: timestamp
+            start: timestamp,
+            attributes: navigationEvent.attributes
         )
 
         return true
@@ -124,10 +137,16 @@ extension Navigation {
     private func completeNavigationControllerTransition(event: any NavigationActionEvent) async {
         let typeName = event.controllerTypeName
         let visibleControllerIdentifier = event.controllerIdentifier
-        let screenName = processAutomatedScreenName(
-            sanitize(typeName: typeName),
-            controllerIdentifier: visibleControllerIdentifier
-        )
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: visibleControllerIdentifier
+            )
+        else {
+            return
+        }
+
+        let screenName = navigationEvent.name
         let lastScreenName = await model.screenName
 
         let existingNavigation = await model.navigation(for: visibleControllerIdentifier)
@@ -147,7 +166,8 @@ extension Navigation {
         await updateCurrentScreen(
             screenName: screenName,
             lastScreenName: lastScreenName,
-            start: start
+            start: start,
+            attributes: navigationEvent.attributes
         )
 
         let endEvent = AutomatedNavigationEvent(
@@ -171,7 +191,12 @@ extension Navigation {
         )
     }
 
-    func updateCurrentScreen(screenName: String, lastScreenName: String, start: Date) async {
+    func updateCurrentScreen(
+        screenName: String,
+        lastScreenName: String,
+        start: Date,
+        attributes: [String: Any]? = nil
+    ) async {
         await model.update(screenName: screenName)
         await model.update(isManualScreenName: false)
 
@@ -180,7 +205,8 @@ extension Navigation {
             send(
                 screenName: screenName,
                 lastScreenName: lastScreenName,
-                start: start
+                start: start,
+                attributes: attributes
             )
         }
     }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -89,13 +89,20 @@ extension Navigation {
 
     private func updateTransitionStart(for snapshot: PresentationTransitionSnapshot) async {
         let typeName = snapshot.controllerTypeName
-        let screenName = sanitize(typeName: typeName)
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: snapshot.controllerIdentifier
+            )
+        else {
+            return
+        }
 
         let navigation = NavigationPair(
             type: .transition,
             start: Date(),
             typeName: typeName,
-            screenName: screenName
+            screenName: navigationEvent.name
         )
 
         await model.update(
@@ -114,7 +121,17 @@ extension Navigation {
         }
 
         let typeName = snapshot.controllerTypeName
-        let screenName = sanitize(typeName: typeName)
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: snapshot.controllerIdentifier
+            )
+        else {
+            await model.removeNavigation(for: snapshot.controllerIdentifier)
+            return
+        }
+
+        let screenName = navigationEvent.name
         let lastScreenName = await model.screenName
 
         if await model.navigation(for: snapshot.controllerIdentifier) == nil {
@@ -137,7 +154,8 @@ extension Navigation {
         await updateCurrentScreen(
             screenName: screenName,
             lastScreenName: lastScreenName,
-            start: start
+            start: start,
+            attributes: navigationEvent.attributes
         )
 
         let event = AutomatedNavigationEvent(

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
@@ -47,7 +47,7 @@ public final class Navigation: Sendable {
     /// Assigned once during ``install(with:remoteConfiguration:)`` and must not be
     /// mutated after detection has started. Manual ``track(screen:)`` calls bypass
     /// the processor.
-    private(set) nonisolated(unsafe) var navigationEventProcessor: any NavigationEventProcessor
+    internal(set) nonisolated(unsafe) var navigationEventProcessor: any NavigationEventProcessor
 
 
     // MARK: - Module configuration

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
@@ -44,9 +44,10 @@ public final class Navigation: Sendable {
 
     /// Processor used to transform automated navigation events before they produce spans.
     ///
-    /// Manual ``track(screen:)`` calls bypass the processor.
-    nonisolated(unsafe) var navigationEventProcessor: any NavigationEventProcessor =
-        DefaultNavigationEventProcessor()
+    /// Assigned once during ``install(with:remoteConfiguration:)`` and must not be
+    /// mutated after detection has started. Manual ``track(screen:)`` calls bypass
+    /// the processor.
+    private(set) nonisolated(unsafe) var navigationEventProcessor: any NavigationEventProcessor
 
 
     // MARK: - Module configuration
@@ -103,8 +104,12 @@ public final class Navigation: Sendable {
         )
     }
 
-    init(navigationEventStreamProvider: any NavigationEventStreamProviding) {
+    init(
+        navigationEventStreamProvider: any NavigationEventStreamProviding,
+        navigationEventProcessor: any NavigationEventProcessor = DefaultNavigationEventProcessor()
+    ) {
         self.navigationEventStreamProvider = navigationEventStreamProvider
+        self.navigationEventProcessor = navigationEventProcessor
         // Prepare a stream for screen name changes
         let (screenNameStream, continuation) = AsyncStream.makeStream(of: String.self)
         self.screenNameStream = screenNameStream
@@ -213,10 +218,16 @@ public final class Navigation: Sendable {
         let start = Date()
 
         let typeName = event.controllerTypeName
-        let screenName = processAutomatedScreenName(
-            sanitize(typeName: typeName),
-            controllerIdentifier: event.controllerIdentifier
-        )
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: event.controllerIdentifier
+            )
+        else {
+            return
+        }
+
+        let screenName = navigationEvent.name
         let lastScreenName = await model.screenName
 
         let navigation = NavigationPair(
@@ -235,7 +246,12 @@ public final class Navigation: Sendable {
         if screenName != lastScreenName {
             continuation.yield(screenName)
 
-            send(screenName: screenName, lastScreenName: lastScreenName, start: start)
+            send(
+                screenName: screenName,
+                lastScreenName: lastScreenName,
+                start: start,
+                attributes: navigationEvent.attributes
+            )
         }
     }
 
@@ -244,10 +260,16 @@ public final class Navigation: Sendable {
         let start = Date()
 
         let typeName = event.controllerTypeName
-        let screenName = processAutomatedScreenName(
-            sanitize(typeName: typeName),
-            controllerIdentifier: event.controllerIdentifier
-        )
+        guard
+            let navigationEvent = processAutomatedNavigationEvent(
+                sanitize(typeName: typeName),
+                controllerIdentifier: event.controllerIdentifier
+            )
+        else {
+            return
+        }
+
+        let screenName = navigationEvent.name
         let lastScreenName = await model.screenName
 
         let navigation = NavigationPair(
@@ -265,7 +287,12 @@ public final class Navigation: Sendable {
         // Yield this change to the consumer and send corresponding span
         if screenName != lastScreenName {
             continuation.yield(screenName)
-            send(screenName: screenName, lastScreenName: lastScreenName, start: start)
+            send(
+                screenName: screenName,
+                lastScreenName: lastScreenName,
+                start: start,
+                attributes: navigationEvent.attributes
+            )
         }
     }
 
@@ -329,18 +356,17 @@ public final class Navigation: Sendable {
     }
 
 
-    /// Passes the raw automated screen name through the ``navigationEventProcessor``
-    /// and returns the (potentially transformed) screen name.
-    func processAutomatedScreenName(
-        _ screenName: String,
+    /// Passes the sanitized type name through the ``navigationEventProcessor``
+    /// and returns the processed event, or `nil` if the event was suppressed.
+    func processAutomatedNavigationEvent(
+        _ typeName: String,
         controllerIdentifier: ObjectIdentifier
-    ) -> String {
-        let event = NavigationEvent(
-            screenName: screenName,
-            controllerIdentifier: controllerIdentifier
+    ) -> NavigationEvent? {
+        let controllerIdentity = String(UInt(bitPattern: controllerIdentifier))
+        return navigationEventProcessor.onViewController(
+            typeName: typeName,
+            controllerIdentity: controllerIdentity
         )
-        let processed = navigationEventProcessor.process(event: event)
-        return processed.screenName
     }
 
     func preferredControllerName(for controller: UIViewController) -> String {

--- a/SplunkNavigation/Sources/SplunkNavigation/NavigationEventProcessor.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/NavigationEventProcessor.swift
@@ -17,37 +17,101 @@ limitations under the License.
 
 import Foundation
 
-/// Transforms automated navigation events before they are handled by the module.
-@objc(SPLKNavigationEventProcessor)
+/// A processor that intercepts automated navigation events before they produce spans.
+///
+/// Implement this protocol to customize how detected `UIViewController` transitions
+/// are named, enriched, or filtered. The processor is called once per automated
+/// navigation event; manual ``Navigation/track(screen:)`` calls bypass it.
+///
+/// **Rename a screen:**
+///
+/// ```swift
+/// func onViewController(
+///     typeName: String,
+///     controllerIdentity: String
+/// ) -> NavigationEvent? {
+///     NavigationEvent(
+///         name: friendlyName(for: typeName),
+///         controllerIdentity: controllerIdentity
+///     )
+/// }
+/// ```
+///
+/// **Add custom attributes to the navigation span:**
+///
+/// ```swift
+/// func onViewController(
+///     typeName: String,
+///     controllerIdentity: String
+/// ) -> NavigationEvent? {
+///     NavigationEvent(
+///         name: typeName,
+///         controllerIdentity: controllerIdentity,
+///         attributes: ["app.section": section(for: typeName)]
+///     )
+/// }
+/// ```
+///
+/// **Suppress an event entirely** by returning `nil`:
+///
+/// ```swift
+/// func onViewController(
+///     typeName: String,
+///     controllerIdentity: String
+/// ) -> NavigationEvent? {
+///     shouldIgnore(typeName) ? nil : NavigationEvent(
+///         name: typeName,
+///         controllerIdentity: controllerIdentity
+///     )
+/// }
+/// ```
+///
+/// Assign your processor to
+/// ``NavigationConfiguration/navigationEventProcessor`` before starting the agent.
+///
+/// ## Threading
+///
+/// The callback may be invoked from a background task. Implementations must be
+/// thread-safe or stateless.
 public protocol NavigationEventProcessor {
 
-    // MARK: - Event processing
+    // MARK: - Processor methods
 
-    /// Processes an automated navigation event.
+    /// Called for each detected `UIViewController` navigation event.
     ///
-    /// - Parameter event: The event produced by navigation detection.
+    /// Return a ``NavigationEvent`` to allow the navigation — potentially with a
+    /// transformed name or additional attributes — or return `nil` to suppress it.
     ///
-    /// - Returns: The event to be used by the module.
-    @objc(processEvent:)
-    func process(event: NavigationEvent) -> NavigationEvent
+    /// - Parameters:
+    ///   - typeName: The view controller's class name. The SDK strips the
+    ///     application module prefix before invoking this method, so your
+    ///     callback will receive `"DetailViewController"` as the value of
+    ///     this parameter rather than `"MyApp.DetailViewController"`.
+    ///   - controllerIdentity: String representation of the controller's object identifier.
+    ///
+    /// - Returns: A navigation event describing the screen, or `nil` to suppress.
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent?
 }
 
-/// A pass-through processor used by default.
-@objc(SPLKDefaultNavigationEventProcessor)
-public final class DefaultNavigationEventProcessor: NSObject, NavigationEventProcessor {
+/// The default processor that passes navigation events through unchanged.
+///
+/// This processor returns the sanitized controller type name as the screen name
+/// with no additional attributes. It is used automatically when no custom
+/// ``NavigationEventProcessor`` is configured.
+public final class DefaultNavigationEventProcessor: NavigationEventProcessor {
 
     // MARK: - Initialization
 
-    @objc
-    override public init() {
-        super.init()
-    }
+    public init() {}
 
 
-    // MARK: - Event processing
+    // MARK: - Processor methods
 
-    @objc(processEvent:)
-    public func process(event: NavigationEvent) -> NavigationEvent {
-        event
+    public func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent? {
+        NavigationEvent(
+            name: typeName,
+            controllerIdentity: controllerIdentity,
+            attributes: nil
+        )
     }
 }

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorTests.swift
@@ -18,6 +18,7 @@ limitations under the License.
 internal import CiscoSwizzling
 import Foundation
 @_spi(SplunkTesting) import SplunkCommon
+import UIKit
 import XCTest
 
 @testable import SplunkNavigation
@@ -79,9 +80,9 @@ final class NavigationEventProcessorTests: XCTestCase {
         ])
 
         let navigation = Navigation(
-            navigationEventStreamProvider: MockNavigationEventStreamProvider(stream: events)
+            navigationEventStreamProvider: MockNavigationEventStreamProvider(stream: events),
+            navigationEventProcessor: PrefixingProcessor(prefix: "Custom")
         )
-        navigation.navigationEventProcessor = PrefixingProcessor(prefix: "Custom")
         navigation.preferences.enableAutomatedTracking = true
         navigation.startDetection()
 
@@ -94,14 +95,15 @@ final class NavigationEventProcessorTests: XCTestCase {
     // MARK: - Manual tracking bypass
 
     func testManualTrackBypassesProcessor() async {
-        let fixture = makeNavigationStreamFixture()
+        let fixture = makeNavigationStreamFixture(
+            navigationEventProcessor: RejectingProcessor()
+        )
 
         defer {
             fixture.finish()
         }
 
         let navigation = fixture.navigation
-        navigation.navigationEventProcessor = RejectingProcessor()
         navigation.preferences.enableAutomatedTracking = true
 
         navigation.startDetection()
@@ -115,14 +117,15 @@ final class NavigationEventProcessorTests: XCTestCase {
     }
 
     func testProcessorAppliesToAutomatedButNotManual() async {
-        let fixture = makeNavigationStreamFixture()
+        let fixture = makeNavigationStreamFixture(
+            navigationEventProcessor: PrefixingProcessor(prefix: "Auto")
+        )
 
         defer {
             fixture.finish()
         }
 
         let navigation = fixture.navigation
-        navigation.navigationEventProcessor = PrefixingProcessor(prefix: "Auto")
         navigation.preferences.enableAutomatedTracking = true
 
         navigation.startDetection()
@@ -155,32 +158,163 @@ final class NavigationEventProcessorTests: XCTestCase {
         }
         XCTAssertTrue(didSetAuto)
     }
+
+    // MARK: - Presentation controller processor
+
+    @MainActor
+    func testProcessorOnPresentationTransitions() async {
+        let provider = MockPresentationEventStreamProvider()
+        let navigation = Navigation(
+            navigationEventStreamProvider: provider,
+            navigationEventProcessor: PrefixingProcessor(prefix: "Nav")
+        )
+        navigation.preferences.enableAutomatedTracking = true
+        navigation.startDetection()
+
+        let presentingController = PresentingViewController()
+        let presentedController = PresentedViewController()
+
+        provider.emit(
+            eventType: .presentationWillBegin,
+            presented: presentedController,
+            presenting: presentingController,
+            completed: nil
+        )
+        provider.emit(
+            eventType: .presentationDidEnd,
+            presented: presentedController,
+            presenting: presentingController,
+            completed: true
+        )
+
+        let didUpdate = await waitUntil {
+            await navigation.model.screenName == "Nav/PresentedViewController"
+        }
+        XCTAssertTrue(didUpdate)
+    }
+
+    @MainActor
+    func testProcessorSuppressesPresentations() async {
+        let provider = MockPresentationEventStreamProvider()
+        let navigation = Navigation(
+            navigationEventStreamProvider: provider,
+            navigationEventProcessor: SuppressingProcessor()
+        )
+        navigation.preferences.enableAutomatedTracking = true
+        navigation.startDetection()
+
+        navigation.track(screen: "InitialScreen")
+
+        let didSetInitial = await waitUntil {
+            await navigation.model.screenName == "InitialScreen"
+        }
+        XCTAssertTrue(didSetInitial)
+
+        let presentingController = PresentingViewController()
+        let presentedController = PresentedViewController()
+
+        provider.emit(
+            eventType: .presentationWillBegin,
+            presented: presentedController,
+            presenting: presentingController,
+            completed: nil
+        )
+        provider.emit(
+            eventType: .presentationDidEnd,
+            presented: presentedController,
+            presenting: presentingController,
+            completed: true
+        )
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let currentScreenName = await navigation.model.screenName
+        XCTAssertEqual(currentScreenName, "InitialScreen")
+    }
+
+
+    // MARK: - Event suppression
+
+    func testProcessorNilSuppressesNavigation() async {
+        let fixture = makeNavigationStreamFixture(
+            navigationEventProcessor: SuppressingProcessor()
+        )
+
+        defer {
+            fixture.finish()
+        }
+
+        let navigation = fixture.navigation
+        navigation.preferences.enableAutomatedTracking = true
+
+        navigation.startDetection()
+
+        // Set an initial screen name manually (bypasses processor)
+        navigation.track(screen: "InitialScreen")
+
+        let didSetInitial = await waitUntil {
+            await navigation.model.screenName == "InitialScreen"
+        }
+        XCTAssertTrue(didSetInitial)
+
+        // Send an automated navigation event; the suppressing processor returns nil
+        let detailIdentifier = ObjectIdentifier(NSString())
+        let navigationControllerIdentifier = ObjectIdentifier(NSNumber(value: 10))
+
+        fixture.sendTransition(
+            type: .navigationControllerWillShow,
+            navigationControllerIdentifier: navigationControllerIdentifier,
+            controllerIdentifier: detailIdentifier,
+            controllerTypeName: "SuppressedViewController"
+        )
+        fixture.sendTransition(
+            type: .navigationControllerDidShow,
+            navigationControllerIdentifier: navigationControllerIdentifier,
+            controllerIdentifier: detailIdentifier,
+            controllerTypeName: "SuppressedViewController"
+        )
+
+        // Give the event loop time to process
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // Screen name should remain unchanged because the event was suppressed
+        let currentScreenName = await navigation.model.screenName
+        XCTAssertEqual(currentScreenName, "InitialScreen")
+    }
 }
 
 
 // MARK: - Test processors
 
-private final class PrefixingProcessor: NSObject, NavigationEventProcessor {
+private final class PrefixingProcessor: NavigationEventProcessor {
     let prefix: String
 
     init(prefix: String) {
         self.prefix = prefix
     }
 
-    func process(event: NavigationEvent) -> NavigationEvent {
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent? {
         NavigationEvent(
-            screenName: "\(prefix)/\(event.screenName)",
-            controllerIdentifier: event.controllerIdentifier,
-            attributes: event.attributes
+            name: "\(prefix)/\(typeName)",
+            controllerIdentity: controllerIdentity
         )
     }
 }
 
-private final class RejectingProcessor: NSObject, NavigationEventProcessor {
-    func process(event: NavigationEvent) -> NavigationEvent {
-        NavigationEvent(
-            screenName: "REJECTED",
-            controllerIdentifier: event.controllerIdentifier
+private final class RejectingProcessor: NavigationEventProcessor {
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent? {
+        _ = typeName
+        return NavigationEvent(
+            name: "REJECTED",
+            controllerIdentity: controllerIdentity
         )
+    }
+}
+
+private final class SuppressingProcessor: NavigationEventProcessor {
+    func onViewController(typeName: String, controllerIdentity: String) -> NavigationEvent? {
+        _ = typeName
+        _ = controllerIdentity
+        return nil
     }
 }

--- a/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/NavigationStreamFixture.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/NavigationStreamFixture.swift
@@ -43,7 +43,9 @@ struct NavigationStreamFixture {
 
 // MARK: - Fixture construction
 
-func makeNavigationStreamFixture() -> NavigationStreamFixture {
+func makeNavigationStreamFixture(
+    navigationEventProcessor: any NavigationEventProcessor = DefaultNavigationEventProcessor()
+) -> NavigationStreamFixture {
     let (stream, continuation) = AsyncStream.makeStream(
         of: (any NavigationActionEvent).self
     )
@@ -51,7 +53,8 @@ func makeNavigationStreamFixture() -> NavigationStreamFixture {
     let navigation = Navigation(
         navigationEventStreamProvider: MockNavigationEventStreamProvider(
             stream: stream
-        )
+        ),
+        navigationEventProcessor: navigationEventProcessor
     )
 
     let collector = ScreenNameCollector()


### PR DESCRIPTION
## Title: Move Navigation ObjC interop from SplunkNavigation to SplunkAgentObjC

### Description

The parity branch had NavigationEventProcessor and NavigationEvent implemented as @objc/NSObject types directly in SplunkNavigation. This violates the two-module architecture where SplunkNavigation is pure Swift and all ObjC interop lives in SplunkAgentObjC.

* Strip @objc and NSObject from NavigationEventProcessor and NavigationEvent, making them pure Swift
* Align API shape with spec: onViewController(typeName:controllerIdentity:) -> NavigationEvent?, screenName -> name
* Create proper ObjC wrapper types in SplunkAgentObjC: NavigationEventProcessorObjC protocol, DefaultNavigationEventProcessorObjC, NavigationEventObjC, and internal adapter
* Restore internal import in conversion files
* Update all call sites in Navigation, NavigationController transitions, and PresentationController transitions to route through the processor
* Add ObjC API tests and presentation controller processor tests
* 
These changes were made after we were alerted of the similar issue in DEMRUM-5290.


- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

n/a
