### PR TITLE
DEMRUM-5318: Suppress SwiftUI internal controllers

### DIFF
--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -40,11 +40,11 @@ extension Navigation {
     ]
 
     static func shouldIgnore(controllerTypeName: String) -> Bool {
-        if ignoredControllerTypeNames.contains(controllerTypeName) {
-            return true
-        }
-        return ignoredControllerTypePrefixes.contains { prefix in
-            controllerTypeName.hasPrefix(prefix)
-        }
+        let isExactMatch = ignoredControllerTypeNames
+            .contains(controllerTypeName)
+        let isPrefixMatch = ignoredControllerTypePrefixes
+            .contains { controllerTypeName.hasPrefix($0) }
+        let shouldIgnore = isExactMatch || isPrefixMatch
+        return shouldIgnore
     }
 }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -40,9 +40,11 @@ extension Navigation {
     ]
 
     static func shouldIgnore(controllerTypeName: String) -> Bool {
-        let isExactMatch = ignoredControllerTypeNames
+        let isExactMatch =
+            ignoredControllerTypeNames
             .contains(controllerTypeName)
-        let isPrefixMatch = ignoredControllerTypePrefixes
+        let isPrefixMatch =
+            ignoredControllerTypePrefixes
             .contains { controllerTypeName.hasPrefix($0) }
         return isExactMatch || isPrefixMatch
     }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -32,6 +32,7 @@ extension Navigation {
 
     /// SwiftUI internal controllers whose type names include generic
     /// parameters (e.g. `UIHostingController<ModifiedContent<...>>`).
+    ///
     /// Prefix matching is required because the suffix varies at runtime.
     private static let ignoredControllerTypePrefixes: [String] = [
         "UIHostingController",

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -44,7 +44,6 @@ extension Navigation {
             .contains(controllerTypeName)
         let isPrefixMatch = ignoredControllerTypePrefixes
             .contains { controllerTypeName.hasPrefix($0) }
-        let shouldIgnore = isExactMatch || isPrefixMatch
-        return shouldIgnore
+        return isExactMatch || isPrefixMatch
     }
 }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -17,7 +17,17 @@ limitations under the License.
 
 extension Navigation {
     /// Internal iOS controllers that should not produce navigation events.
+    ///
+    /// UIKit infrastructure controllers (keyboard, input, rotation) are
+    /// listed without a module prefix because UIKit types are always
+    /// reported as bare names by `String(describing: type(of:))`.
+    ///
+    /// SwiftUI infrastructure controllers are listed *with* the `SwiftUI.`
+    /// module prefix because the SDK's class-name sanitizer only strips the
+    /// host app's bundle prefix, not `SwiftUI.`. These names are verified
+    /// against span data from an instrumented test app on iOS 26.2.
     private static let ignoredControllerTypeNames: Set<String> = [
+        // UIKit infrastructure
         "UIApplicationRotationFollowingController",
         "UICompatibilityInputViewController",
         "UIInputWindowController",
@@ -27,15 +37,37 @@ extension Navigation {
         "UISystemInputViewController",
         "UISystemKeyboardDockController",
         "UINavigationController",
-        "UITabBarController"
+        "UITabBarController",
+
+        // SwiftUI navigation infrastructure (observed in situ with SwiftUI. prefix)
+        "SwiftUI.UIKitNavigationController",
+        "SwiftUI.UIKitTabBarController",
+        "SwiftUI.UIKitSplitViewController",
+        "SwiftUI.UIKitInspectorSplitViewController",
+        "SwiftUI.NotifyingMulticolumnSplitViewController",
+        "SwiftUI.NotificationSendingSplitViewController",
+        "SwiftUI.SplitViewNavigationController",
+        "SwiftUI.TabHostingController",
+
+        // SwiftUI non-navigation infrastructure
+        "SwiftUI.PlatformAlertController",
+        "SwiftUI.SwiftUISearchController"
     ]
 
     /// SwiftUI internal controllers whose type names include generic
     /// parameters (e.g. `UIHostingController<ModifiedContent<...>>`).
     ///
-    /// Prefix matching is required because the suffix varies at runtime.
+    /// Prefix matching is required because the generic suffix varies at
+    /// runtime depending on the view hierarchy.
+    ///
+    /// `NavigationStackHostingController<` and
+    /// `PresentationHostingController<` were observed to be the two noisiest
+    /// SwiftUI-internal generic types. They fire on every `NavigationStack`
+    /// push/pop and every sheet/modal presentation, respectively.
     private static let ignoredControllerTypePrefixes: [String] = [
         "UIHostingController<",
+        "NavigationStackHostingController<",
+        "PresentationHostingController<",
         "StyleContextSplitViewNavigationController<"
     ]
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -39,7 +39,8 @@ extension Navigation {
         "UINavigationController",
         "UITabBarController",
 
-        // SwiftUI navigation infrastructure (observed in situ with SwiftUI. prefix)
+        // SwiftUI navigation infrastructure: both prefixed (SwiftUI.X) and bare
+        // (X) forms were observed in test runs; the prefixed form is matched here
         "SwiftUI.UIKitNavigationController",
         "SwiftUI.UIKitTabBarController",
         "SwiftUI.UIKitSplitViewController",

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -30,7 +30,20 @@ extension Navigation {
         "UITabBarController"
     ]
 
+    /// SwiftUI internal controllers whose type names include generic
+    /// parameters (e.g. `UIHostingController<ModifiedContent<...>>`).
+    /// Prefix matching is required because the suffix varies at runtime.
+    private static let ignoredControllerTypePrefixes: [String] = [
+        "UIHostingController",
+        "StyleContextSplitViewNavigationController"
+    ]
+
     static func shouldIgnore(controllerTypeName: String) -> Bool {
-        ignoredControllerTypeNames.contains(controllerTypeName)
+        if ignoredControllerTypeNames.contains(controllerTypeName) {
+            return true
+        }
+        return ignoredControllerTypePrefixes.contains { prefix in
+            controllerTypeName.hasPrefix(prefix)
+        }
     }
 }

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Filtering.swift
@@ -35,8 +35,8 @@ extension Navigation {
     ///
     /// Prefix matching is required because the suffix varies at runtime.
     private static let ignoredControllerTypePrefixes: [String] = [
-        "UIHostingController",
-        "StyleContextSplitViewNavigationController"
+        "UIHostingController<",
+        "StyleContextSplitViewNavigationController<"
     ]
 
     static func shouldIgnore(controllerTypeName: String) -> Bool {

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
@@ -143,7 +143,7 @@ public final class Navigation: Sendable {
             for await event in stream {
                 guard
                     await shouldProcessEvent(),
-                    !Self.shouldIgnore(controllerTypeName: event.controllerTypeName)
+                    !shouldIgnoreAndLog(controllerTypeName: event.controllerTypeName)
                 else {
                     continue
                 }
@@ -307,6 +307,23 @@ public final class Navigation: Sendable {
         let trackingEnabled = state.isAutomatedTrackingEnabled
 
         return moduleEnabled && trackingEnabled
+    }
+
+    /// Returns whether the controller should be filtered from automatic
+    /// navigation tracking, and logs at debug level when filtering occurs.
+    ///
+    /// The static ``shouldIgnore(controllerTypeName:)`` remains pure for
+    /// testability; this instance method adds the side effect of logging
+    /// so that filtered controller names are observable in debug builds.
+    func shouldIgnoreAndLog(controllerTypeName: String) -> Bool {
+        guard Self.shouldIgnore(controllerTypeName: controllerTypeName) else {
+            return false
+        }
+
+        logger.log(level: .debug) {
+            "Filtered internal controller from automatic navigation tracking: \(controllerTypeName)"
+        }
+        return true
     }
 
     /// Checks whether the event belongs to a view controller whose lifecycle is managed

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
@@ -104,6 +104,21 @@ final class NavigationEventSourcesTests: XCTestCase {
         XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: "DetailViewController"))
     }
 
+    // MARK: - Filtering (instance path)
+
+    func testShouldIgnoreAndLogFiltersInternalControllers() {
+        let navigation = Navigation()
+        XCTAssertTrue(navigation.shouldIgnoreAndLog(controllerTypeName: "UINavigationController"))
+        XCTAssertTrue(navigation.shouldIgnoreAndLog(controllerTypeName: "SwiftUI.UIKitNavigationController"))
+        XCTAssertTrue(navigation.shouldIgnoreAndLog(controllerTypeName: "NavigationStackHostingController<AnyView>"))
+    }
+
+    func testShouldIgnoreAndLogPassesAppControllers() {
+        let navigation = Navigation()
+        XCTAssertFalse(navigation.shouldIgnoreAndLog(controllerTypeName: "SettingsViewController"))
+        XCTAssertFalse(navigation.shouldIgnoreAndLog(controllerTypeName: "ProductDetailsViewController"))
+    }
+
     func testIgnoredControllerNoScreenName() async {
         let (stream, continuation) = AsyncStream.makeStream(of: (any NavigationActionEvent).self)
         defer { continuation.finish() }

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
@@ -56,9 +56,20 @@ final class NavigationEventSourcesTests: XCTestCase {
 
     // MARK: - Filtering
 
-    func testShouldIgnoreInternalControllers() {
+    func testShouldIgnoreUIKitInternalControllers() {
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "UINavigationController"))
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "UITabBarController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "UIInputWindowController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "UISystemKeyboardDockController"))
+    }
+
+    func testShouldIgnoreSwiftUINavigationInfrastructure() {
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.UIKitNavigationController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.UIKitTabBarController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.UIKitSplitViewController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.TabHostingController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.NotifyingMulticolumnSplitViewController"))
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "SwiftUI.PlatformAlertController"))
     }
 
     func testShouldIgnoreRegularController() {
@@ -70,6 +81,14 @@ final class NavigationEventSourcesTests: XCTestCase {
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
     }
 
+    func testShouldIgnoreNavigationStackHostingController() {
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "NavigationStackHostingController<AnyView>"))
+    }
+
+    func testShouldIgnorePresentationHostingController() {
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: "PresentationHostingController<AnyView>"))
+    }
+
     func testShouldIgnoreSplitViewPrefix() {
         let name = "StyleContextSplitViewNavigationController<MergedStyle>"
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
@@ -78,6 +97,11 @@ final class NavigationEventSourcesTests: XCTestCase {
     func testShouldNotIgnoreSimilarPrefix() {
         let name = "UIHostingWrapperViewController"
         XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: name))
+    }
+
+    func testShouldNotIgnoreAppControllers() {
+        XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: "SettingsViewController"))
+        XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: "DetailViewController"))
     }
 
     func testIgnoredControllerNoScreenName() async {

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
@@ -70,17 +70,17 @@ final class NavigationEventSourcesTests: XCTestCase {
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
     }
 
-    func testShouldIgnoreStyleContextSplitViewNavigationController() {
+    func testShouldIgnoreSplitViewPrefix() {
         let name = "StyleContextSplitViewNavigationController<MergedStyle>"
         XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
     }
 
-    func testShouldNotIgnoreControllerWithSimilarPrefix() {
+    func testShouldNotIgnoreSimilarPrefix() {
         let name = "UIHostingWrapperViewController"
         XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: name))
     }
 
-    func testIgnoredControllerDoesNotUpdateScreenName() async {
+    func testIgnoredControllerNoScreenName() async {
         let (stream, continuation) = AsyncStream.makeStream(of: (any NavigationActionEvent).self)
         defer { continuation.finish() }
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventSourcesTests.swift
@@ -65,6 +65,21 @@ final class NavigationEventSourcesTests: XCTestCase {
         XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: "ProductDetailsViewController"))
     }
 
+    func testShouldIgnoreSwiftUIHostingController() {
+        let name = "UIHostingController<ModifiedContent<DemoView, _TraitWritingModifier<AutomaticNavigationSource>>>"
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
+    }
+
+    func testShouldIgnoreStyleContextSplitViewNavigationController() {
+        let name = "StyleContextSplitViewNavigationController<MergedStyle>"
+        XCTAssertTrue(Navigation.shouldIgnore(controllerTypeName: name))
+    }
+
+    func testShouldNotIgnoreControllerWithSimilarPrefix() {
+        let name = "UIHostingWrapperViewController"
+        XCTAssertFalse(Navigation.shouldIgnore(controllerTypeName: name))
+    }
+
     func testIgnoredControllerDoesNotUpdateScreenName() async {
         let (stream, continuation) = AsyncStream.makeStream(of: (any NavigationActionEvent).self)
         defer { continuation.finish() }


### PR DESCRIPTION
## Title: Suppress SwiftUI internal controllers

### Description

Use a prefix match to suppress reporting of UIHostingController and StyleContextSplitViewNavigationController generic types.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Unit tests included.

Prior to these changes, when you had automatic detection enabled and used the .track(screen:attributes:) or .track(screen:) view modifier  in SwiftUI, you would see spurious transitions with the names UIHostingController<...> and StyleContextSplitViewNavigationController<...> in the reported instrumentation data. If you run an end to end test after these changes, such spurious transition names are not reported.

We have a test branch set up where DevelApp has added screens for testing this.
NO-TICKET-automated-testing-for-navigation-tracking
