### PR TITLE
NO-TICKET: Fix ObjC test assertions for default UserTrackingMode

### DIFF
--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-ConfigurationObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-ConfigurationObjCTests.m
@@ -97,7 +97,7 @@ limitations under the License.
 
 
     double expectedSampligRate = 1.0;
-    NSInteger expectedUserTrackingModeValue = SPLKUserTrackingMode.noTracking.integerValue;
+    NSInteger expectedUserTrackingModeValue = SPLKUserTrackingMode.anonymousTracking.integerValue;
 
     XCTAssertEqual(configuration.session.samplingRate, expectedSampligRate);
     XCTAssertNotNil(configuration.user.trackingMode);

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-UserPreferencesObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-UserPreferencesObjCTests.m
@@ -40,7 +40,7 @@ limitations under the License.
 
     // Properties (READ)
     NSInteger initialTrackingModeValue = userPreferences.trackingMode.integerValue;
-    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.noTracking.integerValue;
+    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.anonymousTracking.integerValue;
     XCTAssertEqual(initialTrackingModeValue, expectedTrackingModeValue);
 
 

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-UserStateObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/API-1.0-UserStateObjCTests.m
@@ -40,7 +40,7 @@ limitations under the License.
     // Properties (READ)
     NSNumber *initialTrackingMode = userState.trackingMode;
     NSInteger initialTrackingModeValue = initialTrackingMode.integerValue;
-    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.noTracking.integerValue;
+    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.anonymousTracking.integerValue;
     XCTAssertEqual(initialTrackingModeValue, expectedTrackingModeValue);
 
     agent.user.preferences.trackingMode = SPLKUserTrackingMode.anonymousTracking;

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Model/API-1.0-UserConfigurationObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Model/API-1.0-UserConfigurationObjCTests.m
@@ -42,13 +42,13 @@ limitations under the License.
 
     // Properties (READ)
     NSInteger initialTrackingModeValue = configuration.trackingMode.integerValue;
-    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.noTracking.integerValue;
+    NSInteger expectedTrackingModeValue = SPLKUserTrackingMode.anonymousTracking.integerValue;
     XCTAssertEqual(initialTrackingModeValue, expectedTrackingModeValue);
 
     // Properties (WRITE)
-    configuration.trackingMode = SPLKUserTrackingMode.anonymousTracking;
+    configuration.trackingMode = SPLKUserTrackingMode.noTracking;
     NSInteger updatedTrackingModeValue = configuration.trackingMode.integerValue;
-    XCTAssertEqual(updatedTrackingModeValue, SPLKUserTrackingMode.anonymousTracking.integerValue);
+    XCTAssertEqual(updatedTrackingModeValue, SPLKUserTrackingMode.noTracking.integerValue);
 }
 
 - (void)testWrongTrackingModeConstants {

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Model/API-1.0-UserTrackingModeObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Model/API-1.0-UserTrackingModeObjCTests.m
@@ -29,9 +29,9 @@ limitations under the License.
 // MARK: - API Tests
 
 - (void)testModes {
-    // Default mode (same as No tracking)
+    // Default mode (same as Anonymous tracking)
     NSNumber *defaultTrackingMode = SPLKUserTrackingMode.defaultTracking;
-    XCTAssertEqual(defaultTrackingMode.integerValue, 0);
+    XCTAssertEqual(defaultTrackingMode.integerValue, 1);
 
     // No tracking
     NSNumber *noTrackingMode = SPLKUserTrackingMode.noTracking;


### PR DESCRIPTION
## Title: Fix ObjC test assertions for default UserTrackingMode

### Description

* Update to reflect that default changed from noTracking to anonymousTracking in 3a45c18

Note the tests we've touched here are still not in the test plan, but for other branches that do have them in the test plan, these tests run and fail without these changes. I have not added the tests (SplunkAgentObjCTests) to the test plan in develop because that needs a quick check with the team first to see if there's a reason to leave them out.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

On a branch where SplunkAgentObjCTests are active in the test plan, run the tests and they should pass. They won't show as running in this PR.

<img width="359" height="360" alt="Screenshot 2026-04-26 at 2 51 37 PM" src="https://github.com/user-attachments/assets/9ba78cf7-f157-40e4-8937-9ade7c9a78e1" />
