### PR TITLE
NO-TICKET: Clarify waitUntil timeout semantics in comments

### DIFF
--- a/SplunkCommon/Sources/SplunkCommon/Utils/WaitUntil.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Utils/WaitUntil.swift
@@ -23,7 +23,7 @@ import Foundation
 ///   - timeout: Maximum time to wait, in seconds. Defaults to 1.0.
 ///   - pollIntervalNanoseconds: Interval between polls. Defaults to 10 ms.
 ///   - condition: An async closure that returns `true` when the expected state is reached.
-/// - Returns: `true` if the condition was met before the timeout, `false` otherwise.
+/// - Returns: `true` if the condition was met, `false` if still unmet after timeout.
 @_spi(SplunkTesting)
 @discardableResult
 public func waitUntil(
@@ -41,5 +41,6 @@ public func waitUntil(
         try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
     }
 
+    // Grace check: condition may have satisfied during the final sleep interval.
     return await condition()
 }


### PR DESCRIPTION
## Title: Clarify waitUntil timeout semantics in comments

### Description

* Added clarifying comments explaining the grace check is intentional — it prevents false negatives under CI load when the condition satisfies during the final sleep interval.
* Comment-only change; no behavior change.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] (Optional) I have added unit tests for my changes.
- [ ] (Optional) I have updated the sample app for integration testing.
- [ ] (Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Comment-only change; existing tests continue to pass.
