### PR TITLE
NO-TICKET: Rename RejectingProcessor to NameOverridingProcessor

### DIFF
--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorTests.swift
@@ -96,7 +96,7 @@ final class NavigationEventProcessorTests: XCTestCase {
 
     func testManualTrackBypassesProcessor() async {
         let fixture = makeNavigationStreamFixture(
-            navigationEventProcessor: RejectingProcessor()
+            navigationEventProcessor: NameOverridingProcessor()
         )
 
         defer {

--- a/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/Mocks/MockNavigationEventProcessors.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/Mocks/MockNavigationEventProcessors.swift
@@ -34,9 +34,9 @@ final class PrefixingProcessor: NavigationEventProcessor {
     }
 }
 
-final class RejectingProcessor: NavigationEventProcessor {
+final class NameOverridingProcessor: NavigationEventProcessor {
     func onViewController(typeName _: String, controllerIdentity _: String) -> NavigationEvent? {
-        NavigationEvent(name: "REJECTED")
+        NavigationEvent(name: "OverriddenName")
     }
 }
 


### PR DESCRIPTION
## Title: Rename RejectingProcessor to NameOverridingProcessor

### Description

* Renamed `RejectingProcessor` to `NameOverridingProcessor` and updated the return value to `"OverriddenName"` so name and behavior align.
* Test-only change.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] (Optional) I have added unit tests for my changes.
- [ ] (Optional) I have updated the sample app for integration testing.
- [ ] (Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Existing unit tests continue to pass.
