### PR TITLE
NO-TICKET: Document @unchecked Sendable safety invariant in adapter types

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Model Conversions/NavigationModuleEventProcessorAdapter.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Navigation/Model Conversions/NavigationModuleEventProcessorAdapter.swift
@@ -19,6 +19,9 @@ internal import SplunkNavigation
 
 /// Adapts a ``NavigationModuleEventProcessor`` from the `SplunkAgent` public API
 /// to the internal ``NavigationEventProcessor`` protocol used by the navigation engine.
+///
+/// - Note: We mark this class `@unchecked Sendable` because it is immutable after
+///   init; the single stored property is a private let and is never mutated.
 final class NavigationModuleEventProcessorAdapter: NavigationEventProcessor, @unchecked Sendable {
 
     // MARK: - Private

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavEventProcessorObjCToAgentAdapter.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavEventProcessorObjCToAgentAdapter.swift
@@ -19,6 +19,9 @@ import SplunkAgent
 
 /// Adapts an Objective-C ``NavigationEventProcessorObjC`` to the
 /// ``NavigationModuleEventProcessor`` protocol used by the agent facade.
+///
+/// - Note: We mark this class `@unchecked Sendable` because it is immutable after
+///   init; the single stored property is a private let and is never mutated.
 final class NavEventProcessorObjCToAgentAdapter: NavigationModuleEventProcessor, @unchecked Sendable {
 
     // MARK: - Private

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavProcessorAgentToInternalAdapter.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Navigation/Model Conversions/NavProcessorAgentToInternalAdapter.swift
@@ -25,6 +25,9 @@ internal import SplunkNavigation
 /// which is `internal` and inaccessible from this target. We intentionally
 /// duplicate rather than widen access (e.g. `package`) to preserve
 /// compile-time target isolation.
+///
+/// - Note: We mark this class `@unchecked Sendable` because it is immutable after
+///   init; the single stored property is a private let and is never mutated.
 final class NavProcessorAgentToInternalAdapter: NavigationEventProcessor, @unchecked Sendable {
 
     // MARK: - Private


### PR DESCRIPTION
## Title: Document @unchecked Sendable safety invariant in adapter types

### Description

* Three adapter classes conformed to `@unchecked Sendable` with no explanation of why the conformance was safe.
* Added a `Note:` doc comment paragraph to `NavProcessorAgentToInternalAdapter`, `NavEventProcessorObjCToAgentAdapter`, and `NavigationModuleEventProcessorAdapter` explaining that immutability after init makes the conformance safe.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] (Optional) I have added unit tests for my changes.
- [ ] (Optional) I have updated the sample app for integration testing.
- [ ] (Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Comment-only change; existing tests continue to pass.
