### PR TITLE
DEMRUM-3550: Encapsulate String Literals in Network Monitor module

### DIFF
--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/DebugDestination.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/DebugDestination.swift
@@ -42,9 +42,9 @@ class DebugDestination: NetworkMonitorDestination {
             """
             Network Change span:
                 timestamp: \(networkEvent.timestamp),
-                status: \(networkEvent.isConnected ? "available" : "lost"),
+                status: \(networkEvent.isConnected ? NetworkMonitorSpanAttributes.statusValueAvailable : NetworkMonitorSpanAttributes.statusValueLost),
                 type: \(networkEvent.connectionType.rawValue),
-                subType: \(networkEvent.radioType ?? "na"),
+                subType: \(networkEvent.radioType ?? NetworkMonitorSpanAttributes.debugRadioTypeUnavailable),
             """
         }
     }

--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
@@ -41,9 +41,11 @@ struct OTelDestination: NetworkMonitorDestination {
             .setStartTime(time: networkEvent.timestamp)
             .startSpan()
 
-        let status = networkEvent.isConnected
-            ? NetworkMonitorSpanAttributes.statusValueAvailable
-            : NetworkMonitorSpanAttributes.statusValueLost
+        let status =
+            networkEvent.isConnected
+                ? NetworkMonitorSpanAttributes.statusValueAvailable
+                : NetworkMonitorSpanAttributes.statusValueLost
+
         span.clearAndSetAttribute(key: NetworkMonitorSpanAttributes.networkStatus, value: status)
         span.clearAndSetAttribute(
             key: SemanticConventions.Network.connectionType,

--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
@@ -33,18 +33,24 @@ struct OTelDestination: NetworkMonitorDestination {
         let tracer = OpenTelemetry.instance
             .tracerProvider
             .get(
-                instrumentationName: "NetworkMonitor",
+                instrumentationName: NetworkMonitorSpanAttributes.instrumentationName,
                 instrumentationVersion: sharedState?.agentVersion
             )
 
-        let span = tracer.spanBuilder(spanName: "network.change")
+        let span = tracer.spanBuilder(spanName: NetworkMonitorSpanAttributes.spanName)
             .setStartTime(time: networkEvent.timestamp)
             .startSpan()
 
-        span.clearAndSetAttribute(key: "network.status", value: networkEvent.isConnected ? "available" : "lost")
-        span.clearAndSetAttribute(key: "network.connection.type", value: networkEvent.connectionType.rawValue)
+        let status = networkEvent.isConnected
+            ? NetworkMonitorSpanAttributes.statusValueAvailable
+            : NetworkMonitorSpanAttributes.statusValueLost
+        span.clearAndSetAttribute(key: NetworkMonitorSpanAttributes.networkStatus, value: status)
+        span.clearAndSetAttribute(
+            key: SemanticConventions.Network.connectionType,
+            value: networkEvent.connectionType.rawValue
+        )
         if let radioType = networkEvent.radioType {
-            span.clearAndSetAttribute(key: "network.connection.subtype", value: radioType)
+            span.clearAndSetAttribute(key: SemanticConventions.Network.connectionSubtype, value: radioType)
         }
 
         span.end(time: networkEvent.timestamp)

--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Destination/OTelDestination.swift
@@ -43,8 +43,8 @@ struct OTelDestination: NetworkMonitorDestination {
 
         let status =
             networkEvent.isConnected
-                ? NetworkMonitorSpanAttributes.statusValueAvailable
-                : NetworkMonitorSpanAttributes.statusValueLost
+            ? NetworkMonitorSpanAttributes.statusValueAvailable
+            : NetworkMonitorSpanAttributes.statusValueLost
 
         span.clearAndSetAttribute(key: NetworkMonitorSpanAttributes.networkStatus, value: status)
         span.clearAndSetAttribute(

--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Module/NetworkMonitor+Module.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/Module/NetworkMonitor+Module.swift
@@ -24,7 +24,7 @@ public struct NetworkMonitorData: ModuleEventData {}
 /// Event metadata for NetworkMonitor module events.
 public struct NetworkMonitorMetadata: ModuleEventMetadata {
     public var timestamp = Date()
-    public var eventName: String = "network.change"
+    public var eventName: String = NetworkMonitorSpanAttributes.spanName
 }
 
 /// Extension that makes NetworkMonitor conform to the Module protocol.

--- a/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/NetworkMonitorSpanAttributes.swift
+++ b/SplunkNetworkMonitor/Sources/SplunkNetworkMonitor/NetworkMonitorSpanAttributes.swift
@@ -1,0 +1,50 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// Span names, attribute keys, and attribute values used by network monitor instrumentation.
+///
+/// Standard network connection keys should use ``SemanticConventions/Network`` where applicable.
+enum NetworkMonitorSpanAttributes {
+
+    // MARK: - Span identity
+
+    /// OpenTelemetry tracer instrumentation scope name.
+    static let instrumentationName = "NetworkMonitor"
+
+    /// Span name for network connectivity change events.
+    static let spanName = "network.change"
+
+
+    // MARK: - Splunk-specific attribute keys
+
+    /// Connectivity status (`available` or `lost`).
+    static let networkStatus = "network.status"
+
+
+    // MARK: - Attribute values
+
+    /// Value for ``networkStatus`` when the device has network connectivity.
+    static let statusValueAvailable = "available"
+
+    /// Value for ``networkStatus`` when network connectivity is lost.
+    static let statusValueLost = "lost"
+
+    /// Placeholder used in debug logging when no radio subtype is available.
+    static let debugRadioTypeUnavailable = "na"
+}

--- a/SplunkNetworkMonitor/Tests/SplunkNetworkMonitorTests/SplunkNetworkMonitorTests.swift
+++ b/SplunkNetworkMonitor/Tests/SplunkNetworkMonitorTests/SplunkNetworkMonitorTests.swift
@@ -62,7 +62,7 @@ final class NetworkMonitorTests: XCTestCase {
     func testNetworkMonitorMetadata() {
         let metadata = NetworkMonitorMetadata()
 
-        XCTAssertEqual(metadata.eventName, "network.change")
+        XCTAssertEqual(metadata.eventName, NetworkMonitorSpanAttributes.spanName)
         XCTAssertNotNil(metadata.timestamp)
     }
 


### PR DESCRIPTION
## Tech-Debt: Encapsulate String Literals in Network Monitor module

### Description

- Move string literals to a common file for emitting in spans
- Update outstanding items to Otel Semantic Attributes where possible

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Perform Unit Tests
- Confirm spans are properly consumed by back end
