### PR TITLE
DEMRUM-5625: Suppress "unknown" sentinel as last.screen.name on first navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed `app.ui.navigation` spans incorrectly emitting `last.screen.name` with the value `"unknown"` on the first navigation event. The attribute is now omitted when no previous screen has been shown. #661
+
 ## [2.3.0] - 2026-05-18
 
 ### Added

--- a/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationModel.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationModel.swift
@@ -15,6 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/// The screen state to restore when a UINavigationController-presented modal is dismissed.
+///
+/// A plain `NavigationScreenState?` cannot be stored in the model's dictionary without
+/// introducing a box type, because Swift dictionaries cannot distinguish between a key
+/// that is absent and a key whose value is `nil`. Using a dedicated enum avoids that
+/// ambiguity and makes the two dismissal paths explicit at the call site.
+enum RestorationState {
+    /// A real screen was showing before the modal was presented; restore to it on dismissal.
+    case screen(NavigationScreenState)
+    /// No screen had been tracked yet when the modal was presented; reset to nil on dismissal
+    /// so subsequent `last.screen.name` values are not polluted by the dismissed modal.
+    case noScreen
+}
+
 /// Model actor for data used in Navigation module.
 actor NavigationModel {
 
@@ -24,7 +38,7 @@ actor NavigationModel {
     private(set) var navigations: [ObjectIdentifier: NavigationPair] = [:]
     private(set) var pendingNavigationTargets: [ObjectIdentifier: ObjectIdentifier] = [:]
     private(set) var managedNavigationControllerTargets: Set<ObjectIdentifier> = []
-    private(set) var pendingPresentationRestorations: [ObjectIdentifier: NavigationScreenState] = [:]
+    private(set) var pendingPresentationRestorations: [ObjectIdentifier: RestorationState] = [:]
     private(set) var navigationEventProcessor: any NavigationEventProcessor
 
 
@@ -93,11 +107,11 @@ actor NavigationModel {
 
     // MARK: - Presentation restorations
 
-    func pendingPresentationRestoration(for identifier: ObjectIdentifier) -> NavigationScreenState? {
+    func pendingPresentationRestoration(for identifier: ObjectIdentifier) -> RestorationState? {
         pendingPresentationRestorations[identifier]
     }
 
-    func update(pendingPresentationRestoration: NavigationScreenState, for identifier: ObjectIdentifier) {
+    func update(pendingPresentationRestoration: RestorationState, for identifier: ObjectIdentifier) {
         pendingPresentationRestorations[identifier] = pendingPresentationRestoration
     }
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
@@ -35,13 +35,29 @@ struct NavigationScreenStateUpdate {
 /// Synchronous, lock-protected store for navigation state that must be readable
 /// without an actor hop.
 ///
-/// `moduleEnabled` and `screenName` are kept here so that `track(screen:attributes:)`
-/// can check enabled state, record the screen state, and emit synchronously on the
-/// caller's thread, matching Android's `@Synchronized` setter pattern.
+/// ## Why a lock instead of an actor?
 ///
-/// `sharedState` is kept here because the agent injects it after module construction
-/// and navigation span emission reads it from both automated tasks and synchronous
-/// manual tracking calls.
+/// `track(screen:attributes:)` is a public synchronous API: callers invoke it
+/// without `await` and it must complete on the caller's thread. Swift actors
+/// cannot be accessed synchronously from outside their own isolation domain,
+/// so an actor would force `track(screen:)` to become `async` — a breaking
+/// change to the public API.
+///
+/// Automated navigation detection runs in async `Task` contexts started by
+/// `startDetection()`. Manual tracking runs on whatever thread the host app
+/// calls from. The `NSLock` bridges these two concurrency domains, allowing
+/// both paths to safely read and write shared screen state without coupling
+/// the public API to Swift concurrency.
+///
+/// ## What is stored here?
+///
+/// - `screenState` — updated on every navigation event; read by both automated
+///   tasks and `track(screen:)` for deduplication. `nil` means no real screen
+///   has been shown yet; this is distinct from a customer explicitly tracking
+///   a screen named `"unknown"`.
+/// - `moduleEnabled` — checked synchronously by `track(screen:)` before emitting.
+/// - `sharedState` — injected by the agent after construction; read from both
+///   automated tasks and synchronous manual-tracking calls.
 final class NavigationRuntimeStateStore: @unchecked Sendable {
 
     // MARK: - Private
@@ -49,12 +65,7 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
     private let lock = NSLock()
     private weak var storedSharedState: AgentSharedState?
     private var storedModuleEnabled: Bool = true
-    private static let noScreenSentinel = "unknown"
-
-    private var storedScreenState = NavigationScreenState(
-        name: NavigationRuntimeStateStore.noScreenSentinel,
-        attributes: [:]
-    )
+    private var storedScreenState: NavigationScreenState?
 
 
     // MARK: - Shared state
@@ -82,10 +93,10 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
     // MARK: - Screen name
 
     var screenName: String {
-        lock.withLock { storedScreenState.name }
+        lock.withLock { storedScreenState?.name ?? "unknown" }
     }
 
-    var screenState: NavigationScreenState {
+    var screenState: NavigationScreenState? {
         lock.withLock { storedScreenState }
     }
 
@@ -99,9 +110,8 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
             let previous = storedScreenState
             storedScreenState = state
 
-            let previousName = previous.name == Self.noScreenSentinel ? nil : previous.name
             return NavigationScreenStateUpdate(
-                previousName: previousName,
+                previousName: previous?.name,
                 shouldEmit: forceEmit || previous != state
             )
         }

--- a/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
@@ -27,7 +27,8 @@ struct NavigationScreenState: Equatable {
 
 /// Result of updating the stored navigation screen state.
 struct NavigationScreenStateUpdate {
-    let previousName: String
+    /// The previous screen name, or `nil` if no real screen had been shown yet.
+    let previousName: String?
     let shouldEmit: Bool
 }
 
@@ -48,8 +49,10 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
     private let lock = NSLock()
     private weak var storedSharedState: AgentSharedState?
     private var storedModuleEnabled: Bool = true
+    private static let noScreenSentinel = "unknown"
+
     private var storedScreenState = NavigationScreenState(
-        name: "unknown",
+        name: NavigationRuntimeStateStore.noScreenSentinel,
         attributes: [:]
     )
 
@@ -96,8 +99,9 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
             let previous = storedScreenState
             storedScreenState = state
 
+            let previousName = previous.name == Self.noScreenSentinel ? nil : previous.name
             return NavigationScreenStateUpdate(
-                previousName: previous.name,
+                previousName: previousName,
                 shouldEmit: forceEmit || previous != state
             )
         }

--- a/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Model/NavigationRuntimeStateStore.swift
@@ -53,8 +53,9 @@ struct NavigationScreenStateUpdate {
 ///
 /// - `screenState` — updated on every navigation event; read by both automated
 ///   tasks and `track(screen:)` for deduplication. `nil` means no real screen
-///   has been shown yet; this is distinct from a customer explicitly tracking
-///   a screen named `"unknown"`.
+///   has been shown yet (including after a modal is dismissed over a no-screen
+///   state); this is distinct from a customer explicitly tracking a screen
+///   named `"unknown"`.
 /// - `moduleEnabled` — checked synchronously by `track(screen:)` before emitting.
 /// - `sharedState` — injected by the agent after construction; read from both
 ///   automated tasks and synchronous manual-tracking calls.
@@ -98,6 +99,11 @@ final class NavigationRuntimeStateStore: @unchecked Sendable {
 
     var screenState: NavigationScreenState? {
         lock.withLock { storedScreenState }
+    }
+
+    /// Resets the stored screen state to nil, as if no screen has been shown.
+    func resetScreenState() {
+        lock.withLock { storedScreenState = nil }
     }
 
     /// Atomically updates the stored screen state.

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+NavigationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+NavigationControllerTransitions.swift
@@ -101,6 +101,8 @@ extension Navigation {
         start: Date,
         attributes: [String: Any]? = nil
     ) {
+        // forceEmit: false — automated detection deduplicates repeated visits to the same screen.
+        // Manual track(screen:) uses forceEmit: true because the caller explicitly requests a new span.
         let screenStateUpdate = updateCurrentScreenState(
             screenName: screenName,
             attributes: attributes,

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -59,12 +59,14 @@ extension Navigation {
             return
         }
 
-        if let currentState = currentScreenState() {
-            await model.update(
-                pendingPresentationRestoration: currentState,
-                for: event.presentationControllerIdentifier
-            )
-        }
+        // Always store a restoration, even when no screen has been tracked yet.
+        // Without this, dismissalDidEnd finds no stored state and bails, leaving
+        // the dismissed modal's name stuck as the current screen.
+        let restoration: RestorationState = currentScreenState().map { .screen($0) } ?? .noScreen
+        await model.update(
+            pendingPresentationRestoration: restoration,
+            for: event.presentationControllerIdentifier
+        )
         await updateTransitionStart(for: presentedSnapshot(from: event), timestamp: event.timestamp)
     }
 
@@ -174,14 +176,14 @@ extension Navigation {
     }
 
     private func updateRestorationTransitionStart(event: any PresentationActionEvent) async {
-        guard let restoration = await model.pendingPresentationRestoration(for: event.presentationControllerIdentifier) else {
+        guard case let .screen(state) = await model.pendingPresentationRestoration(for: event.presentationControllerIdentifier) else {
             return
         }
 
         let navigation = NavigationPair(
             type: .transition,
             start: event.timestamp,
-            screenName: restoration.name
+            screenName: state.name
         )
 
         await model.update(
@@ -203,19 +205,23 @@ extension Navigation {
         let existingNavigation = await model.navigation(for: event.presentationControllerIdentifier)
         let start = existingNavigation?.start ?? event.timestamp
 
-        updateCurrentScreen(
-            state: restoration,
-            start: start
-        )
+        switch restoration {
+        case let .screen(state):
+            updateCurrentScreen(state: state, start: start)
 
-        let completedNavigation = NavigationPair(
-            type: existingNavigation?.type ?? .transition,
-            start: start,
-            end: event.timestamp,
-            screenName: restoration.name
-        )
+            let completedNavigation = NavigationPair(
+                type: existingNavigation?.type ?? .transition,
+                start: start,
+                end: event.timestamp,
+                screenName: state.name
+            )
+            send(navigation: completedNavigation)
 
-        send(navigation: completedNavigation)
+        case .noScreen:
+            // No screen was showing before the modal; reset to nil so the dismissed
+            // modal's name does not become last.screen.name for future navigation events.
+            runtimeStateStore.resetScreenState()
+        }
 
         await model.removeNavigation(for: event.presentationControllerIdentifier)
         await model.removePendingPresentationRestoration(for: event.presentationControllerIdentifier)

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -218,9 +218,12 @@ extension Navigation {
             send(navigation: completedNavigation)
 
         case .noScreen:
-            // No screen was showing before the modal; reset to nil so the dismissed
-            // modal's name does not become last.screen.name for future navigation events.
+            // No screen was showing before the modal; reset internal state to nil and
+            // publish "unknown" through the observer/stream path so that
+            // DefaultRuntimeAttributes.currentScreenName and crash-report propagation
+            // are not left stuck on the dismissed modal's name.
             runtimeStateStore.resetScreenState()
+            publishScreenNameChange("unknown")
         }
 
         await model.removeNavigation(for: event.presentationControllerIdentifier)

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -219,11 +219,10 @@ extension Navigation {
 
         case .noScreen:
             // No screen was showing before the modal; reset internal state to nil and
-            // publish "unknown" through the observer/stream path so that
-            // DefaultRuntimeAttributes.currentScreenName and crash-report propagation
-            // are not left stuck on the dismissed modal's name.
-            runtimeStateStore.resetScreenState()
-            publishScreenNameChange("unknown")
+            // publish the resulting fallback name through the observer/stream path so
+            // that DefaultRuntimeAttributes.currentScreenName and crash-report
+            // propagation are not left stuck on the dismissed modal's name.
+            resetScreenToNoScreen()
         }
 
         await model.removeNavigation(for: event.presentationControllerIdentifier)

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -176,6 +176,8 @@ extension Navigation {
     }
 
     private func updateRestorationTransitionStart(event: any PresentationActionEvent) async {
+        // .noScreen means there was no prior screen to restore; dismissalWillBegin
+        // has no span to open for that path, so bail early.
         guard case let .screen(state) = await model.pendingPresentationRestoration(for: event.presentationControllerIdentifier) else {
             return
         }
@@ -193,6 +195,8 @@ extension Navigation {
     }
 
     private func finalizeRestorationTransition(event: any PresentationActionEvent) async {
+        // Treat a missing completed flag as success: dismissalDidEnd without an
+        // explicit false means the presentation controller finished normally.
         guard event.completed ?? true else {
             await model.removeNavigation(for: event.presentationControllerIdentifier)
             return
@@ -202,6 +206,8 @@ extension Navigation {
             return
         }
 
+        // existingNavigation is nil only when dismissalWillBegin was skipped (the .noScreen path);
+        // fall back to event.timestamp so the span still has a valid start time.
         let existingNavigation = await model.navigation(for: event.presentationControllerIdentifier)
         let start = existingNavigation?.start ?? event.timestamp
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+PresentationControllerTransitions.swift
@@ -59,10 +59,12 @@ extension Navigation {
             return
         }
 
-        await model.update(
-            pendingPresentationRestoration: currentScreenState(),
-            for: event.presentationControllerIdentifier
-        )
+        if let currentState = currentScreenState() {
+            await model.update(
+                pendingPresentationRestoration: currentState,
+                for: event.presentationControllerIdentifier
+            )
+        }
         await updateTransitionStart(for: presentedSnapshot(from: event), timestamp: event.timestamp)
     }
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+ScreenState.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+ScreenState.swift
@@ -23,7 +23,7 @@ extension Navigation {
 
     // MARK: - Static constants
 
-    private static let screenStateReservedAttributeKeys: Set<String> = [
+    static let screenStateReservedAttributeKeys: Set<String> = [
         "component",
         "navigation.name",
         "last.screen.name",
@@ -47,7 +47,7 @@ extension Navigation {
         return runtimeStateStore.updateScreenState(state, forceEmit: forceEmit)
     }
 
-    func currentScreenState() -> NavigationScreenState {
+    func currentScreenState() -> NavigationScreenState? {
         runtimeStateStore.screenState
     }
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+ScreenState.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+ScreenState.swift
@@ -51,6 +51,17 @@ extension Navigation {
         runtimeStateStore.screenState
     }
 
+    /// Resets stored screen state to nil and publishes the resulting fallback name
+    /// ("unknown") to observers and the async stream.
+    ///
+    /// Use this instead of calling `runtimeStateStore.resetScreenState()` and
+    /// `publishScreenNameChange` separately, so the reset and its published value
+    /// are always kept in sync.
+    func resetScreenToNoScreen() {
+        runtimeStateStore.resetScreenState()
+        publishScreenNameChange(runtimeStateStore.screenName)
+    }
+
     func updateCurrentScreenState(
         _ state: NavigationScreenState,
         forceEmit: Bool

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -76,7 +76,7 @@ extension Navigation {
 
         // Write user-provided attributes first so that SDK-reserved keys always win.
         if let attributes {
-            for (key, value) in attributes {
+            for (key, value) in attributes where !Self.screenStateReservedAttributeKeys.contains(key) {
                 screenNameSpan.clearAndSetAttribute(key: key, value: value)
             }
         }
@@ -85,6 +85,9 @@ extension Navigation {
         screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
         if let lastScreenName {
             screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        }
+        else {
+            screenNameSpan.setAttribute(key: Self.lastScreenNameKey, value: nil as AttributeValue?)
         }
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -97,9 +97,10 @@ extension Navigation {
         screenNameSpan.end(time: start)
     }
 
-    /// Attributes passed to this overload have already been filtered by effectiveCustomAttributes(from:),
-    /// which strips SDK-reserved keys. The [String: Any] overload filters inline because it is called
-    /// directly from the public track(screen:attributes:) path with raw caller input.
+    /// Attributes passed to this overload have already been filtered by effectiveCustomAttributes(from:).
+    ///
+    /// SDK-reserved keys are stripped before this call. The [String: Any] overload filters inline
+    /// because it is called directly from the public track(screen:attributes:) path with raw caller input.
     func send(screenName: String, lastScreenName: String?, start: Date, attributes: [String: AttributeValue]) {
         // A new zero length span for change screen name event
         let screenNameSpan =

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -83,6 +83,9 @@ extension Navigation {
 
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
         screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
+        // Explicit nil clear when there is no previous screen: a span processor may have
+        // already injected last.screen.name before we reach this point, so omitting the
+        // setAttribute call would leave a stale value on the span.
         if let lastScreenName {
             screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
         }
@@ -94,6 +97,9 @@ extension Navigation {
         screenNameSpan.end(time: start)
     }
 
+    /// Attributes passed to this overload have already been filtered by effectiveCustomAttributes(from:),
+    /// which strips SDK-reserved keys. The [String: Any] overload filters inline because it is called
+    /// directly from the public track(screen:attributes:) path with raw caller input.
     func send(screenName: String, lastScreenName: String?, start: Date, attributes: [String: AttributeValue]) {
         // A new zero length span for change screen name event
         let screenNameSpan =
@@ -109,8 +115,14 @@ extension Navigation {
 
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
         screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
+        // Explicit nil clear when there is no previous screen: a span processor may have
+        // already injected last.screen.name before we reach this point, so omitting the
+        // setAttribute call would leave a stale value on the span.
         if let lastScreenName {
             screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        }
+        else {
+            screenNameSpan.setAttribute(key: Self.lastScreenNameKey, value: nil as AttributeValue?)
         }
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -66,7 +66,7 @@ extension Navigation {
         navigationSpan.end(time: navigationEnd)
     }
 
-    func send(screenName: String, lastScreenName: String, start: Date, attributes: [String: Any]? = nil) {
+    func send(screenName: String, lastScreenName: String?, start: Date, attributes: [String: Any]? = nil) {
         // A new zero length span for change screen name event
         let screenNameSpan =
             tracer
@@ -83,13 +83,15 @@ extension Navigation {
 
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
         screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
-        screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        if let lastScreenName {
+            screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        }
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 
         screenNameSpan.end(time: start)
     }
 
-    func send(screenName: String, lastScreenName: String, start: Date, attributes: [String: AttributeValue]) {
+    func send(screenName: String, lastScreenName: String?, start: Date, attributes: [String: AttributeValue]) {
         // A new zero length span for change screen name event
         let screenNameSpan =
             tracer
@@ -104,7 +106,9 @@ extension Navigation {
 
         screenNameSpan.clearAndSetAttribute(key: Self.componentKey, value: Self.component)
         screenNameSpan.clearAndSetAttribute(key: Self.navigationNameKey, value: screenName)
-        screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        if let lastScreenName {
+            screenNameSpan.clearAndSetAttribute(key: Self.lastScreenNameKey, value: lastScreenName)
+        }
         screenNameSpan.clearAndSetAttribute(key: Self.screenNameKey, value: screenName)
 
         screenNameSpan.end(time: start)

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation+Span.swift
@@ -74,7 +74,7 @@ extension Navigation {
             .setStartTime(time: start)
             .startSpan()
 
-        // Write user-provided attributes first so that SDK-reserved keys always win.
+        // SDK-reserved keys are excluded before writing user-provided attributes.
         if let attributes {
             for (key, value) in attributes where !Self.screenStateReservedAttributeKeys.contains(key) {
                 screenNameSpan.clearAndSetAttribute(key: key, value: value)
@@ -102,7 +102,7 @@ extension Navigation {
             .setStartTime(time: start)
             .startSpan()
 
-        // Write user-provided attributes first so that SDK-reserved keys always win.
+        // Caller-supplied attributes have already had SDK-reserved keys filtered out.
         for (key, value) in attributes {
             screenNameSpan.clearAndSetAttribute(key: key, value: value)
         }

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorEdgeCaseTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationEventProcessorEdgeCaseTests.swift
@@ -115,7 +115,7 @@ final class NavigationEventProcessorEdgeCaseTests: XCTestCase {
         )
 
         // Confirm the processor did return attributes that attempt to override reserved keys.
-        // Navigation+Span.swift writes user attributes first, then overwrites with SDK values.
+        // Navigation+Span.swift filters SDK-reserved keys from processor attributes before writing.
         let processedEvent = await navigation.processAutomatedNavigationEvent(
             "SettingsViewController",
             controllerIdentifier: controllerIdentifier

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
@@ -272,6 +272,12 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
         let presentedController = PresentedViewController()
 
         let (module, provider) = makeModule(autoTrackingEnabled: true)
+
+        var observedNames: [String] = []
+        module.setScreenNameObserver { name in
+            observedNames.append(name)
+        }
+
         module.startDetection()
 
         // No screen has been tracked yet — storedScreenState is nil.
@@ -306,12 +312,13 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
             completed: true
         )
 
-        // After dismissal the module should reset to "unknown" (no tracked screen),
+        // After dismissal the store and the observer must both reflect "unknown",
         // not remain stuck on the dismissed modal's name.
         let didReset = await waitUntil {
             module.currentScreenNameForTesting == "unknown"
         }
         XCTAssertTrue(didReset)
+        XCTAssertEqual(observedNames.last, "unknown", "Observer must be notified with 'unknown' on dismissal with no prior screen")
     }
 
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
@@ -15,13 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// swiftformat:disable sortImports
 internal import CiscoSwizzling
 import Foundation
 @_spi(SplunkTesting) import SplunkCommon
+@_spi(SplunkInternal) @testable import SplunkNavigation
 import UIKit
 import XCTest
-
-@_spi(SplunkInternal) @testable import SplunkNavigation
 
 final class NavigationPresentationTransitionsTests: XCTestCase {
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
@@ -263,6 +263,58 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
     }
 
 
+    // MARK: - No prior screen
+
+    @MainActor
+    func testNavDismissWithNoPriorScreenResetsToUnknown() async {
+        let presentingController = PresentingViewController()
+        let navigationController = UINavigationController(rootViewController: presentingController)
+        let presentedController = PresentedViewController()
+
+        let (module, provider) = makeModule(autoTrackingEnabled: true)
+        module.startDetection()
+
+        // No screen has been tracked yet — storedScreenState is nil.
+
+        provider.emit(
+            eventType: .presentationWillBegin,
+            presented: presentedController,
+            presenting: navigationController,
+            completed: nil
+        )
+        provider.emit(
+            eventType: .presentationDidEnd,
+            presented: presentedController,
+            presenting: navigationController,
+            completed: true
+        )
+
+        await waitUntil {
+            module.currentScreenNameForTesting.contains("PresentedViewController")
+        }
+
+        provider.emit(
+            eventType: .dismissalWillBegin,
+            presented: presentedController,
+            presenting: navigationController,
+            completed: nil
+        )
+        provider.emit(
+            eventType: .dismissalDidEnd,
+            presented: presentedController,
+            presenting: navigationController,
+            completed: true
+        )
+
+        // After dismissal the module should reset to "unknown" (no tracked screen),
+        // not remain stuck on the dismissed modal's name.
+        let didReset = await waitUntil {
+            module.currentScreenNameForTesting == "unknown"
+        }
+        XCTAssertTrue(didReset)
+    }
+
+
     // MARK: - Helpers
 
     @MainActor

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationPresentationControllerTransitionsTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import UIKit
 import XCTest
 
-@testable import SplunkNavigation
+@_spi(SplunkInternal) @testable import SplunkNavigation
 
 final class NavigationPresentationTransitionsTests: XCTestCase {
 
@@ -273,9 +273,9 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
 
         let (module, provider) = makeModule(autoTrackingEnabled: true)
 
-        var observedNames: [String] = []
-        module.setScreenNameObserver { name in
-            observedNames.append(name)
+        let observer = ScreenNameObserverRecorder()
+        module.setScreenNameObserver { [observer] name in
+            observer.append(name)
         }
 
         module.startDetection()
@@ -295,9 +295,14 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
             completed: true
         )
 
-        await waitUntil {
+        let didPresent = await waitUntil {
             module.currentScreenNameForTesting.contains("PresentedViewController")
         }
+        XCTAssertTrue(didPresent, "Screen must become PresentedViewController before dismissal")
+        XCTAssertTrue(
+            observer.values.contains { $0.contains("PresentedViewController") },
+            "Observer must have seen PresentedViewController before dismissal"
+        )
 
         provider.emit(
             eventType: .dismissalWillBegin,
@@ -318,7 +323,7 @@ final class NavigationPresentationTransitionsTests: XCTestCase {
             module.currentScreenNameForTesting == "unknown"
         }
         XCTAssertTrue(didReset)
-        XCTAssertEqual(observedNames.last, "unknown", "Observer must be notified with 'unknown' on dismissal with no prior screen")
+        XCTAssertEqual(observer.last, "unknown", "Observer must be notified with 'unknown' on dismissal with no prior screen")
     }
 
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
@@ -20,8 +20,9 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 @_spi(SplunkTesting) import SplunkCommon
-@_spi(SplunkInternal) @testable import SplunkNavigation
 import XCTest
+
+@_spi(SplunkInternal) @testable import SplunkNavigation
 
 final class NavigationTrackScreenAttributesTests: XCTestCase {
 
@@ -77,7 +78,7 @@ final class NavigationTrackScreenAttributesTests: XCTestCase {
         XCTAssertEqual(span?.instrumentationScope.version, "test-agent-version")
     }
 
-    func testManualSameNameTrackEmitsEveryCallAndPreservesAttributes() async {
+    func testSameScreenEmitsEachCallWithAttributes() async {
         let module = Navigation()
 
         module.track(screen: "HomeScreen", attributes: ["step": "first"])

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
@@ -20,8 +20,9 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 @_spi(SplunkTesting) import SplunkCommon
-@_spi(SplunkInternal) @testable import SplunkNavigation
 import XCTest
+
+@_spi(SplunkInternal) @testable import SplunkNavigation
 
 final class NavigationTrackScreenAttributesTests: XCTestCase {
 
@@ -186,19 +187,6 @@ final class NavigationTrackScreenAttributesTests: XCTestCase {
 
     private var navigationSpans: [SpanData] {
         exporter.spans.filter { $0.name == "app.ui.navigation" }
-    }
-}
-
-private final class ScreenNameObserverRecorder: @unchecked Sendable {
-    private let lock = NSLock()
-    private var storedValues: [String] = []
-
-    var values: [String] {
-        lock.withLock { storedValues }
-    }
-
-    func append(_ value: String) {
-        lock.withLock { storedValues.append(value) }
     }
 }
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
@@ -90,11 +90,25 @@ final class NavigationTrackScreenAttributesTests: XCTestCase {
         let spans = navigationSpans
         XCTAssertEqual(spans.count, 2)
         XCTAssertEqual(spans[0].attributes["screen.name"]?.description, "HomeScreen")
-        XCTAssertEqual(spans[0].attributes["last.screen.name"]?.description, "unknown")
+        XCTAssertNil(spans[0].attributes["last.screen.name"], "First navigation should not emit last.screen.name")
         XCTAssertEqual(spans[0].attributes["step"]?.description, "first")
         XCTAssertEqual(spans[1].attributes["screen.name"]?.description, "HomeScreen")
         XCTAssertEqual(spans[1].attributes["last.screen.name"]?.description, "HomeScreen")
         XCTAssertEqual(spans[1].attributes["step"]?.description, "second")
+    }
+
+    func testFirstNavigationDoesNotEmitLastScreenName() async {
+        let module = Navigation()
+
+        module.track(screen: "FirstScreen")
+
+        await waitUntil {
+            self.navigationSpans.count == 1
+        }
+
+        let span = navigationSpans.first
+        XCTAssertEqual(span?.attributes["screen.name"]?.description, "FirstScreen")
+        XCTAssertNil(span?.attributes["last.screen.name"], "First navigation should not emit last.screen.name")
     }
 
     func testManualTrackDoesNotEmitWhenModuleDisabled() async {

--- a/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/NavigationTrackScreenAttributesTests.swift
@@ -20,9 +20,8 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 @_spi(SplunkTesting) import SplunkCommon
-import XCTest
-
 @_spi(SplunkInternal) @testable import SplunkNavigation
+import XCTest
 
 final class NavigationTrackScreenAttributesTests: XCTestCase {
 

--- a/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/MockPresentationEventStreamProvider.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/MockPresentationEventStreamProvider.swift
@@ -32,12 +32,14 @@ struct MockPresentationActionEvent: PresentationActionEvent {
     let completed: Bool?
 }
 
+private final class PresentationControllerProxy: Sendable {}
+
 final class MockPresentationEventStreamProvider:
     NavigationEventStreamProviding
 {
     private let presentationContinuation: AsyncStream<any PresentationActionEvent>.Continuation
     private let internalPresentationStream: AsyncStream<any PresentationActionEvent>
-    private let presentationControllerProxy = NSObject()
+    private let presentationControllerProxy = PresentationControllerProxy()
 
     init() {
         let (stream, continuation) = AsyncStream.makeStream(

--- a/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/Mocks/MockNavigationEventProcessors.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/Mocks/MockNavigationEventProcessors.swift
@@ -46,7 +46,7 @@ final class SuppressingProcessor: NavigationEventProcessor {
     }
 }
 
-final class CountingProcessor: NavigationEventProcessor {
+final class CountingProcessor: NavigationEventProcessor, @unchecked Sendable {
     private let lock = NSLock()
     private var storedCallCount = 0
 
@@ -67,7 +67,7 @@ final class CountingProcessor: NavigationEventProcessor {
     }
 }
 
-final class SequenceNavigationEventProcessor: NavigationEventProcessor {
+final class SequenceNavigationEventProcessor: NavigationEventProcessor, @unchecked Sendable {
     private let lock = NSLock()
     private let events: [NavigationEvent]
     private var nextIndex = 0

--- a/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/NavigationTestHelpers.swift
+++ b/SplunkNavigation/Tests/SplunkNavigationTests/Testing Support/NavigationTestHelpers.swift
@@ -54,3 +54,23 @@ extension Navigation {
         runtimeStateStore.screenName
     }
 }
+
+
+// MARK: - Screen name observer recording
+
+final class ScreenNameObserverRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValues: [String] = []
+
+    var values: [String] {
+        lock.withLock { storedValues }
+    }
+
+    var last: String? {
+        lock.withLock { storedValues.last }
+    }
+
+    func append(_ value: String) {
+        lock.withLock { storedValues.append(value) }
+    }
+}


### PR DESCRIPTION
## Title: Suppress "unknown" sentinel as last.screen.name on first navigation

### Description

Previously Navigation Tracking would incorrectly emit "unknown" as the name of the previous screen (last.screen.name) diverging from what happens on Android. Fixing this raised a number of edge cases so there is some complexity to it.

* `last.screen.name` is no longer emitted on the first `app.ui.navigation` span; previously the internal `"unknown"` sentinel was forwarded as the attribute value.
* Enhanced `NavigationRuntimeStateStore`, the lock-protected state holder shared by synchronous manual tracking and async automated tracking, so screen state distinguishes "no prior screen" from a real tracked screen instead of relying on the `"unknown"` sentinel string. Why we use a lock and not other approaches is explained in code comments inline. (Other "why" comments have been added as well for different parts of this).
* Dismissing a modal shown before any prior screen now resets runtime screen state and observers back to the `"unknown"` fallback instead of leaving the dismissed modal as current.
* Added `testFirstNavigationDoesNotEmitLastScreenName` and `testNavDismissWithNoPriorScreenResetsToUnknown`.
* Renamed `testManualSameNameTrackEmitsEveryCallAndPreservesAttributes` to `testSameScreenEmitsEachCallWithAttributes` and added an assertion that the first span does not emit `last.screen.name`.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

  Run tests:
  * NavigationTrackScreenAttributesTests/testFirstNavigationDoesNotEmitLastScreenName
  * NavigationTrackScreenAttributesTests/testSameScreenEmitsEachCallWithAttributes
  * NavigationPresentationTransitionsTests/testNavDismissWithNoPriorScreenResetsToUnknown

  For manual validation, capture a session and verify:
  * the first `app.ui.navigation` span has `screen.name` but no `last.screen.name`
  * a later navigation span still sets `last.screen.name` to the previous real screen
  * dismissing a modal shown before any prior screen does not leave the dismissed modal as the current
  screen