### PR TITLE
DEMRUM-5171: Implement the hide wireframe flag

### DIFF
--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPSessionReplayEventProcessor.swift
@@ -31,12 +31,23 @@ import SplunkOpenTelemetryBackgroundExporter
 /// In case the binary body is supported in the future in the upstream, we can revert back to the processors-exporters chain.
 public class OTLPSessionReplayEventProcessor: LogEventProcessor {
 
+    // MARK: - Inline types
+
+    private enum AttributeName {
+        static let segmentMetadata = "segmentMetadata"
+        static let displayWireframe = "displayWireframe"
+    }
+
+
     // MARK: - Private properties
 
     private let backgroundLogExporter: OTLPBackgroundHTTPLogExporterBinary
 
     /// Runtime attributes added manually to each exported log record.
     private unowned let runtimeAttributes: any RuntimeAttributes
+
+    /// Global attributes used for Session Replay-specific metadata decisions.
+    private let globalAttributes: () -> [String: AttributeValue]
 
     /// Resource object, added to all exported logs manually.
     private let resource: Resource
@@ -57,6 +68,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
     #if DEBUG
         public var storedLastProcessedEvent: (any AgentEvent)?
         public var storedLastSentEvent: (any AgentEvent)?
+        public var storedLastSentLogRecord: SplunkReadableLogRecord?
     #endif
 
 
@@ -66,7 +78,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         with sessionReplayEndpoint: URL?,
         resources: AgentResources,
         runtimeAttributes: RuntimeAttributes,
-        globalAttributes _: @escaping () -> [String: AttributeValue],
+        globalAttributes: @escaping () -> [String: AttributeValue],
         debugEnabled: Bool,
         accessToken: String? = nil
     ) {
@@ -90,6 +102,7 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         )
 
         self.runtimeAttributes = runtimeAttributes
+        self.globalAttributes = globalAttributes
         self.debugEnabled = debugEnabled
 
         // Session replay specific resource
@@ -239,12 +252,64 @@ public class OTLPSessionReplayEventProcessor: LogEventProcessor {
         // Merge with provided attributes
         if let providedAttributes = event.attributes {
             for (attributeName, eventAttributeValue) in providedAttributes {
-                let splunkAttributeValue = SplunkAttributeValue(eventAttributeValue: eventAttributeValue)
+                let processedAttributeValue = processedEventAttributeValue(
+                    eventAttributeValue,
+                    forAttributeNamed: attributeName
+                )
+
+                let splunkAttributeValue = SplunkAttributeValue(eventAttributeValue: processedAttributeValue)
                 attributes[attributeName] = splunkAttributeValue
             }
         }
 
         return attributes
+    }
+
+    private func processedEventAttributeValue(
+        _ attributeValue: EventAttributeValue,
+        forAttributeNamed attributeName: String
+    ) -> EventAttributeValue {
+        guard attributeName == AttributeName.segmentMetadata else {
+            return attributeValue
+        }
+
+        return segmentMetadataAttributeValue(attributeValue)
+    }
+
+    private func segmentMetadataAttributeValue(_ attributeValue: EventAttributeValue) -> EventAttributeValue {
+        guard case let .string(metadata) = attributeValue else {
+            return attributeValue
+        }
+
+        guard let updatedMetadata = metadataByAddingDisplayWireframe(to: metadata) else {
+            return attributeValue
+        }
+
+        return .string(updatedMetadata)
+    }
+
+    private func metadataByAddingDisplayWireframe(to metadata: String) -> String? {
+        guard
+            let metadataData = metadata.data(using: .utf8),
+            var metadataObject = try? JSONSerialization.jsonObject(with: metadataData) as? [String: Any]
+        else {
+            return nil
+        }
+
+        metadataObject[AttributeName.displayWireframe] =
+            OTLPInternalGlobalAttributes.shouldDisplaySessionReplayWireframe(
+                globalAttributes: globalAttributes()
+            )
+
+        guard
+            JSONSerialization.isValidJSONObject(metadataObject),
+            let updatedMetadataData = try? JSONSerialization.data(withJSONObject: metadataObject),
+            let updatedMetadata = String(data: updatedMetadataData, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        return updatedMetadata
     }
 }
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPGlobalAttributesSpanProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPGlobalAttributesSpanProcessor.swift
@@ -40,6 +40,10 @@ public class OTLPGlobalAttributesSpanProcessor: SpanProcessor {
     public func onStart(parentContext _: SpanContext?, span: ReadableSpan) {
         // Add global attributes to the span attributes when it's created
         for (key, value) in globalAttributes() {
+            guard OTLPInternalGlobalAttributes.shouldExport(key: key) else {
+                continue
+            }
+
             span.clearAndSetAttribute(key: key, value: value)
         }
     }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPGlobalAttributesSpanProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPGlobalAttributesSpanProcessor.swift
@@ -39,11 +39,7 @@ public class OTLPGlobalAttributesSpanProcessor: SpanProcessor {
 
     public func onStart(parentContext _: SpanContext?, span: ReadableSpan) {
         // Add global attributes to the span attributes when it's created
-        for (key, value) in globalAttributes() {
-            guard OTLPInternalGlobalAttributes.shouldExport(key: key) else {
-                continue
-            }
-
+        for (key, value) in globalAttributes() where OTLPInternalGlobalAttributes.shouldExport(key: key) {
             span.clearAndSetAttribute(key: key, value: value)
         }
     }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Utils/OTLPInternalGlobalAttributes.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Utils/OTLPInternalGlobalAttributes.swift
@@ -1,0 +1,37 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import OpenTelemetryApi
+
+enum OTLPInternalGlobalAttributes {
+
+    // MARK: - Constants
+
+    static let prefix = "splunk.agent.internal."
+    static let sessionReplayHideWireframe = "\(prefix)sessionReplay.hideWireframe"
+
+
+    // MARK: - Utilities
+
+    static func shouldExport(key: String) -> Bool {
+        !key.hasPrefix(prefix)
+    }
+
+    static func shouldDisplaySessionReplayWireframe(globalAttributes: [String: AttributeValue]) -> Bool {
+        !globalAttributes.keys.contains(sessionReplayHideWireframe)
+    }
+}

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPGlobalAttributesSpanProcessorTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPGlobalAttributesSpanProcessorTests.swift
@@ -1,0 +1,73 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import XCTest
+
+@testable import SplunkOpenTelemetry
+
+final class OTLPGlobalAttributesSpanProcessorTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func testSpanReceivesGlobalAttributes() throws {
+        let exportedSpan = try recordedSpan(
+            globalAttributes: [
+                "app.version": .string("1.0")
+            ]
+        )
+
+        XCTAssertEqual(exportedSpan.attributes["app.version"]?.description, "1.0")
+    }
+
+    func testSpanSkipsInternalGlobalAttributes() throws {
+        let exportedSpan = try recordedSpan(
+            globalAttributes: [
+                "app.version": .string("1.0"),
+                OTLPInternalGlobalAttributes.sessionReplayHideWireframe: .bool(true)
+            ]
+        )
+
+        XCTAssertEqual(exportedSpan.attributes["app.version"]?.description, "1.0")
+        XCTAssertNil(exportedSpan.attributes[OTLPInternalGlobalAttributes.sessionReplayHideWireframe])
+    }
+
+
+    // MARK: - Private
+
+    private func recordedSpan(globalAttributes: [String: AttributeValue]) throws -> SpanData {
+        let tracerProvider = TracerProviderBuilder()
+            .add(
+                spanProcessor: OTLPGlobalAttributesSpanProcessor {
+                    globalAttributes
+                }
+            )
+            .build()
+
+        let tracer = tracerProvider.get(
+            instrumentationName: "test",
+            instrumentationVersion: "1.0"
+        )
+
+        let span = tracer.spanBuilder(spanName: "background-task").startSpan()
+        span.end()
+        let readableSpan = try XCTUnwrap(span as? ReadableSpan)
+
+        return readableSpan.toSpanData()
+    }
+}


### PR DESCRIPTION
Implement the hide wireframe flag

### Description

This PR implements a temporary solution for hybrids to hide wireframe in the player, by implementing the ability to set global attributes with a specific internal prefix. Global attributes with this prefix do not get exported and are for internal agent consumption only.

Hybrids will now be able to set a `splunk.agent.internal.sessionReplay.hideWireframe` global attribute. If this attribute is present (with any value), the agents sets the new `displayWireframe` session replay metadata flag to `false`.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Check console logs:

By default, the session replay's log record `metadata` object should contain the `"displayWireframe":true` attribute.

When the `splunk.agent.internal.sessionReplay.hideWireframe` global attribute is set (with any value), the `metadata` should contain `"displayWireframe":false`.

Any `splunk.agent.internal.*` prefixed global attribute should not be exported (visible in the logs).

### Future Considerations (Optional)

Feature in this PR will later be removed and succeeded by a better internal api mechanism.
