### PR TITLE
NO-TICKET: docs: remove outdated public-o11y-docs contribution note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,6 @@ Prescriptive guidance consists of step-by-step instructions, conceptual material
 and decision support for customers. Reference documentation and development
 documentation is still hosted on this repository.
 
-To contribute documentation for this project, open a pull request in the
-[public-o11y-docs](https://github.com/splunk/public-o11y-docs) repository. See
-the [CONTRIBUTING.md](https://github.com/splunk/public-o11y-docs/blob/main/CONTRIBUTING.md)
-guide of the Splunk Observability Cloud documentation for more information.
-
 ## Finding contributions to work on
 
 Looking at the existing issues is a great way to find something to contribute


### PR DESCRIPTION
## Title: remove outdated public-o11y-docs contribution note

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.
### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI