### PR TITLE
DEMRUM-5839: Add Request Marker for Internal Network Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed SDK-owned exporter uploads incorrectly being emitted as Network Instrumentation HTTP spans. Internal SDK requests are now excluded from network telemetry. #683
+
 ## [2.3.1] - 2026-06-15
 
 ### Fixed

--- a/SplunkCommon/Sources/SplunkCommon/Utils/InternalNetworkRequestMarker.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Utils/InternalNetworkRequestMarker.swift
@@ -1,0 +1,48 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// Marks URL requests that are owned by the SDK and must not be captured by network instrumentation.
+@_spi(SplunkInternal)
+public enum InternalNetworkRequestMarker {
+
+    // MARK: - Constants
+
+    private static let propertyKey = "com.splunk.rum.internal-network-request"
+
+
+    // MARK: - Request marking
+
+    /// Returns a copy of the request marked as SDK-internal.
+    ///
+    /// The marker is stored as a local `URLProtocol` property, so it is available to in-process
+    /// instrumentation but is not serialized as an HTTP header or sent over the wire.
+    public static func mark(_ request: URLRequest) -> URLRequest {
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            return request
+        }
+
+        URLProtocol.setProperty(true, forKey: propertyKey, in: mutableRequest)
+        return mutableRequest as URLRequest
+    }
+
+    /// Returns whether the request was marked as SDK-internal.
+    public static func isMarked(_ request: URLRequest) -> Bool {
+        URLProtocol.property(forKey: propertyKey, in: request) as? Bool == true
+    }
+}

--- a/SplunkCommon/Sources/SplunkCommon/Utils/InternalNetworkRequestMarker.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Utils/InternalNetworkRequestMarker.swift
@@ -18,8 +18,7 @@ limitations under the License.
 import Foundation
 
 /// Marks URL requests that are owned by the SDK and must not be captured by network instrumentation.
-@_spi(SplunkInternal)
-public enum InternalNetworkRequestMarker {
+package enum InternalNetworkRequestMarker {
 
     // MARK: - Constants
 
@@ -32,7 +31,7 @@ public enum InternalNetworkRequestMarker {
     ///
     /// The marker is stored as a local `URLProtocol` property, so it is available to in-process
     /// instrumentation but is not serialized as an HTTP header or sent over the wire.
-    public static func mark(_ request: URLRequest) -> URLRequest {
+    package static func mark(_ request: URLRequest) -> URLRequest {
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             return request
         }
@@ -42,7 +41,7 @@ public enum InternalNetworkRequestMarker {
     }
 
     /// Returns whether the request was marked as SDK-internal.
-    public static func isMarked(_ request: URLRequest) -> Bool {
+    package static func isMarked(_ request: URLRequest) -> Bool {
         URLProtocol.property(forKey: propertyKey, in: request) as? Bool == true
     }
 }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
@@ -215,6 +215,7 @@ func swizzleDownloadTaskWithResumeData() {
         guard let request = task.currentRequest else {
             return task
         }
+
         guard shouldInstrumentRequest(request) else {
             return markSkippedForInstrumentation(task)
         }
@@ -259,6 +260,7 @@ func swizzleDownloadTaskWithResumeDataAndCompletion() {
         guard let request = task.currentRequest else {
             return task
         }
+
         guard shouldInstrumentRequest(request) else {
             return markSkippedForInstrumentation(task)
         }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
@@ -61,11 +61,11 @@ func swizzleDownloadTaskWithURL() {
 
         let request = URLRequest(url: url)
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, url)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, url)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -111,11 +111,11 @@ func swizzleDownloadTaskWithRequestAndCompletion() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -164,11 +164,11 @@ func swizzleDownloadTaskWithURLAndCompletion() {
 
         let request = URLRequest(url: url)
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, url, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, url, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -212,12 +212,15 @@ func swizzleDownloadTaskWithResumeData() {
 
         // Header injection is not possible for resumed downloads because the request
         // is embedded in the opaque resume data. We only create a span for observability.
-        guard let request = task.currentRequest, shouldInstrumentRequest(request) else {
+        guard let request = task.currentRequest else {
             return task
+        }
+        guard shouldInstrumentRequest(request) else {
+            return markSkippedForInstrumentation(task)
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return task
+            return markSkippedForInstrumentation(task)
         }
 
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
@@ -253,12 +256,15 @@ func swizzleDownloadTaskWithResumeDataAndCompletion() {
         // Create the task first since the request is embedded in resume data
         let task = castedIMP(session, selector, resumeData, completion)
 
-        guard let request = task.currentRequest, shouldInstrumentRequest(request) else {
+        guard let request = task.currentRequest else {
             return task
+        }
+        guard shouldInstrumentRequest(request) else {
+            return markSkippedForInstrumentation(task)
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return task
+            return markSkippedForInstrumentation(task)
         }
 
         objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
@@ -60,27 +60,22 @@ func swizzleDownloadTaskWithURL() {
         )
 
         let request = URLRequest(url: url)
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-
-        // Call the ORIGINAL (un-swizzled) request-based method directly.
-        // This bypasses the request-based swizzle, preventing double instrumentation
-        // when trace header injection is disabled.
-        let castedRequestIMP = unsafeBitCast(
-            originalRequestIMP,
-            to: (@convention(c) (URLSession, Selector, URLRequest) -> URLSessionDownloadTask).self
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, url)
+            },
+            createInstrumentedTask: { instrumentedRequest, _ in
+                // Call the ORIGINAL (un-swizzled) request-based method directly.
+                // This bypasses the request-based swizzle, preventing double instrumentation
+                // when trace header injection is disabled.
+                let castedRequestIMP = unsafeBitCast(
+                    originalRequestIMP,
+                    to: (@convention(c) (URLSession, Selector, URLRequest) -> URLSessionDownloadTask).self
+                )
+                return castedRequestIMP(session, requestSelector, instrumentedRequest)
+            }
         )
-        let task = castedRequestIMP(session, requestSelector, instrumentedRequest)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -110,21 +105,16 @@ func swizzleDownloadTaskWithRequestAndCompletion() {
             to: (@convention(c) (URLSession, Selector, URLRequest, DownloadHandler?) -> URLSessionDownloadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
-
-        let task = castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
+                return castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -163,25 +153,20 @@ func swizzleDownloadTaskWithURLAndCompletion() {
         )
 
         let request = URLRequest(url: url)
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
-
-        let castedRequestIMP = unsafeBitCast(
-            originalRequestIMP,
-            to: (@convention(c) (URLSession, Selector, URLRequest, DownloadHandler?) -> URLSessionDownloadTask).self
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, url, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
+                let castedRequestIMP = unsafeBitCast(
+                    originalRequestIMP,
+                    to: (@convention(c) (URLSession, Selector, URLRequest, DownloadHandler?) -> URLSessionDownloadTask).self
+                )
+                return castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
+            }
         )
-        let task = castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -216,17 +201,7 @@ func swizzleDownloadTaskWithResumeData() {
             return task
         }
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(task)
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(task)
-        }
-
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return instrumentTaskAtCreationIfNeeded(task, request: request)
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -261,17 +236,7 @@ func swizzleDownloadTaskWithResumeDataAndCompletion() {
             return task
         }
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(task)
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(task)
-        }
-
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return instrumentTaskAtCreationIfNeeded(task, request: request)
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
@@ -36,6 +36,10 @@ func startHttpSpan(request: URLRequest?) -> Span? {
         return nil
     }
 
+    if TraceContextInjector.hasTraceContext(in: request) {
+        return nil
+    }
+
     if !(url.scheme?.lowercased().starts(with: "http") ?? false) {
         return nil
     }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
@@ -29,6 +29,13 @@ func startHttpSpan(request: URLRequest?) -> Span? {
         return nil
     }
 
+    if InternalNetworkRequestMarker.isMarked(request) {
+        NetworkInstrumentationManager.shared.logger.log(level: .debug) {
+            "URL excluded as an internal SDK request \(url.absoluteString)"
+        }
+        return nil
+    }
+
     if !(url.scheme?.lowercased().starts(with: "http") ?? false) {
         return nil
     }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
@@ -36,10 +36,6 @@ func startHttpSpan(request: URLRequest?) -> Span? {
         return nil
     }
 
-    if TraceContextInjector.hasTraceContext(in: request) {
-        return nil
-    }
-
     if !(url.scheme?.lowercased().starts(with: "http") ?? false) {
         return nil
     }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Swizzling.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Swizzling.swift
@@ -67,6 +67,10 @@ extension URLSessionTask {
             return
         }
 
+        if wasSkippedForInstrumentation(self) {
+            return
+        }
+
         // Check if we already have a span from a previous resume call
         let existingSpan: Span? = objc_getAssociatedObject(self, &associatedKeySpanResume) as? Span
         if existingSpan != nil {

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -23,6 +23,7 @@ import OpenTelemetryApi
 
 var associatedKeySpan: UInt8 = 0
 var associatedKeyInstrumented: UInt8 = 1
+var associatedKeySkipped: UInt8 = 2
 
 // MARK: - Original IMP Storage
 
@@ -169,11 +170,11 @@ func createInstrumentedDataTask(
     originalIMP: (URLSession, Selector, Any) -> URLSessionDataTask
 ) -> URLSessionDataTask {
     guard shouldInstrumentRequest(request) else {
-        return originalIMP(session, selector, request)
+        return markSkippedForInstrumentation(originalIMP(session, selector, request))
     }
 
     guard let span = startHttpSpan(request: request) else {
-        return originalIMP(session, selector, request)
+        return markSkippedForInstrumentation(originalIMP(session, selector, request))
     }
 
     let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -194,11 +195,11 @@ func createInstrumentedDownloadTask(
     originalIMP: (URLSession, Selector, Any) -> URLSessionDownloadTask
 ) -> URLSessionDownloadTask {
     guard shouldInstrumentRequest(request) else {
-        return originalIMP(session, selector, request)
+        return markSkippedForInstrumentation(originalIMP(session, selector, request))
     }
 
     guard let span = startHttpSpan(request: request) else {
-        return originalIMP(session, selector, request)
+        return markSkippedForInstrumentation(originalIMP(session, selector, request))
     }
 
     let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -209,10 +210,12 @@ func createInstrumentedDownloadTask(
 }
 
 func shouldInstrumentRequest(_ request: URLRequest) -> Bool {
-    // Prevent double-instrumentation of requests that already carry trace context.
+    // Prevent instrumentation of SDK-owned requests and double-instrumentation of
+    // requests that already carry trace context.
     // All other filtering (URL scheme, excluded endpoints, ignoreURLs) is handled
     // by startHttpSpan, which is always called immediately after this check.
-    !TraceContextInjector.hasTraceContext(in: request)
+    !InternalNetworkRequestMarker.isMarked(request)
+        && !TraceContextInjector.hasTraceContext(in: request)
 }
 
 func injectTraceContextIfEnabled(into request: URLRequest, span: Span) -> URLRequest {
@@ -298,6 +301,17 @@ func endHttpSpanFromCompletion(span: Span, response: URLResponse?, error: Error?
 /// This is used by the resume swizzling to avoid double instrumentation.
 func wasInstrumentedAtCreation(_ task: URLSessionTask) -> Bool {
     objc_getAssociatedObject(task, &associatedKeyInstrumented) as? Bool ?? false
+}
+
+/// Checks if a URLSessionTask was intentionally skipped during task creation.
+func wasSkippedForInstrumentation(_ task: URLSessionTask) -> Bool {
+    objc_getAssociatedObject(task, &associatedKeySkipped) as? Bool ?? false
+}
+
+/// Marks a URLSessionTask as intentionally skipped during task creation.
+func markSkippedForInstrumentation<T: URLSessionTask>(_ task: T) -> T {
+    objc_setAssociatedObject(task, &associatedKeySkipped, true, .OBJC_ASSOCIATION_RETAIN)
+    return task
 }
 
 /// Gets the span associated with a task during creation.

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -106,6 +106,7 @@ func swizzleURLSessionTaskCreation() {
 
 enum RequestInstrumentationDecision {
     case instrumentAtCreation
+    case deferToResume
     case skipInstrumentation
 }
 
@@ -212,7 +213,7 @@ func instrumentationDecision(for request: URLRequest) -> RequestInstrumentationD
     }
 
     if TraceContextInjector.hasTraceContext(in: request) {
-        return .skipInstrumentation
+        return .deferToResume
     }
 
     return .instrumentAtCreation
@@ -226,6 +227,9 @@ func createTaskWithInstrumentation<T: URLSessionTask>(
     switch instrumentationDecision(for: request) {
     case .skipInstrumentation:
         return markSkippedForInstrumentation(createOriginalTask())
+
+    case .deferToResume:
+        return createOriginalTask()
 
     case .instrumentAtCreation:
         guard let span = startHttpSpan(request: request) else {
@@ -247,6 +251,9 @@ func instrumentTaskAtCreationIfNeeded<T: URLSessionTask>(
     switch instrumentationDecision(for: request) {
     case .skipInstrumentation:
         return markSkippedForInstrumentation(task)
+
+    case .deferToResume:
+        return task
 
     case .instrumentAtCreation:
         guard let span = startHttpSpan(request: request) else {

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -106,7 +106,6 @@ func swizzleURLSessionTaskCreation() {
 
 enum RequestInstrumentationDecision {
     case instrumentAtCreation
-    case deferToResume
     case skipInstrumentation
 }
 
@@ -213,7 +212,7 @@ func instrumentationDecision(for request: URLRequest) -> RequestInstrumentationD
     }
 
     if TraceContextInjector.hasTraceContext(in: request) {
-        return .deferToResume
+        return .skipInstrumentation
     }
 
     return .instrumentAtCreation
@@ -227,9 +226,6 @@ func createTaskWithInstrumentation<T: URLSessionTask>(
     switch instrumentationDecision(for: request) {
     case .skipInstrumentation:
         return markSkippedForInstrumentation(createOriginalTask())
-
-    case .deferToResume:
-        return createOriginalTask()
 
     case .instrumentAtCreation:
         guard let span = startHttpSpan(request: request) else {
@@ -251,9 +247,6 @@ func instrumentTaskAtCreationIfNeeded<T: URLSessionTask>(
     switch instrumentationDecision(for: request) {
     case .skipInstrumentation:
         return markSkippedForInstrumentation(task)
-
-    case .deferToResume:
-        return task
 
     case .instrumentAtCreation:
         guard let span = startHttpSpan(request: request) else {

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -104,6 +104,12 @@ func swizzleURLSessionTaskCreation() {
 
 // MARK: - Helper Functions
 
+enum RequestInstrumentationDecision {
+    case instrumentAtCreation
+    case deferToResume
+    case skipInstrumentation
+}
+
 func swizzleTaskCreationMethod(
     selector: Selector,
     handler: @escaping (URLSession, Any, @escaping (URLSession, Selector, Any) -> URLSessionDataTask) -> URLSessionDataTask
@@ -169,19 +175,15 @@ func createInstrumentedDataTask(
     selector: Selector,
     originalIMP: (URLSession, Selector, Any) -> URLSessionDataTask
 ) -> URLSessionDataTask {
-    guard shouldInstrumentRequest(request) else {
-        return markSkippedForInstrumentation(originalIMP(session, selector, request))
-    }
-
-    guard let span = startHttpSpan(request: request) else {
-        return markSkippedForInstrumentation(originalIMP(session, selector, request))
-    }
-
-    let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-    let task = originalIMP(session, selector, instrumentedRequest)
-    objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-    objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-    return task
+    createTaskWithInstrumentation(
+        request: request,
+        createOriginalTask: {
+            originalIMP(session, selector, request)
+        },
+        createInstrumentedTask: { instrumentedRequest, _ in
+            originalIMP(session, selector, instrumentedRequest)
+        }
+    )
 }
 
 /// Creates a download task with instrumentation: starts a span, injects trace headers, and
@@ -194,28 +196,72 @@ func createInstrumentedDownloadTask(
     selector: Selector,
     originalIMP: (URLSession, Selector, Any) -> URLSessionDownloadTask
 ) -> URLSessionDownloadTask {
-    guard shouldInstrumentRequest(request) else {
-        return markSkippedForInstrumentation(originalIMP(session, selector, request))
-    }
-
-    guard let span = startHttpSpan(request: request) else {
-        return markSkippedForInstrumentation(originalIMP(session, selector, request))
-    }
-
-    let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-    let task = originalIMP(session, selector, instrumentedRequest)
-    objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-    objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-    return task
+    createTaskWithInstrumentation(
+        request: request,
+        createOriginalTask: {
+            originalIMP(session, selector, request)
+        },
+        createInstrumentedTask: { instrumentedRequest, _ in
+            originalIMP(session, selector, instrumentedRequest)
+        }
+    )
 }
 
-func shouldInstrumentRequest(_ request: URLRequest) -> Bool {
-    // Prevent instrumentation of SDK-owned requests and double-instrumentation of
-    // requests that already carry trace context.
-    // All other filtering (URL scheme, excluded endpoints, ignoreURLs) is handled
-    // by startHttpSpan, which is always called immediately after this check.
-    !InternalNetworkRequestMarker.isMarked(request)
-        && !TraceContextInjector.hasTraceContext(in: request)
+func instrumentationDecision(for request: URLRequest) -> RequestInstrumentationDecision {
+    if InternalNetworkRequestMarker.isMarked(request) {
+        return .skipInstrumentation
+    }
+
+    if TraceContextInjector.hasTraceContext(in: request) {
+        return .deferToResume
+    }
+
+    return .instrumentAtCreation
+}
+
+func createTaskWithInstrumentation<T: URLSessionTask>(
+    request: URLRequest,
+    createOriginalTask: () -> T,
+    createInstrumentedTask: (_ instrumentedRequest: URLRequest, _ span: Span) -> T
+) -> T {
+    switch instrumentationDecision(for: request) {
+    case .skipInstrumentation:
+        return markSkippedForInstrumentation(createOriginalTask())
+
+    case .deferToResume:
+        return createOriginalTask()
+
+    case .instrumentAtCreation:
+        guard let span = startHttpSpan(request: request) else {
+            return markSkippedForInstrumentation(createOriginalTask())
+        }
+
+        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
+        return markInstrumentedAtCreation(
+            createInstrumentedTask(instrumentedRequest, span),
+            span: span
+        )
+    }
+}
+
+func instrumentTaskAtCreationIfNeeded<T: URLSessionTask>(
+    _ task: T,
+    request: URLRequest
+) -> T {
+    switch instrumentationDecision(for: request) {
+    case .skipInstrumentation:
+        return markSkippedForInstrumentation(task)
+
+    case .deferToResume:
+        return task
+
+    case .instrumentAtCreation:
+        guard let span = startHttpSpan(request: request) else {
+            return markSkippedForInstrumentation(task)
+        }
+
+        return markInstrumentedAtCreation(task, span: span)
+    }
 }
 
 func injectTraceContextIfEnabled(into request: URLRequest, span: Span) -> URLRequest {
@@ -311,6 +357,12 @@ func wasSkippedForInstrumentation(_ task: URLSessionTask) -> Bool {
 /// Marks a URLSessionTask as intentionally skipped during task creation.
 func markSkippedForInstrumentation<T: URLSessionTask>(_ task: T) -> T {
     objc_setAssociatedObject(task, &associatedKeySkipped, true, .OBJC_ASSOCIATION_RETAIN)
+    return task
+}
+
+func markInstrumentedAtCreation<T: URLSessionTask>(_ task: T, span: Span) -> T {
+    objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
+    objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
     return task
 }
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
@@ -61,11 +61,11 @@ func swizzleDataTaskWithURL() {
 
         let request = URLRequest(url: url)
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, url)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, url)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -108,12 +108,12 @@ func swizzleDataTaskWithRequestAndCompletion() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
         }
 
         // Create span and inject headers
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -162,12 +162,12 @@ func swizzleDataTaskWithURLAndCompletion() {
 
         let request = URLRequest(url: url)
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, url, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
         }
 
         // Create span and inject headers
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, url, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -212,11 +212,11 @@ func swizzleUploadTaskWithRequestFromData() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, data)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, data))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, data)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, data))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -250,11 +250,11 @@ func swizzleUploadTaskWithRequestFromFile() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, fileURL)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, fileURL)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -291,11 +291,11 @@ func swizzleUploadTaskWithRequestFromDataAndCompletion() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, data, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, data, completion))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, data, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, data, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -334,11 +334,11 @@ func swizzleUploadTaskWithRequestFromFileAndCompletion() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request, fileURL, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL, completion))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request, fileURL, completion)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL, completion))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
@@ -375,11 +375,11 @@ func swizzleUploadTaskWithStreamedRequest() {
         )
 
         guard shouldInstrumentRequest(request) else {
-            return castedIMP(session, selector, request)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request))
         }
 
         guard let span = startHttpSpan(request: request) else {
-            return castedIMP(session, selector, request)
+            return markSkippedForInstrumentation(castedIMP(session, selector, request))
         }
 
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
@@ -60,27 +60,22 @@ func swizzleDataTaskWithURL() {
         )
 
         let request = URLRequest(url: url)
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-
-        // Call the ORIGINAL (un-swizzled) request-based method directly.
-        // This bypasses the request-based swizzle, preventing double instrumentation
-        // when trace header injection is disabled.
-        let castedRequestIMP = unsafeBitCast(
-            originalRequestIMP,
-            to: (@convention(c) (URLSession, Selector, URLRequest) -> URLSessionDataTask).self
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, url)
+            },
+            createInstrumentedTask: { instrumentedRequest, _ in
+                // Call the ORIGINAL (un-swizzled) request-based method directly.
+                // This bypasses the request-based swizzle, preventing double instrumentation
+                // when trace header injection is disabled.
+                let castedRequestIMP = unsafeBitCast(
+                    originalRequestIMP,
+                    to: (@convention(c) (URLSession, Selector, URLRequest) -> URLSessionDataTask).self
+                )
+                return castedRequestIMP(session, requestSelector, instrumentedRequest)
+            }
         )
-        let task = castedRequestIMP(session, requestSelector, instrumentedRequest)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -107,22 +102,16 @@ func swizzleDataTaskWithRequestAndCompletion() {
             to: (@convention(c) (URLSession, Selector, URLRequest, CompletionHandler?) -> URLSessionDataTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
-        }
-
-        // Create span and inject headers
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapCompletionHandler(completion, span: span)
-
-        let task = castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+                return castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -161,29 +150,24 @@ func swizzleDataTaskWithURLAndCompletion() {
         )
 
         let request = URLRequest(url: url)
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
-        }
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, url, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
 
-        // Create span and inject headers
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, url, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapCompletionHandler(completion, span: span)
-
-        // Call the ORIGINAL (un-swizzled) request-based method directly.
-        // This bypasses the request-based swizzle, preventing double instrumentation
-        // when trace header injection is disabled.
-        let castedRequestIMP = unsafeBitCast(
-            originalRequestIMP,
-            to: (@convention(c) (URLSession, Selector, URLRequest, CompletionHandler?) -> URLSessionDataTask).self
+                // Call the ORIGINAL (un-swizzled) request-based method directly.
+                // This bypasses the request-based swizzle, preventing double instrumentation
+                // when trace header injection is disabled.
+                let castedRequestIMP = unsafeBitCast(
+                    originalRequestIMP,
+                    to: (@convention(c) (URLSession, Selector, URLRequest, CompletionHandler?) -> URLSessionDataTask).self
+                )
+                return castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
+            }
         )
-        let task = castedRequestIMP(session, requestSelector, instrumentedRequest, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -211,19 +195,15 @@ func swizzleUploadTaskWithRequestFromData() {
             to: (@convention(c) (URLSession, Selector, URLRequest, Data?) -> URLSessionUploadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, data))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, data))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let task = castedIMP(session, selector, instrumentedRequest, data)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, data)
+            },
+            createInstrumentedTask: { instrumentedRequest, _ in
+                castedIMP(session, selector, instrumentedRequest, data)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -249,19 +229,15 @@ func swizzleUploadTaskWithRequestFromFile() {
             to: (@convention(c) (URLSession, Selector, URLRequest, URL) -> URLSessionUploadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let task = castedIMP(session, selector, instrumentedRequest, fileURL)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, fileURL)
+            },
+            createInstrumentedTask: { instrumentedRequest, _ in
+                castedIMP(session, selector, instrumentedRequest, fileURL)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -290,21 +266,16 @@ func swizzleUploadTaskWithRequestFromDataAndCompletion() {
             to: (@convention(c) (URLSession, Selector, URLRequest, Data?, CompletionHandler?) -> URLSessionUploadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, data, completion))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, data, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapCompletionHandler(completion, span: span)
-
-        let task = castedIMP(session, selector, instrumentedRequest, data, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, data, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+                return castedIMP(session, selector, instrumentedRequest, data, wrappedCompletion)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -333,21 +304,16 @@ func swizzleUploadTaskWithRequestFromFileAndCompletion() {
             to: (@convention(c) (URLSession, Selector, URLRequest, URL, CompletionHandler?) -> URLSessionUploadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL, completion))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request, fileURL, completion))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let wrappedCompletion = wrapCompletionHandler(completion, span: span)
-
-        let task = castedIMP(session, selector, instrumentedRequest, fileURL, wrappedCompletion)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request, fileURL, completion)
+            },
+            createInstrumentedTask: { instrumentedRequest, span in
+                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+                return castedIMP(session, selector, instrumentedRequest, fileURL, wrappedCompletion)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))
@@ -374,19 +340,15 @@ func swizzleUploadTaskWithStreamedRequest() {
             to: (@convention(c) (URLSession, Selector, URLRequest) -> URLSessionUploadTask).self
         )
 
-        guard shouldInstrumentRequest(request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request))
-        }
-
-        guard let span = startHttpSpan(request: request) else {
-            return markSkippedForInstrumentation(castedIMP(session, selector, request))
-        }
-
-        let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
-        let task = castedIMP(session, selector, instrumentedRequest)
-        objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
-        objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
-        return task
+        return createTaskWithInstrumentation(
+            request: request,
+            createOriginalTask: {
+                castedIMP(session, selector, request)
+            },
+            createInstrumentedTask: { instrumentedRequest, _ in
+                castedIMP(session, selector, instrumentedRequest)
+            }
+        )
     }
 
     let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(block, to: AnyObject.self))

--- a/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
@@ -124,6 +124,39 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
 
     // MARK: - Download Task Completion Handler Tests
 
+    func testDataTaskWithExistingTraceparent_CreatesSpanAtResumeWithoutOverwritingHeader() throws {
+        let existingTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        let url = URLSessionMockProtocol.url(path: "/headers")
+        var request = URLRequest(url: url)
+        request.setValue(existingTraceparent, forHTTPHeaderField: "traceparent")
+
+        let expectation = expectation(description: "Completion called")
+        var responseBody: Data?
+        let session = URLSession(configuration: URLSessionMockProtocol.configuration())
+
+        let task = session.dataTask(with: request) { data, _, _ in
+            responseBody = data
+            expectation.fulfill()
+        }
+
+        XCTAssertFalse(wasSkippedForInstrumentation(task))
+        XCTAssertFalse(wasInstrumentedAtCreation(task))
+
+        task.resume()
+
+        wait(for: [expectation], timeout: 10.0)
+        waitForSpans(count: 1)
+
+        let body = try XCTUnwrap(responseBody, "Mock protocol should return a response body")
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let headers = try XCTUnwrap(json["headers"] as? [String: Any])
+        let receivedTraceparent = try XCTUnwrap((headers["Traceparent"] ?? headers["traceparent"]) as? String)
+        XCTAssertEqual(receivedTraceparent, existingTraceparent)
+
+        let spans = Self.exporter.spans.filter { $0.name.starts(with: "HTTP") }
+        XCTAssertEqual(spans.count, 1, "Existing traceparent customer requests should still create one HTTP span")
+    }
+
     func testDownloadTaskWithRequestAndCompletion_CreatesSpan() {
         let url = URLSessionMockProtocol.url()
         let request = URLRequest(url: url)

--- a/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
@@ -124,7 +124,7 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
 
     // MARK: - Download Task Completion Handler Tests
 
-    func testDataTaskWithExistingTraceparent_DoesNotCreateSpanOrOverwriteHeader() throws {
+    func testDataTaskWithExistingTraceparent_CreatesSpanAtResumeWithoutOverwritingHeader() throws {
         let existingTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
         let url = URLSessionMockProtocol.url(path: "/headers")
         var request = URLRequest(url: url)
@@ -139,13 +139,13 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
             expectation.fulfill()
         }
 
-        XCTAssertTrue(wasSkippedForInstrumentation(task))
+        XCTAssertFalse(wasSkippedForInstrumentation(task))
         XCTAssertFalse(wasInstrumentedAtCreation(task))
 
         task.resume()
 
         wait(for: [expectation], timeout: 10.0)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        waitForSpans(count: 1)
 
         let body = try XCTUnwrap(responseBody, "Mock protocol should return a response body")
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
@@ -154,7 +154,7 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
         XCTAssertEqual(receivedTraceparent, existingTraceparent)
 
         let spans = Self.exporter.spans.filter { $0.name.starts(with: "HTTP") }
-        XCTAssertTrue(spans.isEmpty, "Requests with existing traceparent should not create duplicate HTTP spans")
+        XCTAssertEqual(spans.count, 1, "Existing traceparent customer requests should still create one HTTP span")
     }
 
     func testDownloadTaskWithRequestAndCompletion_CreatesSpan() {

--- a/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/AdditionalTaskSwizzlingTests.swift
@@ -124,7 +124,7 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
 
     // MARK: - Download Task Completion Handler Tests
 
-    func testDataTaskWithExistingTraceparent_CreatesSpanAtResumeWithoutOverwritingHeader() throws {
+    func testDataTaskWithExistingTraceparent_DoesNotCreateSpanOrOverwriteHeader() throws {
         let existingTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
         let url = URLSessionMockProtocol.url(path: "/headers")
         var request = URLRequest(url: url)
@@ -139,13 +139,13 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
             expectation.fulfill()
         }
 
-        XCTAssertFalse(wasSkippedForInstrumentation(task))
+        XCTAssertTrue(wasSkippedForInstrumentation(task))
         XCTAssertFalse(wasInstrumentedAtCreation(task))
 
         task.resume()
 
         wait(for: [expectation], timeout: 10.0)
-        waitForSpans(count: 1)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
 
         let body = try XCTUnwrap(responseBody, "Mock protocol should return a response body")
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
@@ -154,7 +154,7 @@ final class AdditionalTaskSwizzlingTests: XCTestCase {
         XCTAssertEqual(receivedTraceparent, existingTraceparent)
 
         let spans = Self.exporter.spans.filter { $0.name.starts(with: "HTTP") }
-        XCTAssertEqual(spans.count, 1, "Existing traceparent customer requests should still create one HTTP span")
+        XCTAssertTrue(spans.isEmpty, "Requests with existing traceparent should not create duplicate HTTP spans")
     }
 
     func testDownloadTaskWithRequestAndCompletion_CreatesSpan() {

--- a/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
@@ -1,0 +1,47 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SplunkCommon
+import XCTest
+
+@testable import SplunkNetwork
+
+final class RequestInstrumentationDecisionTests: XCTestCase {
+
+    func testInstrumentationDecisionWithExistingTraceparentDefersToResume() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/customer-request"))
+        var request = URLRequest(url: url)
+        request.setValue("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", forHTTPHeaderField: "traceparent")
+
+        if case .deferToResume = instrumentationDecision(for: request) {
+            return
+        }
+
+        XCTFail("Customer requests with existing traceparent should defer to resume-time instrumentation")
+    }
+
+    func testInstrumentationDecisionWithInternalSDKMarkedRequestSkipsInstrumentation() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/v1/rum"))
+        let request = InternalNetworkRequestMarker.mark(URLRequest(url: url))
+
+        if case .skipInstrumentation = instrumentationDecision(for: request) {
+            return
+        }
+
+        XCTFail("SDK-internal marked requests should be skipped")
+    }
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
@@ -22,16 +22,16 @@ import XCTest
 
 final class RequestInstrumentationDecisionTests: XCTestCase {
 
-    func testInstrumentationDecisionWithExistingTraceparentDefersToResume() throws {
+    func testInstrumentationDecisionWithExistingTraceparentSkipsInstrumentation() throws {
         let url = try XCTUnwrap(URL(string: "https://example.com/customer-request"))
         var request = URLRequest(url: url)
         request.setValue("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", forHTTPHeaderField: "traceparent")
 
-        if case .deferToResume = instrumentationDecision(for: request) {
+        if case .skipInstrumentation = instrumentationDecision(for: request) {
             return
         }
 
-        XCTFail("Customer requests with existing traceparent should defer to resume-time instrumentation")
+        XCTFail("Requests with existing traceparent should be skipped to avoid double instrumentation")
     }
 
     func testInstrumentationDecisionWithInternalSDKMarkedRequestSkipsInstrumentation() throws {

--- a/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/RequestInstrumentationDecisionTests.swift
@@ -22,16 +22,16 @@ import XCTest
 
 final class RequestInstrumentationDecisionTests: XCTestCase {
 
-    func testInstrumentationDecisionWithExistingTraceparentSkipsInstrumentation() throws {
+    func testInstrumentationDecisionWithExistingTraceparentDefersToResume() throws {
         let url = try XCTUnwrap(URL(string: "https://example.com/customer-request"))
         var request = URLRequest(url: url)
         request.setValue("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", forHTTPHeaderField: "traceparent")
 
-        if case .skipInstrumentation = instrumentationDecision(for: request) {
+        if case .deferToResume = instrumentationDecision(for: request) {
             return
         }
 
-        XCTFail("Requests with existing traceparent should be skipped to avoid double instrumentation")
+        XCTFail("Customer requests with existing traceparent should defer to resume-time instrumentation")
     }
 
     func testInstrumentationDecisionWithInternalSDKMarkedRequestSkipsInstrumentation() throws {

--- a/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
@@ -31,13 +31,14 @@ final class StartHttpSpanTests: XCTestCase {
         XCTAssertNil(span)
     }
 
-    func testStartHttpSpanWithExistingTraceparentReturnsNil() throws {
+    func testStartHttpSpanWithExistingTraceparentReturnsSpan() throws {
         let url = try XCTUnwrap(URL(string: "https://example.com/customer-request"))
         var request = URLRequest(url: url)
         request.setValue("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", forHTTPHeaderField: "traceparent")
 
         let span = startHttpSpan(request: request)
 
-        XCTAssertNil(span)
+        XCTAssertNotNil(span)
+        span?.end()
     }
 }

--- a/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
@@ -30,4 +30,14 @@ final class StartHttpSpanTests: XCTestCase {
 
         XCTAssertNil(span)
     }
+
+    func testStartHttpSpanWithExistingTraceparentReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/customer-request"))
+        var request = URLRequest(url: url)
+        request.setValue("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", forHTTPHeaderField: "traceparent")
+
+        let span = startHttpSpan(request: request)
+
+        XCTAssertNil(span)
+    }
 }

--- a/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/StartHttpSpanTests.swift
@@ -1,0 +1,33 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SplunkCommon
+import XCTest
+
+@testable import SplunkNetwork
+
+final class StartHttpSpanTests: XCTestCase {
+
+    func testStartHttpSpanWithInternalSDKMarkedRequestReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/v1/rum"))
+        let request = InternalNetworkRequestMarker.mark(URLRequest(url: url))
+
+        let span = startHttpSpan(request: request)
+
+        XCTAssertNil(span)
+    }
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/TaskCreationSwizzlingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/TaskCreationSwizzlingTests.swift
@@ -18,7 +18,7 @@ limitations under the License.
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
-@_spi(SplunkInternal) import SplunkCommon
+import SplunkCommon
 import XCTest
 
 @testable import SplunkNetwork

--- a/SplunkNetwork/Tests/SplunkNetworkTests/TaskCreationSwizzlingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/TaskCreationSwizzlingTests.swift
@@ -18,6 +18,7 @@ limitations under the License.
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+@_spi(SplunkInternal) import SplunkCommon
 import XCTest
 
 @testable import SplunkNetwork
@@ -171,6 +172,35 @@ final class TaskCreationSwizzlingTests: XCTestCase {
 
         let spans = Self.exporter.spans.filter { $0.name.starts(with: "HTTP") }
         XCTAssertEqual(spans.count, 1, "Exactly one HTTP span should be created for uploadTask(with:fromFile:completionHandler:)")
+    }
+
+    func testInternalSDKMarkedUploadTaskWithFile_DoesNotCreateSpan() throws {
+        let url = URLSessionMockProtocol.url(path: "/post")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request = InternalNetworkRequestMarker.mark(request)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("test-upload-\(UUID().uuidString).txt")
+        try "test file content".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let expectation = expectation(description: "Upload task completed")
+        let delegate = TaskCompletionDelegate(expectation: expectation)
+        let session = URLSession(
+            configuration: URLSessionMockProtocol.configuration(),
+            delegate: delegate,
+            delegateQueue: nil
+        )
+
+        let task = session.uploadTask(with: request, fromFile: fileURL)
+        task.resume()
+
+        wait(for: [expectation], timeout: 10.0)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        let spans = Self.exporter.spans.filter { $0.name.starts(with: "HTTP") }
+        XCTAssertTrue(spans.isEmpty, "Internal SDK upload requests should not create HTTP spans")
     }
 
     func testUploadTaskWithDataAndCompletion_CompletionReceivesData() {

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Models/RequestDescriptor.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Models/RequestDescriptor.swift
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import Foundation
+@_spi(SplunkInternal) import SplunkCommon
 
 enum RequestPayloadFormat: String, Codable {
     case json
@@ -147,7 +148,7 @@ struct RequestDescriptor: RequestDescriptorProtocol {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        return request
+        return InternalNetworkRequestMarker.mark(request)
     }
 }
 

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Models/RequestDescriptor.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Models/RequestDescriptor.swift
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Foundation
-@_spi(SplunkInternal) import SplunkCommon
+import SplunkCommon
 
 enum RequestPayloadFormat: String, Codable {
     case json

--- a/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Models/SplunkRequestDescriptorTests.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Models/SplunkRequestDescriptorTests.swift
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@_spi(SplunkInternal) import SplunkCommon
+import SplunkCommon
 import XCTest
 
 @testable import SplunkOpenTelemetryBackgroundExporter

--- a/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Models/SplunkRequestDescriptorTests.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Models/SplunkRequestDescriptorTests.swift
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+@_spi(SplunkInternal) import SplunkCommon
 import XCTest
 
 @testable import SplunkOpenTelemetryBackgroundExporter
@@ -142,5 +143,20 @@ final class SplunkRequestDescriptorTests: XCTestCase {
         let request = descriptor.createRequest()
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-protobuf")
+    }
+
+    func testCreateRequestMarksRequestAsInternalSDKTraffic() throws {
+        let exampleURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let descriptor = RequestDescriptor(
+            id: UUID(),
+            endpoint: exampleURL,
+            explicitTimeout: 1.0,
+            fileKeyType: fileKeyType
+        )
+
+        let request = descriptor.createRequest()
+
+        XCTAssertTrue(InternalNetworkRequestMarker.isMarked(request))
+        XCTAssertNil(request.value(forHTTPHeaderField: "com.splunk.rum.internal-network-request"))
     }
 }

--- a/tools/xcframework/Project.swift
+++ b/tools/xcframework/Project.swift
@@ -75,6 +75,10 @@ let sharedSettings: SettingsDictionary = [
     // Enable module interface generation.
     "SWIFT_EMIT_MODULE_INTERFACE": "YES",
 
+    // Tell the compiler these sources belong to the `SplunkAgent` package.
+    // This allows `package` access declarations to compile outside SwiftPM.
+    "OTHER_SWIFT_FLAGS": "-package-name SplunkAgent",
+
     // Minimum deployment targets matching Package.swift.
     "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
     "TVOS_DEPLOYMENT_TARGET": "15.0",

--- a/tools/xcframework/scripts/build-xcframeworks.sh
+++ b/tools/xcframework/scripts/build-xcframeworks.sh
@@ -233,6 +233,7 @@ archive_module() {
             -archivePath "${archive_path}"
             SKIP_INSTALL=NO
             BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+            "OTHER_SWIFT_FLAGS=-package-name SplunkAgent"
         )
         if [[ "${label}" == "maccatalyst" ]]; then
             xcodebuild_args+=("ARCHS=arm64")


### PR DESCRIPTION
## Title: Add Request Marker for Internal Network Requests

### Description

Internal SDK calls to the RUM platform are being instrumented and emitted as network telemetry. This suggests the network exclusion logic may not be consistently suppressing internal SDK/RUM platform requests.

- Add an internal-request marker in the exporter request creation path and have SplunkNetwork skip those before URL matching.
- Retain current endpoint exclusion logic to support IngoreURLs

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

[Provide clear and step-by-step instructions on how reviewers can test the changes you've made.]

### Future Considerations (Optional)

[Mention any related upcoming work or considerations for the future.]
