### PR TITLE
NO-TICKET: Consolidate Unreleased CHANGELOG entries per review feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-* Custom error and exception reporting may now include `crash.processPath` and stack-referenced `exception.images` metadata, matching the crash report payload shape. Configure binary images via `CustomTrackingConfiguration.includeBinaryImagesOnErrors`. #677
-* Objective-C installs can configure Custom Tracking binary image metadata via `SPLKCustomTrackingConfiguration.includeBinaryImagesOnErrors`. #677
-* Custom error and exception reporting with stack traces now includes `exception.threads` stack frame metadata, matching the crash report payload shape. #677
-* Custom error and exception `exception.threads` stack frame image names are now resolved from loaded binary image metadata when binary image metadata is enabled. #677
+* Custom error and exception reporting now includes crash-report-style metadata: `crash.processPath`, `exception.images`, and `exception.threads` stack frames with resolved binary image names. Configure via `CustomTrackingConfiguration.includeBinaryImagesOnErrors` (Swift) or `SPLKCustomTrackingConfiguration.includeBinaryImagesOnErrors` (Objective-C). #677
 
 ### Changed
 
@@ -20,8 +17,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* Custom error and exception binary image enrichment no longer generates PLCrashReporter live reports on the caller thread or at install time. #677
-* Objective-C Custom Tracking configuration conversion now preserves `SPLKCustomTrackingConfiguration.isEnabled`. #677
 * Fixed SDK-owned exporter uploads incorrectly being emitted as Network Instrumentation HTTP spans. Internal SDK requests are now excluded from network telemetry. #683
 
 ## [2.3.1] - 2026-06-15


### PR DESCRIPTION
## Title: Consolidate Unreleased CHANGELOG entries per review feedback

### Description

Clean up CHANGELOG entries based on review feedback.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Code was generated entirely by GAI

### How to Test These Changes

n/a
