### PR TITLE
DEMRUM-6055: Rewrite RELEASING.md with current release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,7 @@
 # How to Release Splunk RUM for iOS
 
+This project is distributed as a Swift Package. The release process is driven by creating and pushing versioned Git tags.
+
 ## Pre-flight
 
 1. Confirm all features for the release are merged to `develop`.
@@ -7,17 +9,17 @@
 
 ## Release
 
-3. Run the **"New release"** workflow from the Actions tab, targeting `develop`, with the version (e.g. `2.3.2`) and Jira ticket (e.g. `DEMRUM-1234`).
+3. Run the **"New release"** workflow from the Actions tab, targeting `develop`, with the version (e.g. `2.3.2`) and Jira ticket (e.g. `DEMRUM-1234`). The action will prepare a release pull request.
 4. On the resulting PR, click **"Approve workflows to run"** when prompted, then approve the PR and wait for all checks to pass.
 5. Ask a repo admin to merge the PR into `main` — **regular merge commit only** (not squash, not rebase merge). Admins can bypass the stuck CLA check if needed (see Known issue below).
-6. The **"Release finalize"** workflow runs automatically: creates the tag, GitHub release, and opens a `main → develop` back-merge PR.
+6. After the release PR is merged into `main`, a new tag and release will be created automatically, and a new back-merge PR into `develop` will be opened.
 
 ## Sign and upload xcframeworks
 
 7. With the Apple Distribution certificate in your keychain and the Session Replay repo checked out locally:
    ```bash
    SESSION_REPLAY_LOCAL_PATH=/path/to/session-replay \
-     tools/xcframework/scripts/sign-and-upload.sh VERSION --upload-to VERSION
+     tools/xcframework/scripts/sign-and-upload.sh <VERSION> --upload-to <VERSION>
    ```
 
 ## Back-merge
@@ -27,9 +29,9 @@
 
 ## Smoke test
 
-12. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
-13. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
-14. Build and run. Confirm sessions appear in mon0 with `rum.sdk.version` matching the new version.
+10. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
+11. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
+12. Build and run. Confirm sessions appear in mon0 with `rum.sdk.version` matching the new version.
 
 ## Manual workflow (automated steps broken down)
 
@@ -38,21 +40,26 @@ Use this if any part of the automated workflow fails and needs to be reproduced 
 1. Create the release branch from `develop`:
    ```bash
    git checkout develop && git pull
-   git checkout -b release/VERSION
+   git checkout -b release/<VERSION>
    ```
-2. In `CHANGELOG.md`, rename `[Unreleased]` to `[VERSION] - YYYY-MM-DD` and add a new empty `[Unreleased]` section above it.
+2. In `CHANGELOG.md`, rename `[Unreleased]` to `[<VERSION>] - YYYY-MM-DD` and add a new empty `[Unreleased]` section above it.
 3. Bump the version constant in `SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift`.
-4. Commit, push, and open a PR from `release/VERSION` to `main`. Title: `DEMRUM-XXXX: Release VERSION`.
-5. Merge the PR — **regular merge commit only** (not squash, not rebase merge).
-6. Create and push a signed tag:
+4. Build the project and run the full test suite to ensure everything is passing:
+   ```bash
+   xcodebuild build -scheme SplunkAgent -destination 'generic/platform=iOS Simulator'
+   xcodebuild test -scheme SplunkAgent -destination 'platform=iOS Simulator,name=iPhone 16'
+   ```
+5. Commit, push, and open a PR from `release/<VERSION>` to `main`. Title: `DEMRUM-XXXX: Release <VERSION>`.
+6. Merge the PR — **regular merge commit only** (not squash, not rebase merge).
+7. Create and push a signed tag. Swift Package Manager uses these tags to resolve package versions:
    ```bash
    git checkout main && git pull
-   git tag -s VERSION -m "VERSION"
-   git push origin VERSION
+   git tag -s v<VERSION> -m "v<VERSION>"
+   git push origin v<VERSION>
    ```
-7. On the GitHub Releases page, draft a new release for the tag. Paste the `[VERSION]` section from `CHANGELOG.md` as the release notes and publish.
-8. Open a PR from `main` to `develop`. Title: `NO-TICKET: Merge back VERSION to develop`.
-9. Merge the PR — **regular merge commit only** (not squash, not rebase merge). Requires temporarily disabling "Require linear history" on `main` (see Back-merge section above).
+8. On the GitHub Releases page, draft a new release for the tag. Paste the `[<VERSION>]` section from `CHANGELOG.md` as the release notes and publish.
+9. Open a PR from `main` to `develop`. Title: `NO-TICKET: Merge back <VERSION> to develop`.
+10. Merge the PR — **regular merge commit only** (not squash, not rebase merge). Requires temporarily disabling "Require linear history" on `main` (see Back-merge section above).
 
 ## Known issue: CLA check stuck
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,23 +16,29 @@ This project is distributed as a Swift Package. Versioned Git tags define the ve
 
 ## Sign and upload XCFrameworks
 
-7. With the Apple Distribution certificate in your keychain and the Session Replay repository checked out locally, replace `<VERSION>` with the release version and upload both distributions:
+7. With the Apple Distribution certificate and private key in your keychain and the Session Replay repository checked out locally, replace `<VERSION>` and `<APPLE_DISTRIBUTION_SIGNING_IDENTITY>` with the release values and upload both distributions:
    ```bash
    export SESSION_REPLAY_LOCAL_PATH=/path/to/session-replay
-   tools/xcframework/scripts/sign-and-upload.sh <VERSION> --upload-to <VERSION>
-   tools/xcframework/scripts/sign-and-upload.sh <VERSION> --ios-only --upload-to <VERSION>
+   tools/xcframework/scripts/sign-and-upload.sh <VERSION> \
+     --identity "<APPLE_DISTRIBUTION_SIGNING_IDENTITY>" \
+     --upload-to <VERSION>
+   tools/xcframework/scripts/sign-and-upload.sh <VERSION> \
+     --identity "<APPLE_DISTRIBUTION_SIGNING_IDENTITY>" \
+     --ios-only \
+     --upload-to <VERSION>
    ```
+8. Open the GitHub release for `<VERSION>` and confirm both `SplunkAgent-XCFrameworks.zip` and `SplunkAgent-XCFrameworks-iOS-only.zip` are attached and downloadable. This check validates the uploaded XCFramework distributions; the SPM smoke test below does not validate these archives.
 
 ## Back-merge
 
-8. On the back-merge PR, click **"Approve workflows to run"** when prompted, obtain the required approvals, and wait for the required checks.
-9. Ask a repository administrator to temporarily disable **"Require linear history"** for `develop`, merge the PR into `develop` with a **regular merge commit only** (not squash or rebase), and immediately re-enable the rule. If the CLA check remains pending after everything else passes, the administrator should bypass it during this merge.
+9. On the back-merge PR, click **"Approve workflows to run"** when prompted, obtain the required approvals, and wait for the required checks.
+10. Ask a repository administrator to temporarily disable **"Require linear history"** for `develop`, merge the PR into `develop` with a **regular merge commit only** (not squash or rebase), and immediately re-enable the rule. If the CLA check remains pending after everything else passes, the administrator should bypass it during this merge.
 
 ## Smoke test
 
-10. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
-11. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
-12. Build and run. Confirm the session appears in a testing realm with `rum.sdk.version` matching the new version.
+11. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
+12. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
+13. Build and run. Confirm the session appears in a testing realm with `rum.sdk.version` matching the new version.
 
 ## Manual recovery
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,50 +1,59 @@
 # How to Release Splunk RUM for iOS
 
-This project is distributed as a Swift Package. The release process is driven by creating and pushing versioned Git tags.
+## Pre-flight
 
-## Automated workflow
+1. Confirm all features for the release are merged to `develop`.
+2. Confirm `CHANGELOG.md` on `develop` has complete `[Unreleased]` entries, each with a PR link (e.g. `#123`).
 
-- An action named “New release” is available in the Actions tab of the repository.
-- Fill in the required fields and select the target branch.
-- The action will prepare a release pull request.
-- After the release pull request is merged into main, a new tag and release will be created automatically, and a new pull request into develop will be opened.
+## Release
 
-## Manual workflow
+3. Run the **"New release"** workflow from the Actions tab, targeting `develop`, with the version (e.g. `2.3.2`) and Jira ticket (e.g. `DEMRUM-1234`).
+4. On the resulting PR, click **"Approve workflows to run"** when prompted, then approve the PR and wait for all checks to pass.
+5. Ask a repo admin to merge the PR into `main` — **regular merge commit only** (not squash, not rebase merge). Admins can bypass the stuck CLA check if needed (see Known issue below).
+6. The **"Release finalize"** workflow runs automatically: creates the tag, GitHub release, and opens a `main → develop` back-merge PR.
 
-### 1. Prepare the Release
+## Sign and upload xcframeworks
 
-1. Ensure the `main` branch is stable and all changes for the release have been merged.
-2. Update `CHANGELOG.md` by moving all items from the `[Unreleased]` section to a new version heading (e.g., `[2.0.0] - YYYY-MM-DD`).
-3. Update the `version` constant in `SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift`.
+7. With the Apple Distribution certificate in your keychain and the Session Replay repo checked out locally:
+   ```bash
+   SESSION_REPLAY_LOCAL_PATH=/path/to/session-replay \
+     tools/xcframework/scripts/sign-and-upload.sh VERSION --upload-to VERSION
+   ```
 
-### 2. Run Final Checks
+## Back-merge
 
-Build the project and run the full test suite from the command line to ensure everything is passing.
+8. On the back-merge PR, click **"Approve workflows to run"**, approve the PR, and wait for checks to pass.
+9. Ask a repo admin to: (1) temporarily disable **"Require linear history"** on `main` in Settings → Branches, (2) merge the PR into `develop` — **regular merge commit only** (not squash, not rebase merge), (3) re-enable **"Require linear history"** on `main`.
 
-```bash
-# Build the project
-xcodebuild build -scheme SplunkAgent -destination 'generic/platform=iOS Simulator'
+## Smoke test
 
-# Run the tests
-xcodebuild test -scheme SplunkAgent -destination 'platform=iOS Simulator,name=iPhone 16'
-```
+12. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
+13. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
+14. Build and run. Confirm sessions appear in mon0 with `rum.sdk.version` matching the new version.
 
-### 3. Tag and Push the Release
+## Manual workflow (automated steps broken down)
 
-Create a signed Git tag for the new version. Swift Package Manager uses these tags to resolve package versions.
+Use this if any part of the automated workflow fails and needs to be reproduced manually.
 
-```bash
-# Create a signed tag (e.g., for version 2.0.0) with a 'v' prefix
-git tag -s v2.0.0
+1. Create the release branch from `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b release/VERSION
+   ```
+2. In `CHANGELOG.md`, rename `[Unreleased]` to `[VERSION] - YYYY-MM-DD` and add a new empty `[Unreleased]` section above it.
+3. Bump the version constant in `SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift`.
+4. Commit, push, and open a PR from `release/VERSION` to `main`. Title: `DEMRUM-XXXX: Release VERSION`.
+5. Merge the PR — **regular merge commit only** (not squash, not rebase merge).
+6. Create and push a signed tag:
+   ```bash
+   git checkout main && git pull
+   git tag -s VERSION -m "VERSION"
+   git push origin VERSION
+   ```
+7. On the GitHub Releases page, draft a new release for the tag. Paste the `[VERSION]` section from `CHANGELOG.md` as the release notes and publish.
+8. Open a PR from `main` to `develop`. Title: `NO-TICKET: Merge back VERSION to develop`.
+9. Merge the PR — **regular merge commit only** (not squash, not rebase merge). Requires temporarily disabling "Require linear history" on `main` (see Back-merge section above).
 
-# Push the tag to the remote repository
-git push origin v2.0.0
-```
+## Known issue: CLA check stuck
 
-### 4. Publish on GitHub
-
-1. Go to the "Releases" page in the GitHub repository and click "Draft a new release".
-2. Choose the tag you just pushed.
-3. For the release notes, copy and paste the content from the corresponding version section in `CHANGELOG.md`.
-4. Click the **Publish release** button. This will finalize the release, making it public and visible to the community.
-
+The `ContributorLicenseAgreement` check on bot-created PRs may remain stuck as "Waiting for status to be reported" after all other checks pass. This is a known workflow issue pending a fix. If it occurs, ask a repo admin to perform the merge — admins have the ability to bypass the stuck required check.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # How to Release Splunk RUM for iOS
 
-This project is distributed as a Swift Package. Versioned Git tags define the versions available to Swift Package Manager.
+This project is distributed through Swift Package Manager and as signed XCFramework archives attached to GitHub releases. Versioned Git tags define the versions available to Swift Package Manager.
 
 ## Pre-flight
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,66 +1,78 @@
 # How to Release Splunk RUM for iOS
 
-This project is distributed as a Swift Package. The release process is driven by creating and pushing versioned Git tags.
+This project is distributed as a Swift Package. Versioned Git tags define the versions available to Swift Package Manager.
 
 ## Pre-flight
 
 1. Confirm all features for the release are merged to `develop`.
-2. Confirm `CHANGELOG.md` on `develop` has complete `[Unreleased]` entries, each with a PR link (e.g. `#123`).
+2. Confirm `CHANGELOG.md` on `develop` has complete `[Unreleased]` entries, each with a PR link (e.g., `#123`).
 
 ## Release
 
-3. Run the **"New release"** workflow from the Actions tab, targeting `develop`, with the version (e.g. `2.3.2`) and Jira ticket (e.g. `DEMRUM-1234`). The action will prepare a release pull request.
-4. On the resulting PR, click **"Approve workflows to run"** when prompted, then approve the PR and wait for all checks to pass.
-5. Ask a repo admin to merge the PR into `main` — **regular merge commit only** (not squash, not rebase merge). Admins can bypass the stuck CLA check if needed (see Known issue below).
+3. Run the **"New release"** workflow from the Actions tab, targeting `develop`, with the version (e.g., `2.3.2`) and Jira ticket (e.g., `DEMRUM-1234`). The action will prepare a release pull request.
+4. On the resulting PR, click **"Approve workflows to run"** when prompted, obtain the required approvals, and wait for the required checks.
+5. Merge the PR into `main` with a **regular merge commit only** (not squash or rebase). If the CLA check remains pending after everything else passes, use the administrator workaround below.
 6. After the release PR is merged into `main`, a new tag and release will be created automatically, and a new back-merge PR into `develop` will be opened.
 
-## Sign and upload xcframeworks
+## Sign and upload XCFrameworks
 
-7. With the Apple Distribution certificate in your keychain and the Session Replay repo checked out locally:
+7. With the Apple Distribution certificate in your keychain and the Session Replay repository checked out locally, replace `<VERSION>` with the release version and upload both distributions:
    ```bash
-   SESSION_REPLAY_LOCAL_PATH=/path/to/session-replay \
-     tools/xcframework/scripts/sign-and-upload.sh <VERSION> --upload-to <VERSION>
+   export SESSION_REPLAY_LOCAL_PATH=/path/to/session-replay
+   tools/xcframework/scripts/sign-and-upload.sh <VERSION> --upload-to <VERSION>
+   tools/xcframework/scripts/sign-and-upload.sh <VERSION> --ios-only --upload-to <VERSION>
    ```
 
 ## Back-merge
 
-8. On the back-merge PR, click **"Approve workflows to run"**, approve the PR, and wait for checks to pass.
-9. Ask a repo admin to: (1) temporarily disable **"Require linear history"** on `main` in Settings → Branches, (2) merge the PR into `develop` — **regular merge commit only** (not squash, not rebase merge), (3) re-enable **"Require linear history"** on `main`.
+8. On the back-merge PR, click **"Approve workflows to run"** when prompted, obtain the required approvals, and wait for the required checks.
+9. Ask a repository administrator to temporarily disable **"Require linear history"** for `develop`, merge the PR into `develop` with a **regular merge commit only** (not squash or rebase), and immediately re-enable the rule. If the CLA check remains pending after everything else passes, the administrator should bypass it during this merge.
 
 ## Smoke test
 
 10. In a test app, add an SPM dependency on `signalfx/splunk-otel-ios` at the new version.
 11. In Xcode: **File → Packages → Reset Package Caches**, then **File → Packages → Resolve Package Versions**.
-12. Build and run. Confirm sessions appear in mon0 with `rum.sdk.version` matching the new version.
+12. Build and run. Confirm the session appears in a testing realm with `rum.sdk.version` matching the new version.
 
-## Manual workflow (automated steps broken down)
+## Manual recovery
 
-Use this if any part of the automated workflow fails and needs to be reproduced manually.
+Use this only when an automated workflow fails. Inspect the failed run and complete only the missing steps; do not recreate a branch, tag, release, or PR that already exists.
+
+### Prepare the release PR
 
 1. Create the release branch from `develop`:
    ```bash
-   git checkout develop && git pull
-   git checkout -b release/<VERSION>
+   git switch develop
+   git pull --ff-only
+   git switch -c release/<VERSION>
    ```
 2. In `CHANGELOG.md`, rename `[Unreleased]` to `[<VERSION>] - YYYY-MM-DD` and add a new empty `[Unreleased]` section above it.
 3. Bump the version constant in `SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift`.
-4. Build the project and run the full test suite to ensure everything is passing:
+4. Add `<VERSION>` to the version dropdown in `.github/ISSUE_TEMPLATE/bug.yml`.
+5. Build the project and run the full test suite using an installed simulator:
    ```bash
-   xcodebuild build -scheme SplunkAgent -destination 'generic/platform=iOS Simulator'
-   xcodebuild test -scheme SplunkAgent -destination 'platform=iOS Simulator,name=iPhone 16'
+   xcodebuild -scheme SplunkAgent -destination 'generic/platform=iOS Simulator' build
+   xcodebuild -scheme SplunkAgent -showdestinations
+   xcodebuild -scheme SplunkAgent -destination 'OS=<installed OS>,name=<installed iPhone simulator>' test
    ```
-5. Commit, push, and open a PR from `release/<VERSION>` to `main`. Title: `DEMRUM-XXXX: Release <VERSION>`.
-6. Merge the PR — **regular merge commit only** (not squash, not rebase merge).
-7. Create and push a signed tag. Swift Package Manager uses these tags to resolve package versions:
+6. Create a signed commit, push the branch, and open a PR from `release/<VERSION>` to `main`. Title: `DEMRUM-XXXX: Release <VERSION>`.
+7. Merge the PR with a **regular merge commit only** (not squash or rebase). This starts the **"Release finalize"** workflow.
+
+### Complete a failed Release finalize workflow
+
+The workflow creates the tag, GitHub release, and back-merge PR in that order. Check which artifacts exist and perform only the missing steps.
+
+1. If the `<VERSION>` tag is missing, create and push it without a `v` prefix. Swift Package Manager uses this tag to resolve the release:
    ```bash
-   git checkout main && git pull
-   git tag -s v<VERSION> -m "v<VERSION>"
-   git push origin v<VERSION>
+   git switch main
+   git pull --ff-only
+   git tag -s <VERSION> -m "Release <VERSION>"
+   git push origin <VERSION>
    ```
-8. On the GitHub Releases page, draft a new release for the tag. Paste the `[<VERSION>]` section from `CHANGELOG.md` as the release notes and publish.
-9. Open a PR from `main` to `develop`. Title: `NO-TICKET: Merge back <VERSION> to develop`.
-10. Merge the PR — **regular merge commit only** (not squash, not rebase merge). Requires temporarily disabling "Require linear history" on `main` (see Back-merge section above).
+2. If the GitHub release is missing, draft one for the `<VERSION>` tag, use the `[<VERSION>]` section from `CHANGELOG.md` as its notes, and publish it.
+3. If the back-merge PR is missing, open one from `main` to `develop`. Title: `NO-TICKET: Merge back <VERSION> to develop`.
+4. Complete the back-merge steps above.
 
-## Known issue: CLA check stuck
+## Known issue: pending CLA check
 
-The `ContributorLicenseAgreement` check on bot-created PRs may remain stuck as "Waiting for status to be reported" after all other checks pass. This is a known workflow issue pending a fix. If it occurs, ask a repo admin to perform the merge — admins have the ability to bypass the stuck required check.
+The `ContributorLicenseAgreement` check on bot-created PRs may remain at "Waiting for status to be reported." After every other required check and review passes, ask a repository administrator to bypass the pending check and perform a regular merge commit. This workaround applies to both the release and back-merge PRs until the workflow is fixed.


### PR DESCRIPTION
## Title: Rewrite RELEASING.md with current release process

### Description

* Update stale information in `RELEASING.md` to document the current automated release workflow.
* Document the merge-commit-only requirement, XCFramework signing and post-upload asset verification, back-merge linear-history workaround, temporary workaround for the stuck CLA check, and SPM smoke test.
* Add manual recovery steps for partially completed release workflows.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [x] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

This documentation-only change can be validated against the implementation:

1. Compare the **Release**, **Back-merge**, and **Manual recovery** sections with `.github/workflows/release.yml` and `.github/workflows/merge_release.yml`. Confirm the workflow names, branch directions, and generated tag, release, and pull request match. Check `.github/workflows/cla.yml` for the CLA job name referenced by the workaround.
2. Run the following command, then confirm the flags and both ZIP names match **Sign and upload XCFrameworks**:
   ```bash
   rg -n -- '--identity|--ios-only|--upload-to|SplunkAgent-XCFrameworks' \
     tools/xcframework/scripts/sign-and-upload.sh \
     tools/xcframework/scripts/release.sh
   ```

### Future Considerations (Optional)

We plan to do some enhancements to the workflows in the near future to overcome some of the hiccups that currently require workarounds.
