### PR TITLE
NO-TICKET: Fixed non-finite floating-point span attributes blocking exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed non-finite floating-point span attributes blocking subsequent trace export from the in-memory batch queue.
+
 ### Changed
 
 * Trace spans are now persisted in batches of up to 100 every 0.5 seconds, reducing disk activity and export overhead. Spans still buffered in memory may be lost if the app crashes or is force-terminated.

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
@@ -37,7 +37,13 @@ public class OTLPBackgroundHTTPTraceExporter: OTLPBackgroundHTTPBaseExporter, Sp
 
         do {
             // Encode to JSON instead of protobuf binary
-            let storeData = try JSONEncoder().encode(request)
+            let encoder = JSONEncoder()
+            encoder.nonConformingFloatEncodingStrategy = .convertToString(
+                positiveInfinity: "Infinity",
+                negativeInfinity: "-Infinity",
+                nan: "NaN"
+            )
+            let storeData = try encoder.encode(request)
 
             // If no endpoint is configured, store in pending folder for later
             if isPendingEndpoint {

--- a/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Exporters/OTLPBackgroundHTTPTraceExporterTests.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Exporters/OTLPBackgroundHTTPTraceExporterTests.swift
@@ -71,7 +71,10 @@ struct OTLPBackgroundHTTPTraceExporterTests {
         return exporter
     }
 
-    func makeSpanData(name: String = "test-span") -> SpanData {
+    func makeSpanData(
+        name: String = "test-span",
+        attributes: [String: AttributeValue] = [:]
+    ) -> SpanData {
         let exporter = NoOpSpanExporter()
         let processor = SimpleSpanProcessor(spanExporter: exporter)
         let tracerProvider = TracerProviderBuilder()
@@ -79,6 +82,9 @@ struct OTLPBackgroundHTTPTraceExporterTests {
             .build()
         let tracer = tracerProvider.get(instrumentationName: "trace-exporter-test", instrumentationVersion: "1.0")
         let span = tracer.spanBuilder(spanName: name).startSpan()
+        for (key, value) in attributes {
+            span.setAttribute(key: key, value: value)
+        }
         span.end()
 
         guard let readableSpan = span as? ReadableSpan else {
@@ -120,6 +126,36 @@ struct OTLPBackgroundHTTPTraceExporterTests {
 
         let entries = try disk.list(forKey: exporter.getStorageKey())
         #expect(entries.count == 1)
+    }
+
+    @Test
+    func exportEncodesBatchContainingNonFiniteDoubleAttributes() throws {
+        let disk = makeDisk(uniqueLabel: "non_finite_doubles_\(UUID().uuidString)")
+        let http = MockHTTPClient()
+        let exporter = try makeExporter(disk: disk, http: http)
+        let span = makeSpanData(
+            attributes: [
+                "nan": .double(.nan),
+                "positive.infinity": .double(.infinity),
+                "negative.infinity": .double(-.infinity)
+            ]
+        )
+
+        let result = exporter.export(
+            spans: [span, makeSpanData(name: "subsequent-span")],
+            explicitTimeout: nil
+        )
+
+        #expect(result == .success)
+        let sent = try #require(http.sent.first)
+        let fileKey = exporter.getStorageKey().append(sent.id.uuidString)
+        let finalURL = try disk.finalDestination(forKey: fileKey)
+        let payload = try Data(contentsOf: finalURL)
+        let json = try #require(String(data: payload, encoding: .utf8))
+        #expect(json.contains(#""doubleValue":"NaN""#))
+        #expect(json.contains(#""doubleValue":"Infinity""#))
+        #expect(json.contains(#""doubleValue":"-Infinity""#))
+        #expect(json.contains(#""name":"subsequent-span""#))
     }
 
     @Test


### PR DESCRIPTION
## Title: Fixed non-finite floating-point span attributes blocking subsequent trace export from the in-memory batch queue.

### Description
Failed batches are always requeued at the front of the queue.  The same poisoned batch is then retried forever, later spans accumulate behind it, and the queue eventually drops all new telemetry.

- Implemented the poison-span fix on bug/NO-TICKET-Span-Batching.
- Trace JSON now encodes non-finite doubles using OTLP/protobuf JSON values: "NaN", "Infinity", and "-Infinity"l
- Added regression coverage proving a batch containing non-finite attributes and a subsequent valid span is persisted successfully.
- Added an Unreleased changelog entry

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Confirm that a span containing non-finite attributes does not stall pending and future spans.
