### PR TITLE
NO-TICKET: Address 2.4.0 release Codex issues

### DIFF
--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -236,14 +236,17 @@ extension SplunkRum {
             crashReportsModule?.sharedState = sharedState
 
             if let eventManager = eventManager as? DefaultEventManager {
+                let crashReportPersistenceTimeout: TimeInterval = 2
+
                 crashReportsModule?.crashReportPersistenceHandler = { [weak eventManager] emitSpan, completion in
                     guard let eventManager else {
                         completion(false)
                         return
                     }
 
-                    eventManager.concreteTraceProcessor.persistCrashReportSpan(
+                    eventManager.concreteTraceProcessor.emitAndPersistSpan(
                         emitting: emitSpan,
+                        timeout: crashReportPersistenceTimeout,
                         completion: completion
                     )
                 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Modules/SplunkRum+Modules.swift
@@ -236,13 +236,16 @@ extension SplunkRum {
             crashReportsModule?.sharedState = sharedState
 
             if let eventManager = eventManager as? DefaultEventManager {
-                crashReportsModule?.crashReportPersistenceHandler = { [weak eventManager] completion in
+                crashReportsModule?.crashReportPersistenceHandler = { [weak eventManager] emitSpan, completion in
                     guard let eventManager else {
                         completion(false)
                         return
                     }
 
-                    eventManager.concreteTraceProcessor.persistBufferedSpans(completion: completion)
+                    eventManager.concreteTraceProcessor.persistCrashReportSpan(
+                        emitting: emitSpan,
+                        completion: completion
+                    )
                 }
             }
 

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Persistence.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports+Persistence.swift
@@ -1,0 +1,87 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+@_spi(SplunkInternal) import SplunkCommon
+
+extension CrashReports {
+    func finishPersistenceAttempt() {
+        persistenceLock.lock()
+        isAwaitingPersistence = false
+        persistenceLock.unlock()
+    }
+
+    func beginPersistenceAttempt() -> Bool {
+        persistenceLock.lock()
+        defer {
+            persistenceLock.unlock()
+        }
+
+        guard !isAwaitingPersistence else {
+            return false
+        }
+
+        isAwaitingPersistence = true
+        return true
+    }
+
+    func requestCrashReportPersistence(
+        crashReport: [CrashReportKeys: Any],
+        sharedState: (any AgentSharedState)?,
+        timestamp: Date
+    ) {
+        guard let crashReportPersistenceHandler else {
+            finishPersistenceAttempt()
+            logger.log(level: .error) {
+                "Crash Report retained because durable span persistence is unavailable."
+            }
+            return
+        }
+
+        crashReportPersistenceHandler(
+            { [weak self] in
+                guard let self else {
+                    return .invalid
+                }
+
+                return send(
+                    crashReport: crashReport,
+                    sharedState: sharedState,
+                    timestamp: timestamp
+                )
+            },
+            { [weak self] succeeded in
+                DispatchQueue.main.async {
+                    guard let self else {
+                        return
+                    }
+
+                    if succeeded {
+                        self.crashReporter?.purgePendingCrashReport()
+                    }
+                    else {
+                        self.logger.log(level: .error) {
+                            "Crash Report retained because its span could not be persisted."
+                        }
+                    }
+
+                    self.finishPersistenceAttempt()
+                }
+            }
+        )
+    }
+}

--- a/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
+++ b/SplunkCrashReports/Sources/SplunkCrashReports/CrashReports.swift
@@ -21,7 +21,11 @@ import Foundation
 import OpenTelemetryApi
 @_spi(SplunkInternal) import SplunkCommon
 
-package typealias CrashReportPersistenceHandler = (@escaping (Bool) -> Void) -> Void
+package typealias CrashReportSpanEmitter = () -> SpanId
+package typealias CrashReportPersistenceHandler = (
+    @escaping CrashReportSpanEmitter,
+    @escaping (Bool) -> Void
+) -> Void
 
 public class CrashReports {
 
@@ -45,10 +49,10 @@ public class CrashReports {
 
     // MARK: - Private
 
-    private var crashReporter: PLCrashReporter?
+    var crashReporter: PLCrashReporter?
 
-    private let persistenceLock = NSLock()
-    private var isAwaitingPersistence = false
+    let persistenceLock = NSLock()
+    var isAwaitingPersistence = false
 
     var crashSpanName: String = CrashReportConstants.defaultSpanName
 
@@ -146,8 +150,11 @@ public class CrashReports {
                 }
             }
 
-            // Send the report to the backend
-            send(crashReport: reportPayload, sharedState: sharedState, timestamp: timestamp)
+            requestCrashReportPersistence(
+                crashReport: reportPayload,
+                sharedState: sharedState,
+                timestamp: timestamp
+            )
         }
         catch {
             finishPersistenceAttempt()
@@ -156,8 +163,6 @@ public class CrashReports {
             }
             return
         }
-
-        requestCrashReportPersistence()
 
         // And indicate that crash occured
         logger.log(level: .warn) {
@@ -303,7 +308,11 @@ public class CrashReports {
         return appState
     }
 
-    private func send(crashReport: [CrashReportKeys: Any], sharedState: (any AgentSharedState)?, timestamp: Date) {
+    func send(
+        crashReport: [CrashReportKeys: Any],
+        sharedState: (any AgentSharedState)?,
+        timestamp: Date
+    ) -> SpanId {
         let tracer = OpenTelemetry.instance
             .tracerProvider
             .get(
@@ -320,55 +329,7 @@ public class CrashReports {
         }
 
         crashSpan.end(time: timestamp)
-    }
-
-    private func finishPersistenceAttempt() {
-        persistenceLock.lock()
-        isAwaitingPersistence = false
-        persistenceLock.unlock()
-    }
-
-    private func beginPersistenceAttempt() -> Bool {
-        persistenceLock.lock()
-        defer {
-            persistenceLock.unlock()
-        }
-
-        guard !isAwaitingPersistence else {
-            return false
-        }
-
-        isAwaitingPersistence = true
-        return true
-    }
-
-    private func requestCrashReportPersistence() {
-        guard let crashReportPersistenceHandler else {
-            finishPersistenceAttempt()
-            logger.log(level: .error) {
-                "Crash Report retained because durable span persistence is unavailable."
-            }
-            return
-        }
-
-        crashReportPersistenceHandler { [weak self] succeeded in
-            DispatchQueue.main.async {
-                guard let self else {
-                    return
-                }
-
-                if succeeded {
-                    self.crashReporter?.purgePendingCrashReport()
-                }
-                else {
-                    self.logger.log(level: .error) {
-                        "Crash Report retained because its span could not be persisted."
-                    }
-                }
-
-                self.finishPersistenceAttempt()
-            }
-        }
+        return crashSpan.context.spanId
     }
 }
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPLogToSpanEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPLogToSpanEventProcessor.swift
@@ -65,12 +65,10 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
             debugEnabled: debugEnabled,
             tracerProviderProvider: { OpenTelemetry.instance.tracerProvider },
             spanFlusher: { timeout in
-                guard let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk else {
-                    return .failure
-                }
-
-                tracerProvider.forceFlush(timeout: timeout)
-                return .failure
+                OTLPLogToSpanExporter.flushTracerProvider(
+                    OpenTelemetry.instance.tracerProvider,
+                    timeout: timeout
+                )
             }
         )
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPLogToSpanEventProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Log Event Processors/OTLPLogToSpanEventProcessor.swift
@@ -63,7 +63,15 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
         let state = Self.makeInitializationState(
             resources: resources,
             debugEnabled: debugEnabled,
-            tracerProviderProvider: { OpenTelemetry.instance.tracerProvider }
+            tracerProviderProvider: { OpenTelemetry.instance.tracerProvider },
+            spanFlusher: { timeout in
+                guard let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk else {
+                    return .failure
+                }
+
+                tracerProvider.forceFlush(timeout: timeout)
+                return .failure
+            }
         )
 
         loggerProvider = state.loggerProvider
@@ -83,7 +91,10 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
             with: traceUrl,
             resources: resources,
             debugEnabled: debugEnabled,
-            tracerProvider: traceProcessor.tracerProvider
+            tracerProvider: traceProcessor.tracerProvider,
+            spanFlusher: { timeout in
+                traceProcessor.forceFlushBufferedSpans(timeout: timeout)
+            }
         )
     }
 
@@ -91,12 +102,14 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
         with _: URL?,
         resources: AgentResources,
         debugEnabled: Bool,
-        tracerProvider: any TracerProvider
+        tracerProvider: any TracerProvider,
+        spanFlusher: @escaping (TimeInterval?) -> ExportResult = { _ in .failure }
     ) {
         let state = Self.makeInitializationState(
             resources: resources,
             debugEnabled: debugEnabled,
-            tracerProviderProvider: { tracerProvider }
+            tracerProviderProvider: { tracerProvider },
+            spanFlusher: spanFlusher
         )
 
         loggerProvider = state.loggerProvider
@@ -109,7 +122,8 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
     private static func makeInitializationState(
         resources: AgentResources,
         debugEnabled: Bool,
-        tracerProviderProvider: @escaping () -> any TracerProvider
+        tracerProviderProvider: @escaping () -> any TracerProvider,
+        spanFlusher: @escaping (TimeInterval?) -> ExportResult
     ) -> InitializationState {
         #if DEBUG
             var resource = Resource()
@@ -119,7 +133,8 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
         let loggerProvider = makeLoggerProvider(
             agentVersion: resources.agentVersion,
             debugEnabled: debugEnabled,
-            tracerProviderProvider: tracerProviderProvider
+            tracerProviderProvider: tracerProviderProvider,
+            spanFlusher: spanFlusher
         )
 
         #if DEBUG
@@ -132,11 +147,13 @@ public class OTLPLogToSpanEventProcessor: LogEventProcessor {
     private static func makeLoggerProvider(
         agentVersion: String,
         debugEnabled: Bool,
-        tracerProviderProvider: @escaping () -> any TracerProvider
+        tracerProviderProvider: @escaping () -> any TracerProvider,
+        spanFlusher: @escaping (TimeInterval?) -> ExportResult
     ) -> LoggerProvider {
         let logToSpanExporter = OTLPLogToSpanExporter(
             agentVersion: agentVersion,
-            tracerProviderProvider: tracerProviderProvider
+            tracerProviderProvider: tracerProviderProvider,
+            spanFlusher: spanFlusher
         )
 
         // Initialize LogRecordProcessor

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/LogToSpanExporter/OTLPLogToSpanExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/LogToSpanExporter/OTLPLogToSpanExporter.swift
@@ -29,6 +29,8 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
 
     private let tracerProvider: () -> any TracerProvider
 
+    private let spanFlusher: (TimeInterval?) -> ExportResult
+
     /// Internal Logger.
     private let logger = DefaultLogAgent(poolName: PackageIdentifier.instance(), category: "Log to Span Exporter")
 
@@ -36,16 +38,31 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
     // MARK: - Initialization
 
     convenience init(agentVersion: String) {
-        self.init(agentVersion: agentVersion, tracerProviderProvider: { OpenTelemetry.instance.tracerProvider })
+        self.init(
+            agentVersion: agentVersion,
+            tracerProviderProvider: { OpenTelemetry.instance.tracerProvider },
+            spanFlusher: Self.flushGlobalTracerProvider
+        )
     }
 
     convenience init(agentVersion: String, tracerProvider: any TracerProvider) {
-        self.init(agentVersion: agentVersion, tracerProviderProvider: { tracerProvider })
+        self.init(
+            agentVersion: agentVersion,
+            tracerProviderProvider: { tracerProvider },
+            spanFlusher: { timeout in
+                Self.flushWithoutResult(tracerProvider, timeout: timeout)
+            }
+        )
     }
 
-    init(agentVersion: String, tracerProviderProvider: @escaping () -> any TracerProvider) {
+    init(
+        agentVersion: String,
+        tracerProviderProvider: @escaping () -> any TracerProvider,
+        spanFlusher: @escaping (TimeInterval?) -> ExportResult
+    ) {
         self.agentVersion = agentVersion
         tracerProvider = tracerProviderProvider
+        self.spanFlusher = spanFlusher
     }
 
 
@@ -109,7 +126,21 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
 
     public func shutdown(explicitTimeout _: TimeInterval?) {}
 
-    public func forceFlush(explicitTimeout _: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
-        .success
+    public func forceFlush(explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
+        spanFlusher(explicitTimeout)
+    }
+
+    private static func flushGlobalTracerProvider(timeout: TimeInterval?) -> ExportResult {
+        flushWithoutResult(OpenTelemetry.instance.tracerProvider, timeout: timeout)
+    }
+
+    /// The generic provider API exposes only a void flush, so it can be triggered best effort but
+    /// cannot truthfully report successful completion to the log pipeline.
+    private static func flushWithoutResult(
+        _ tracerProvider: any TracerProvider,
+        timeout: TimeInterval?
+    ) -> ExportResult {
+        (tracerProvider as? TracerProviderSdk)?.forceFlush(timeout: timeout)
+        return .failure
     }
 }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/LogToSpanExporter/OTLPLogToSpanExporter.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/LogToSpanExporter/OTLPLogToSpanExporter.swift
@@ -41,7 +41,9 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
         self.init(
             agentVersion: agentVersion,
             tracerProviderProvider: { OpenTelemetry.instance.tracerProvider },
-            spanFlusher: Self.flushGlobalTracerProvider
+            spanFlusher: { timeout in
+                Self.flushTracerProvider(OpenTelemetry.instance.tracerProvider, timeout: timeout)
+            }
         )
     }
 
@@ -50,7 +52,7 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
             agentVersion: agentVersion,
             tracerProviderProvider: { tracerProvider },
             spanFlusher: { timeout in
-                Self.flushWithoutResult(tracerProvider, timeout: timeout)
+                Self.flushTracerProvider(tracerProvider, timeout: timeout)
             }
         )
     }
@@ -130,17 +132,16 @@ public class OTLPLogToSpanExporter: LogRecordExporter {
         spanFlusher(explicitTimeout)
     }
 
-    private static func flushGlobalTracerProvider(timeout: TimeInterval?) -> ExportResult {
-        flushWithoutResult(OpenTelemetry.instance.tracerProvider, timeout: timeout)
-    }
-
-    /// The generic provider API exposes only a void flush, so it can be triggered best effort but
-    /// cannot truthfully report successful completion to the log pipeline.
-    private static func flushWithoutResult(
+    /// Flushes an SDK tracer provider and reports whether the request was accepted.
+    static func flushTracerProvider(
         _ tracerProvider: any TracerProvider,
         timeout: TimeInterval?
     ) -> ExportResult {
-        (tracerProvider as? TracerProviderSdk)?.forceFlush(timeout: timeout)
-        return .failure
+        guard let tracerProvider = tracerProvider as? TracerProviderSdk else {
+            return .failure
+        }
+
+        tracerProvider.forceFlush(timeout: timeout)
+        return .success
     }
 }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+FlushResult.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+FlushResult.swift
@@ -21,8 +21,8 @@ extension BatchSpanProcessorCore {
 
     /// Flushes the current snapshot and returns an honest completion result.
     ///
-    /// Main-thread callers are never blocked: their flush is scheduled asynchronously and `false`
-    /// is returned because completion cannot be guaranteed before this method returns.
+    /// Main-thread callers are never blocked: their flush is scheduled asynchronously and success
+    /// indicates that the best-effort work was accepted. Off-main success indicates completion.
     func forceFlushResult(timeout: TimeInterval?) -> Bool {
         let waitTimeout = forceFlushWaitTimeout(for: timeout)
         let deadline = Date().addingTimeInterval(waitTimeout)
@@ -35,7 +35,7 @@ extension BatchSpanProcessorCore {
             processorQueue.async {
                 _ = self.performForceFlush(deadline: deadline)
             }
-            return false
+            return true
         }
 
         let completed = DispatchSemaphore(value: 0)

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+FlushResult.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+FlushResult.swift
@@ -1,0 +1,61 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+extension BatchSpanProcessorCore {
+
+    /// Flushes the current snapshot and returns an honest completion result.
+    ///
+    /// Main-thread callers are never blocked: their flush is scheduled asynchronously and `false`
+    /// is returned because completion cannot be guaranteed before this method returns.
+    func forceFlushResult(timeout: TimeInterval?) -> Bool {
+        let waitTimeout = forceFlushWaitTimeout(for: timeout)
+        let deadline = Date().addingTimeInterval(waitTimeout)
+
+        if DispatchQueue.getSpecific(key: processorQueueKey) != nil {
+            return performForceFlush(deadline: deadline)
+        }
+
+        guard !Thread.isMainThread else {
+            processorQueue.async {
+                _ = self.performForceFlush(deadline: deadline)
+            }
+            return false
+        }
+
+        let completed = DispatchSemaphore(value: 0)
+        let resultLock = NSLock()
+        var flushSucceeded = false
+
+        processorQueue.async {
+            let result = self.performForceFlush(deadline: deadline)
+            resultLock.lock()
+            flushSucceeded = result
+            resultLock.unlock()
+            completed.signal()
+        }
+
+        guard completed.wait(timeout: .now() + waitTimeout) == .success else {
+            return false
+        }
+
+        resultLock.lock()
+        defer { resultLock.unlock() }
+        return flushSucceeded
+    }
+}

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+Persistence.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/BatchSpanProcessorCore+Persistence.swift
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import Foundation
+import OpenTelemetryApi
 
 extension BatchSpanProcessorCore {
     /// Drains a snapshot to the exporter without waiting for background URLSession activity.
@@ -28,6 +29,36 @@ extension BatchSpanProcessorCore {
         let deadline = Date().addingTimeInterval(boundedTimeout)
 
         processorQueue.async {
+            let succeeded = self.drainSnapshot(
+                deadline: deadline,
+                requeueOnFailure: true,
+                forwardDeadlineToExporter: false
+            )
+            completion(succeeded)
+        }
+    }
+
+    /// Emits a span on the processor queue and persists a snapshot containing that exact span.
+    func persistSpan(
+        emitting emitSpan: @escaping () -> SpanId,
+        timeout: TimeInterval,
+        completion: @escaping (Bool) -> Void
+    ) {
+        let boundedTimeout = timeout.isFinite ? max(0, timeout) : 0
+        let deadline = Date().addingTimeInterval(boundedTimeout)
+
+        processorQueue.async {
+            let spanId = emitSpan()
+
+            self.lock.lock()
+            let wasAdmitted = self.queue.contains(spanId: spanId)
+            self.lock.unlock()
+
+            guard wasAdmitted else {
+                completion(false)
+                return
+            }
+
             let succeeded = self.drainSnapshot(
                 deadline: deadline,
                 requeueOnFailure: true,

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPBatchSpanProcessor+Persistence.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPBatchSpanProcessor+Persistence.swift
@@ -1,0 +1,30 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+
+extension OTLPBatchSpanProcessor {
+    /// Emits and persists one span, reporting success only when that exact span was admitted.
+    func persistSpan(
+        emitting emitSpan: @escaping () -> SpanId,
+        timeout: TimeInterval,
+        completion: @escaping (Bool) -> Void
+    ) {
+        core.persistSpan(emitting: emitSpan, timeout: timeout, completion: completion)
+    }
+}

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPBatchSpanProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/OTLPBatchSpanProcessor.swift
@@ -101,6 +101,11 @@ struct OTLPBatchSpanProcessor: SpanProcessor {
         core.forceFlush(timeout: timeout)
     }
 
+    /// Flushes the current snapshot and reports whether it reached the exporter successfully.
+    func forceFlushResult(timeout: TimeInterval? = nil) -> Bool {
+        core.forceFlushResult(timeout: timeout)
+    }
+
     /// Flushes asynchronously and runs `completion` on the processor queue after the drain finishes.
     func forceFlush(timeout: TimeInterval? = nil, completion: @escaping () -> Void) {
         core.forceFlush(timeout: timeout, completion: completion)
@@ -160,7 +165,7 @@ final class BatchSpanProcessorCore: @unchecked Sendable {
         qos: .utility
     )
 
-    private let processorQueueKey = DispatchSpecificKey<Void>()
+    let processorQueueKey = DispatchSpecificKey<Void>()
 
     /// Guards `queue`, `isShutdown`, `isFlushScheduled`, and the drop-tracking counters.
     let lock = NSLock()
@@ -261,7 +266,7 @@ final class BatchSpanProcessorCore: @unchecked Sendable {
         let waitTimeout = forceFlushWaitTimeout(for: timeout)
         let deadline = Date().addingTimeInterval(waitTimeout)
         runOnProcessorQueue(wait: waitTimeout) {
-            self.performForceFlush(deadline: deadline)
+            _ = self.performForceFlush(deadline: deadline)
         }
     }
 
@@ -271,7 +276,7 @@ final class BatchSpanProcessorCore: @unchecked Sendable {
         let deadline = Date().addingTimeInterval(waitTimeout)
 
         processorQueue.async {
-            self.performForceFlush(deadline: deadline)
+            _ = self.performForceFlush(deadline: deadline)
             completion()
         }
     }
@@ -338,13 +343,18 @@ final class BatchSpanProcessorCore: @unchecked Sendable {
         min(Self.shutdownWaitTimeout, max(0, explicitTimeout ?? Self.shutdownWaitTimeout))
     }
 
-    private func forceFlushWaitTimeout(for explicitTimeout: TimeInterval?) -> TimeInterval {
+    func forceFlushWaitTimeout(for explicitTimeout: TimeInterval?) -> TimeInterval {
         max(0, explicitTimeout ?? Self.forceFlushWaitTimeout)
     }
 
-    private func performForceFlush(deadline: Date) {
-        drainSnapshot(deadline: deadline, requeueOnFailure: true, forwardDeadlineToExporter: false)
-        _ = spanExporter.flush(explicitTimeout: max(0, deadline.timeIntervalSinceNow))
+    func performForceFlush(deadline: Date) -> Bool {
+        let drained = drainSnapshot(
+            deadline: deadline,
+            requeueOnFailure: true,
+            forwardDeadlineToExporter: false
+        )
+        let exporterResult = spanExporter.flush(explicitTimeout: max(0, deadline.timeIntervalSinceNow))
+        return drained && exporterResult != .failure
     }
 
     // MARK: - Drop accounting

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/ReadableSpanQueue.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/ReadableSpanQueue.swift
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import OpenTelemetryApi
 import OpenTelemetrySdk
 
 /// A fixed-capacity, first-in-first-out queue for ended spans awaiting export.
@@ -65,6 +66,18 @@ struct ReadableSpanQueue {
         tail = (tail + 1) % storage.count
         count += 1
         return true
+    }
+
+    /// Returns whether a span with the specified identifier is currently queued.
+    func contains(spanId: SpanId) -> Bool {
+        var index = head
+        for _ in 0 ..< count {
+            if storage[index]?.context.spanId == spanId {
+                return true
+            }
+            index = (index + 1) % storage.count
+        }
+        return false
     }
 
     /// Removes up to the requested number of oldest spans.

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/ReadableSpanQueue.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Span Processors/ReadableSpanQueue.swift
@@ -71,12 +71,15 @@ struct ReadableSpanQueue {
     /// Returns whether a span with the specified identifier is currently queued.
     func contains(spanId: SpanId) -> Bool {
         var index = head
+
         for _ in 0 ..< count {
             if storage[index]?.context.spanId == spanId {
                 return true
             }
+
             index = (index + 1) % storage.count
         }
+
         return false
     }
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
@@ -195,6 +195,18 @@ public class OTLPTraceProcessor: TraceProcessor {
         )
     }
 
+    /// Emits and persists one crash-report span, reporting success only for that exact span.
+    package func persistCrashReportSpan(
+        emitting emitSpan: @escaping () -> SpanId,
+        completion: @escaping (Bool) -> Void
+    ) {
+        batchSpanProcessor.persistSpan(
+            emitting: emitSpan,
+            timeout: Self.crashReportPersistenceTimeout,
+            completion: completion
+        )
+    }
+
     /// Flushes the shared direct and log-derived span batch and reports durable completion.
     package func forceFlushBufferedSpans(timeout: TimeInterval?) -> ExportResult {
         batchSpanProcessor.forceFlushResult(timeout: timeout) ? .success : .failure

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
@@ -195,6 +195,11 @@ public class OTLPTraceProcessor: TraceProcessor {
         )
     }
 
+    /// Flushes the shared direct and log-derived span batch and reports durable completion.
+    package func forceFlushBufferedSpans(timeout: TimeInterval?) -> ExportResult {
+        batchSpanProcessor.forceFlushResult(timeout: timeout) ? .success : .failure
+    }
+
 
     // MARK: - Endpoint Management
 

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Trace Processor/OTLPTraceProcessor.swift
@@ -42,10 +42,6 @@ public class OTLPTraceProcessor: TraceProcessor {
         let activityTracker: ActivityTracker
     }
 
-    // MARK: - Constants
-
-    private static let crashReportPersistenceTimeout: TimeInterval = 2
-
     // MARK: - Internal properties
 
     /// OTel tracer provider shared by direct and log-derived spans.
@@ -187,22 +183,15 @@ public class OTLPTraceProcessor: TraceProcessor {
         )
     }
 
-    /// Persists buffered spans before a producer deletes its only source payload.
-    package func persistBufferedSpans(completion: @escaping (Bool) -> Void) {
-        batchSpanProcessor.persistBufferedSpans(
-            timeout: Self.crashReportPersistenceTimeout,
-            completion: completion
-        )
-    }
-
-    /// Emits and persists one crash-report span, reporting success only for that exact span.
-    package func persistCrashReportSpan(
+    /// Emits and persists one span, reporting success only for that exact span.
+    package func emitAndPersistSpan(
         emitting emitSpan: @escaping () -> SpanId,
+        timeout: TimeInterval,
         completion: @escaping (Bool) -> Void
     ) {
         batchSpanProcessor.persistSpan(
             emitting: emitSpan,
-            timeout: Self.crashReportPersistenceTimeout,
+            timeout: timeout,
             completion: completion
         )
     }

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorFlushResultTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorFlushResultTests.swift
@@ -1,0 +1,59 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import Testing
+
+@testable import SplunkOpenTelemetry
+
+@Suite(.serialized)
+struct OTLPBatchSpanProcessorFlushResultTests {
+    @Test
+    func mainThreadFlushReportsScheduled() {
+        let exporter = BatchProcessorTestExporter()
+        let processor = OTLPBatchSpanProcessor(
+            spanExporter: exporter,
+            scheduleDelay: 3_600
+        )
+        let tracer = TracerProviderBuilder()
+            .add(spanProcessor: processor)
+            .build()
+            .get(instrumentationName: "BatchSpanProcessorFlushResultTests")
+
+        tracer.spanBuilder(spanName: "main-thread.span").startSpan().end()
+
+        let forceFlushReturned = DispatchSemaphore(value: 0)
+        let resultQueue = DispatchQueue(label: "com.splunk.batch-processor-test.force-flush-result")
+        var flushResult = false
+
+        DispatchQueue.main.async {
+            let result = processor.forceFlushResult(timeout: 1)
+            resultQueue.sync {
+                flushResult = result
+            }
+            forceFlushReturned.signal()
+        }
+
+        #expect(forceFlushReturned.wait(timeout: .now() + 1) == .success)
+        #expect(resultQueue.sync { flushResult })
+        #expect(exporter.waitForExport(timeout: 1) == .success)
+        #expect(exporter.successfulSpanNames == ["main-thread.span"])
+        #expect(exporter.flushCount == 1)
+    }
+}

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorPersistenceTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorPersistenceTests.swift
@@ -24,7 +24,7 @@ import Testing
 @Suite(.serialized)
 struct OTLPBatchSpanProcessorPersistenceTests {
     @Test
-    func specificSpanPersistenceReportsSuccessOnlyAfterThatSpanIsExported() {
+    func persistsTargetSpan() {
         let exporter = BatchProcessorTestExporter()
         let processor = OTLPBatchSpanProcessor(
             spanExporter: exporter,
@@ -54,7 +54,7 @@ struct OTLPBatchSpanProcessorPersistenceTests {
     }
 
     @Test
-    func specificSpanPersistenceReportsFailureWhenThatSpanIsDroppedByFullQueue() {
+    func rejectsDroppedTargetSpan() {
         let batchSize = 10
         let exporter = BatchProcessorTestExporter(
             results: [.success, .failure],

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorPersistenceTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPBatchSpanProcessorPersistenceTests.swift
@@ -1,0 +1,115 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import Testing
+
+@testable import SplunkOpenTelemetry
+
+@Suite(.serialized)
+struct OTLPBatchSpanProcessorPersistenceTests {
+    @Test
+    func specificSpanPersistenceReportsSuccessOnlyAfterThatSpanIsExported() {
+        let exporter = BatchProcessorTestExporter()
+        let processor = OTLPBatchSpanProcessor(
+            spanExporter: exporter,
+            scheduleDelay: Self.neverFires,
+            maxExportBatchSize: Self.hugeBatch,
+            maxQueueSize: 2_048
+        )
+        let tracer = makeTracer(for: processor)
+        let completed = DispatchSemaphore(value: 0)
+
+        processor.persistSpan(
+            emitting: {
+                let span = tracer.spanBuilder(spanName: "crash-span").startSpan()
+                let spanId = span.context.spanId
+                span.end()
+                return spanId
+            },
+            timeout: 1,
+            completion: { succeeded in
+                #expect(succeeded)
+                completed.signal()
+            }
+        )
+
+        #expect(completed.wait(timeout: .now() + 1) == .success)
+        #expect(exporter.successfulSpanNames == ["crash-span"])
+    }
+
+    @Test
+    func specificSpanPersistenceReportsFailureWhenThatSpanIsDroppedByFullQueue() {
+        let batchSize = 10
+        let exporter = BatchProcessorTestExporter(
+            results: [.success, .failure],
+            blockExports: true
+        )
+        let processor = OTLPBatchSpanProcessor(
+            spanExporter: exporter,
+            scheduleDelay: Self.neverFires,
+            maxExportBatchSize: batchSize,
+            maxQueueSize: batchSize
+        )
+        let tracer = makeTracer(for: processor)
+        let completed = DispatchSemaphore(value: 0)
+
+        // Occupy the processor queue with the first batch, then fill the in-memory queue again.
+        endSpans(batchSize, using: tracer)
+        #expect(exporter.waitUntilExportStarts(timeout: 1) == .success)
+        endSpans(batchSize, using: tracer)
+
+        processor.persistSpan(
+            emitting: {
+                let span = tracer.spanBuilder(spanName: "crash-span").startSpan()
+                let spanId = span.context.spanId
+                span.end()
+                return spanId
+            },
+            timeout: 1,
+            completion: { succeeded in
+                #expect(!succeeded)
+                completed.signal()
+            }
+        )
+
+        // The queued batch fails and is restored at full capacity before the crash span is emitted.
+        exporter.resumeExports()
+        #expect(exporter.waitUntilExportStarts(timeout: 1) == .success)
+        exporter.resumeExports()
+
+        #expect(completed.wait(timeout: .now() + 1) == .success)
+        #expect(!exporter.successfulSpanNames.contains("crash-span"))
+        #expect(exporter.exportAttemptCount == 2)
+    }
+
+    private static let neverFires: TimeInterval = 3_600
+    private static let hugeBatch = 1_000_000
+
+    private func makeTracer(for processor: OTLPBatchSpanProcessor) -> Tracer {
+        TracerProviderTestBuilder
+            .buildBatch(processor: processor)
+            .get(instrumentationName: "test", instrumentationVersion: "1.0")
+    }
+
+    private func endSpans(_ count: Int, using tracer: Tracer) {
+        for index in 0 ..< count {
+            tracer.spanBuilder(spanName: "span-\(index)").startSpan().end()
+        }
+    }
+}

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
@@ -73,9 +73,10 @@ struct OTLPLogToSpanExporterTests {
         }
 
         let result = exporter.export(logRecords: [makeLogRecord()], explicitTimeout: nil)
-        spanProcessor.forceFlush(timeout: 1)
+        let flushResult = exporter.forceFlush(explicitTimeout: 1)
 
         #expect(result == .success)
+        #expect(flushResult == .success)
         #expect(spanExporter.waitForExport(timeout: 1) == .success)
         #expect(spanExporter.successfulSpanNames == ["test.event"])
     }

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
@@ -80,6 +80,73 @@ struct OTLPLogToSpanExporterTests {
         #expect(spanExporter.successfulSpanNames == ["test.event"])
     }
 
+    @Test
+    func forceFlushDrainsLogDerivedSpanBeforeReportingSuccess() async {
+        let spanExporter = BatchProcessorTestExporter()
+        let spanProcessor = OTLPBatchSpanProcessor(
+            spanExporter: spanExporter,
+            scheduleDelay: 5
+        )
+        let tracerProvider = TracerProviderBuilder()
+            .add(spanProcessor: spanProcessor)
+            .build()
+        let exporter = OTLPLogToSpanExporter(
+            agentVersion: "1.0.0",
+            tracerProviderProvider: { tracerProvider },
+            spanFlusher: { timeout in
+                spanProcessor.forceFlushResult(timeout: timeout) ? .success : .failure
+            }
+        )
+
+        let exportResult = exporter.export(logRecords: [makeLogRecord()], explicitTimeout: nil)
+        #expect(spanExporter.successfulSpanCount == 0)
+
+        let flushTask = Task.detached {
+            exporter.forceFlush(explicitTimeout: 1)
+        }
+        let flushResult = await flushTask.value
+
+        #expect(exportResult == .success)
+        #expect(flushResult == .success)
+        #expect(spanExporter.successfulSpanNames == ["test.event"])
+        #expect(spanExporter.flushCount == 1)
+    }
+
+    @Test
+    func forceFlushReportsFailureWhenLogDerivedSpanCannotBeExported() async {
+        let spanExporter = BatchProcessorTestExporter(results: [.failure, .success])
+        let spanProcessor = OTLPBatchSpanProcessor(
+            spanExporter: spanExporter,
+            scheduleDelay: 5
+        )
+        let tracerProvider = TracerProviderBuilder()
+            .add(spanProcessor: spanProcessor)
+            .build()
+        let exporter = OTLPLogToSpanExporter(
+            agentVersion: "1.0.0",
+            tracerProviderProvider: { tracerProvider },
+            spanFlusher: { timeout in
+                spanProcessor.forceFlushResult(timeout: timeout) ? .success : .failure
+            }
+        )
+
+        _ = exporter.export(logRecords: [makeLogRecord()], explicitTimeout: nil)
+        let flushTask = Task.detached {
+            exporter.forceFlush(explicitTimeout: 1)
+        }
+        let flushResult = await flushTask.value
+
+        #expect(flushResult == .failure)
+        #expect(spanExporter.successfulSpanCount == 0)
+        #expect(spanExporter.exportAttemptCount == 1)
+        #expect(spanExporter.flushCount == 1)
+
+        let cleanupTask = Task.detached {
+            spanProcessor.forceFlush(timeout: 1)
+        }
+        await cleanupTask.value
+    }
+
     private func makeLogRecord() -> ReadableLogRecord {
         ReadableLogRecord(
             resource: Resource(),

--- a/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
+++ b/SplunkOpenTelemetry/Tests/SplunkOpenTelemetryTests/OTLPLogToSpanExporterTests.swift
@@ -81,7 +81,7 @@ struct OTLPLogToSpanExporterTests {
     }
 
     @Test
-    func forceFlushDrainsLogDerivedSpanBeforeReportingSuccess() async {
+    func forceFlushExportsPendingSpan() async {
         let spanExporter = BatchProcessorTestExporter()
         let spanProcessor = OTLPBatchSpanProcessor(
             spanExporter: spanExporter,
@@ -113,7 +113,7 @@ struct OTLPLogToSpanExporterTests {
     }
 
     @Test
-    func forceFlushReportsFailureWhenLogDerivedSpanCannotBeExported() async {
+    func forceFlushReportsExportFailure() async {
         let spanExporter = BatchProcessorTestExporter(results: [.failure, .success])
         let spanProcessor = OTLPBatchSpanProcessor(
             spanExporter: spanExporter,

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
@@ -88,8 +88,9 @@ public class OTLPBackgroundHTTPTraceExporter: OTLPBackgroundHTTPBaseExporter, Sp
         }
         catch {
             // The batch is already durable in active storage. Report success so upstream in-memory
-            // processors do not re-encode and enqueue duplicate span files; stalled upload recovery
-            // or a later endpoint flush will retry the persisted file.
+            // processors do not re-encode and enqueue duplicate span files. Explicitly schedule a
+            // recovery scan because the initialization scan may already have completed.
+            scheduleStalledUploadRecovery()
             return .success
         }
     }

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/Exporters/trace/OTLPBackgroundHTTPTraceExporter.swift
@@ -90,7 +90,7 @@ public class OTLPBackgroundHTTPTraceExporter: OTLPBackgroundHTTPBaseExporter, Sp
             // The batch is already durable in active storage. Report success so upstream in-memory
             // processors do not re-encode and enqueue duplicate span files. Explicitly schedule a
             // recovery scan because the initialization scan may already have completed.
-            scheduleStalledUploadRecovery()
+            startStalledUploadCheck()
             return .success
         }
     }

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter+Recovery.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter+Recovery.swift
@@ -1,0 +1,97 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+/// Scheduling mechanics for persisted uploads that do not have a matching URLSession task.
+///
+/// The state this extension uses is `internal` because Swift requires cross-file extension members
+/// to have module visibility. All access remains serialized by `stalledUploadCheckLock`.
+extension OTLPBackgroundHTTPBaseExporter {
+    /// Schedules a coalesced scan after an active file could not be assigned a URLSession task.
+    ///
+    /// The file is already durable, so callers can report success without creating another copy in
+    /// the in-memory retry queue. If a scan is already pending, it will cover the newly persisted file.
+    func scheduleStalledUploadRecovery() {
+        startStalledUploadCheck(replacingExisting: false)
+    }
+
+    func startStalledUploadCheck(replacingExisting: Bool = false) {
+        guard endpoint != nil else {
+            return
+        }
+
+        stalledUploadCheckLock.lock()
+        if !replacingExisting, checkStalledTask != nil {
+            stalledUploadCheckLock.unlock()
+            return
+        }
+
+        let previousTask = checkStalledTask
+        stalledUploadCheckGeneration &+= 1
+        let generation = stalledUploadCheckGeneration
+        let delay = stalledUploadCheckDelayNanoseconds
+
+        // Wait 5-8s to clean caches content from abandoned or stalled files.
+        let task = Task.detached(priority: .utility) { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: delay)
+            }
+            catch {
+                return
+            }
+
+            guard let self else {
+                return
+            }
+
+            httpClient.getAllSessionsTasks { [weak self] tasks in
+                guard let self, finishStalledUploadCheck(generation: generation) else {
+                    return
+                }
+
+                checkStalledUploadsOperation(tasks: tasks)
+            }
+        }
+        checkStalledTask = task
+        stalledUploadCheckLock.unlock()
+
+        previousTask?.cancel()
+    }
+
+    func finishStalledUploadCheck(generation: UInt64) -> Bool {
+        stalledUploadCheckLock.lock()
+        defer { stalledUploadCheckLock.unlock() }
+
+        guard stalledUploadCheckGeneration == generation else {
+            return false
+        }
+
+        checkStalledTask = nil
+        return true
+    }
+
+    func cancelStalledUploadCheck() {
+        stalledUploadCheckLock.lock()
+        stalledUploadCheckGeneration &+= 1
+        let task = checkStalledTask
+        checkStalledTask = nil
+        stalledUploadCheckLock.unlock()
+
+        task?.cancel()
+    }
+}

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter+Recovery.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter+Recovery.swift
@@ -22,22 +22,20 @@ import Foundation
 /// The state this extension uses is `internal` because Swift requires cross-file extension members
 /// to have module visibility. All access remains serialized by `stalledUploadCheckLock`.
 extension OTLPBackgroundHTTPBaseExporter {
-    /// Schedules a coalesced scan after an active file could not be assigned a URLSession task.
+    /// Schedules a scan for active files without a matching URLSession task.
     ///
-    /// The file is already durable, so callers can report success without creating another copy in
-    /// the in-memory retry queue. If a scan is already pending, it will cover the newly persisted file.
-    func scheduleStalledUploadRecovery() {
-        startStalledUploadCheck(replacingExisting: false)
-    }
-
+    /// When `replacingExisting` is `false`, a pending scan is retained because it will cover files
+    /// persisted after the scan was scheduled.
     func startStalledUploadCheck(replacingExisting: Bool = false) {
         guard endpoint != nil else {
             return
         }
 
         stalledUploadCheckLock.lock()
+
         if !replacingExisting, checkStalledTask != nil {
             stalledUploadCheckLock.unlock()
+
             return
         }
 

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
@@ -42,7 +42,20 @@ public class OTLPBackgroundHTTPBaseExporter {
     let envVarHeaders: [(String, String)]?
     let config: OTLPExporterConfiguration
     let diskStorage: DiskStorage
+
+    /// State used by the recovery extension.
+    ///
+    /// Access is serialized by `stalledUploadCheckLock`.
+    let stalledUploadCheckLock = NSLock()
+    var stalledUploadCheckGeneration: UInt64 = 0
     var checkStalledTask: Task<Void, Never>?
+
+    /// Delay before scanning active storage for persisted files without a matching upload task.
+    ///
+    /// Overridable by tests so recovery behavior can be exercised without a production-length wait.
+    var stalledUploadCheckDelayNanoseconds: UInt64 {
+        UInt64(Int.random(in: 5 ... 8) * 1_000_000_000)
+    }
 
     /// Thread-safe accessor for the endpoint URL.
     var endpoint: URL? {
@@ -112,7 +125,7 @@ public class OTLPBackgroundHTTPBaseExporter {
     }
 
     deinit {
-        checkStalledTask?.cancel()
+        cancelStalledUploadCheck()
     }
 
     // MARK: - Endpoint Management
@@ -135,14 +148,13 @@ public class OTLPBackgroundHTTPBaseExporter {
         }
 
         if performStalledUploadCheck {
-            startStalledUploadCheck()
+            startStalledUploadCheck(replacingExisting: true)
         }
     }
 
     /// Clears the endpoint, causing new data to be cached to pending storage.
     public func clearEndpoint() {
-        checkStalledTask?.cancel()
-        checkStalledTask = nil
+        cancelStalledUploadCheck()
 
         stateLock.lock()
         endpointRevision &+= 1
@@ -312,18 +324,6 @@ public class OTLPBackgroundHTTPBaseExporter {
 // MARK: - Private helpers
 
 extension OTLPBackgroundHTTPBaseExporter {
-    private func startStalledUploadCheck() {
-        checkStalledTask?.cancel()
-        // Wait 5-8s to clean caches content from abandoned or stalled files.
-        checkStalledTask = Task.detached(priority: .utility) { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(Int.random(in: 5 ... 8) * 1_000_000_000))
-            self?.httpClient
-                .getAllSessionsTasks { [weak self] tasks in
-                    self?.checkStalledUploadsOperation(tasks: tasks)
-                }
-        }
-    }
-
     /// Flushes any data stored in pending storage by moving it to active storage and scheduling uploads.
     private func flushPendingData(for activationRevision: UInt64) {
         guard endpointState(for: activationRevision) != nil else {

--- a/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Exporters/OTLPBackgroundHTTPTraceExporterTests.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Test Exporters/OTLPBackgroundHTTPTraceExporterTests.swift
@@ -117,15 +117,54 @@ struct OTLPBackgroundHTTPTraceExporterTests {
     @Test
     func exportReturnsSuccessWhenSchedulingFailsAfterPersistingBatch() throws {
         let disk = makeDisk(uniqueLabel: "http_throw_\(UUID().uuidString)")
-        let http = ThrowingHTTPClient()
-        let exporter = try makeExporter(disk: disk, http: http, config: OTLPExporterConfiguration(timeout: 5))
+        let http = FirstSendThrowingHTTPClient()
+        let endpoint = try #require(URL(string: "https://example.com"))
+        let exporter = ImmediateRecoveryTraceExporter(
+            endpoint: endpoint,
+            config: OTLPExporterConfiguration(timeout: 5),
+            qosConfig: SessionQOSConfiguration(),
+            envVarHeaders: nil,
+            diskStorage: disk,
+            performStalledUploadCheck: false
+        )
+        exporter.httpClient = http
 
         let result = exporter.export(spans: [makeSpanData()], explicitTimeout: nil)
 
         #expect(result == .success)
+        #expect(http.waitForRecoveredSend(timeout: 1) == .success)
 
         let entries = try disk.list(forKey: exporter.getStorageKey())
         #expect(entries.count == 1)
+        #expect(http.sendAttemptCount == 2)
+        #expect(http.successfulRequests.count == 1)
+    }
+
+    @Test
+    func repeatedSchedulingFailuresCoalesceRecoveryScan() throws {
+        let disk = makeDisk(uniqueLabel: "coalesced_recovery_\(UUID().uuidString)")
+        let http = AlwaysThrowingHTTPClient()
+        let endpoint = try #require(URL(string: "https://example.com"))
+        let exporter = DelayedRecoveryTraceExporter(
+            endpoint: endpoint,
+            qosConfig: SessionQOSConfiguration(),
+            envVarHeaders: nil,
+            diskStorage: disk,
+            performStalledUploadCheck: false
+        )
+        exporter.httpClient = http
+
+        let firstResult = exporter.export(spans: [makeSpanData(name: "first")], explicitTimeout: nil)
+        let secondResult = exporter.export(spans: [makeSpanData(name: "second")], explicitTimeout: nil)
+
+        #expect(firstResult == .success)
+        #expect(secondResult == .success)
+        #expect(http.waitForRecoveryScan(timeout: 1) == .success)
+        #expect(http.recoveryScanCount == 1)
+        #expect(http.sendAttemptCount == 4)
+
+        let entries = try disk.list(forKey: exporter.getStorageKey())
+        #expect(entries.count == 2)
     }
 
     @Test
@@ -213,4 +252,18 @@ private final class NoOpSpanExporter: SpanExporter {
     }
 
     func shutdown(explicitTimeout _: TimeInterval?) {}
+}
+
+
+private final class ImmediateRecoveryTraceExporter: OTLPBackgroundHTTPTraceExporter {
+    override var stalledUploadCheckDelayNanoseconds: UInt64 {
+        0
+    }
+}
+
+
+private final class DelayedRecoveryTraceExporter: OTLPBackgroundHTTPTraceExporter {
+    override var stalledUploadCheckDelayNanoseconds: UInt64 {
+        200_000_000
+    }
 }

--- a/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Testing Support/MockHttpClient.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Tests/SplunkOpenTelemetryBackgroundExporterTests/Testing Support/MockHttpClient.swift
@@ -54,6 +54,107 @@ final class ThrowingHTTPClient: NSObject, BackgroundHTTPClientProtocol {
     }
 }
 
+final class FirstSendThrowingHTTPClient: NSObject, BackgroundHTTPClientProtocol {
+    enum StubError: Error {
+        case firstSendFailed
+    }
+
+    private let lock = NSLock()
+    private let recoveredSend = DispatchSemaphore(value: 0)
+    private var storedSendAttemptCount = 0
+    private var storedSuccessfulRequests: [RequestDescriptorProtocol] = []
+
+    var sendAttemptCount: Int {
+        withLock { storedSendAttemptCount }
+    }
+
+    var successfulRequests: [RequestDescriptorProtocol] {
+        withLock { storedSuccessfulRequests }
+    }
+
+    func send(_ requestDescriptor: RequestDescriptorProtocol) throws {
+        let shouldFail = withLock {
+            storedSendAttemptCount += 1
+            return storedSendAttemptCount == 1
+        }
+
+        guard !shouldFail else {
+            throw StubError.firstSendFailed
+        }
+
+        withLock {
+            storedSuccessfulRequests.append(requestDescriptor)
+        }
+        recoveredSend.signal()
+    }
+
+    func flush(completion: @escaping () -> Void) {
+        completion()
+    }
+
+    func getAllSessionsTasks(_ completionHandler: @escaping ([URLSessionTask]) -> Void) {
+        completionHandler([])
+    }
+
+    func waitForRecoveredSend(timeout: TimeInterval) -> DispatchTimeoutResult {
+        recoveredSend.wait(timeout: .now() + timeout)
+    }
+
+    private func withLock<T>(_ work: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try work()
+    }
+}
+
+final class AlwaysThrowingHTTPClient: NSObject, BackgroundHTTPClientProtocol {
+    enum StubError: Error {
+        case sendFailed
+    }
+
+    private let lock = NSLock()
+    private let recoveryScan = DispatchSemaphore(value: 0)
+    private var storedRecoveryScanCount = 0
+    private var storedSendAttemptCount = 0
+
+    var recoveryScanCount: Int {
+        withLock { storedRecoveryScanCount }
+    }
+
+    var sendAttemptCount: Int {
+        withLock { storedSendAttemptCount }
+    }
+
+    func send(_: RequestDescriptorProtocol) throws {
+        withLock {
+            storedSendAttemptCount += 1
+        }
+        throw StubError.sendFailed
+    }
+
+    func flush(completion: @escaping () -> Void) {
+        completion()
+    }
+
+    func getAllSessionsTasks(_ completionHandler: @escaping ([URLSessionTask]) -> Void) {
+        withLock {
+            storedRecoveryScanCount += 1
+        }
+        completionHandler([])
+        recoveryScan.signal()
+    }
+
+    func waitForRecoveryScan(timeout: TimeInterval) -> DispatchTimeoutResult {
+        recoveryScan.wait(timeout: .now() + timeout)
+    }
+
+    private func withLock<T>(_ work: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try work()
+    }
+}
+
 final class FlushSpyHTTPClient: NSObject, BackgroundHTTPClientProtocol {
     var sent: [RequestDescriptorProtocol] = []
     var flushed = false


### PR DESCRIPTION
## Title: Update issues uncovered during release cycle

### Description
There were 3 codex issues identified while creating 2.4.0 https://github.com/signalfx/splunk-otel-ios/pull/698

This PR addresses those three issues
- Retry persisted trace files after send failures
- Log-derived span flush
- Crash report purged after its span was dropped

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [ ] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI
