### PR TITLE
DEMRUM-5816: Expose Session Replay interaction capture controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* Added Swift runtime controls under `sessionReplay.preferences.interactionCapture` for enabling or disabling keyboard, touch, gesture, focus, and rage tap interactions in Session Replay.
 * Session Replay segment metadata now includes a `userActivity` field containing Unix-millisecond timestamps of user interactions that occurred during the segment window, enabling timeline visualization in the backend. Timestamps are only collected while Session Replay is recording; disabling `InteractionsConfiguration` does not affect Session Replay segment recording but does prevent user-activity timestamps from being collected because they originate from the Interactions detector. #646
 * Added `customTracking.trackError(typeName:message:stacktrace:attributes:)` for reporting an error with an explicitly supplied stacktrace. Unlike the existing `trackError` overloads, the supplied stack is emitted verbatim as `exception.stacktrace` (no native stack is derived) and the resulting `component=error` span is named after `typeName` (falling back to `"error"`). This is the native emission path for caught JavaScript/Dart errors bridged from the React Native and Flutter agents. A matching Objective-C selector (`trackErrorWithType:message:stacktrace:attributes:`) is also available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-* Added Swift runtime controls under `sessionReplay.preferences.interactionCapture` for enabling or disabling keyboard, touch, gesture, focus, and rage tap interactions in Session Replay.
+* Added Swift and Objective-C runtime controls under `sessionReplay.preferences.interactionCapture` for enabling or disabling keyboard, touch, gesture, focus, and rage tap interactions in Session Replay.
 * Session Replay segment metadata now includes a `userActivity` field containing Unix-millisecond timestamps of user interactions that occurred during the segment window, enabling timeline visualization in the backend. Timestamps are only collected while Session Replay is recording; disabling `InteractionsConfiguration` does not affect Session Replay segment recording but does prevent user-activity timestamps from being collected because they originate from the Interactions detector. #646
 * Added `customTracking.trackError(typeName:message:stacktrace:attributes:)` for reporting an error with an explicitly supplied stacktrace. Unlike the existing `trackError` overloads, the supplied stack is emitted verbatim as `exception.stacktrace` (no native stack is derived) and the resulting `component=error` span is named after `typeName` (falling back to `"error"`). This is the native emission path for caught JavaScript/Dart errors bridged from the React Native and Flutter agents. A matching Objective-C selector (`trackErrorWithType:message:stacktrace:attributes:`) is also available.
 

--- a/SplunkAgent/Sources/SplunkAgent/Extensions/SplunkRum+TestingSupport.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Extensions/SplunkRum+TestingSupport.swift
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+internal import CiscoSessionReplay
 import Foundation
 internal import SplunkCommon
 
@@ -27,13 +28,18 @@ extension SplunkRum {
     ///
     /// - Parameters:
     ///   - configuration: A configuration for the initial SDK setup.
+    ///   - sessionReplay: An optional Session Replay module to link with the agent.
     ///   - named: A `String` with the name of the test being performed.
     ///
     /// - Returns: An agent instance suitable for performing unit tests.
     ///
     /// - Warning: This method is not meant for client applications and may produce
     ///            unexpected results, which are not supported by the product.
-    public static func buildTestInstance(with configuration: AgentConfiguration, testNamed named: String? = nil) -> SplunkRum {
+    public static func buildTestInstance(
+        with configuration: AgentConfiguration,
+        sessionReplay: (any SessionReplayModule)? = nil,
+        testNamed named: String? = nil
+    ) -> SplunkRum {
         let testName = named ?? "agent"
 
         // Custom key-value storage instance with different keys for testing
@@ -69,7 +75,16 @@ extension SplunkRum {
         // Links the current session with the agent
         (agent.currentSession as? DefaultSession)?.owner = agent
 
+        if let sessionReplay {
+            agent.sessionReplayProxy = sessionReplay
+        }
+
         return agent
+    }
+
+    /// Creates an operational Session Replay proxy for cross-module API tests.
+    public static func buildTestSessionReplay() -> any SessionReplayModule {
+        SessionReplay(for: CiscoSessionReplay.SessionReplay.instance)
     }
 
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Model Conversions/InteractionCapture+Conversions.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Model Conversions/InteractionCapture+Conversions.swift
@@ -1,0 +1,52 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+internal import CiscoSessionReplay
+
+typealias SplunkSessionReplayInteractionCapture = CiscoSessionReplay.InteractionCapture
+
+/// Internal extensions to convert between the proxy and Session Replay interaction capture models.
+extension SplunkSessionReplayInteractionCapture {
+
+    // MARK: - Conversion initialization
+
+    convenience init(from interactionCapture: any SessionReplayModuleInteractionCapture) {
+        self.init()
+
+        isKeyboardEnabled = interactionCapture.isKeyboardEnabled
+        isTouchEnabled = interactionCapture.isTouchEnabled
+        isGestureEnabled = interactionCapture.isGestureEnabled
+        isFocusEnabled = interactionCapture.isFocusEnabled
+        isRageTapEnabled = interactionCapture.isRageTapEnabled
+    }
+}
+
+
+extension SessionReplayInteractionCapture {
+
+    // MARK: - Conversion initialization
+
+    convenience init(from interactionCapture: SplunkSessionReplayInteractionCapture) {
+        self.init()
+
+        isKeyboardEnabled = interactionCapture.isKeyboardEnabled
+        isTouchEnabled = interactionCapture.isTouchEnabled
+        isGestureEnabled = interactionCapture.isGestureEnabled
+        isFocusEnabled = interactionCapture.isFocusEnabled
+        isRageTapEnabled = interactionCapture.isRageTapEnabled
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Model Conversions/Preferences+Conversions.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Model Conversions/Preferences+Conversions.swift
@@ -27,22 +27,26 @@ extension SplunkSessionReplayPreferences {
     // MARK: - Initialization conversion
 
     convenience init(preferences: SessionReplayModulePreferences) {
-        guard let srRenderingMode = preferences.renderingMode?.srRenderingMode else {
-            self.init(renderingMode: .default)
-            return
-        }
+        let renderingMode = preferences.renderingMode?.srRenderingMode ?? .default
+        let interactionCapture = SplunkSessionReplayInteractionCapture(from: preferences.interactionCapture)
 
-        self.init(renderingMode: srRenderingMode)
+        self.init(
+            renderingMode: renderingMode,
+            interactionCapture: interactionCapture
+        )
     }
 }
 
-extension SessionReplayModulePreferences {
+extension SessionReplayPreferences {
 
     // MARK: - Initialization conversion
 
-    init(srPreferences: SplunkSessionReplayPreferences) {
+    convenience init(srPreferences: SplunkSessionReplayPreferences) {
         let renderingMode = RenderingMode(with: srPreferences.renderingMode)
+        let interactionCapture = SessionReplayInteractionCapture(from: srPreferences.interactionCapture)
 
-        self.init(renderingMode: renderingMode)
+        self.init(interactionCapture: interactionCapture)
+
+        self.renderingMode = renderingMode
     }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplay.swift
@@ -62,11 +62,11 @@ final class SessionReplay: SessionReplayModule {
 
     lazy var preferences: any SessionReplayModulePreferences = SessionReplayPreferences(for: module) {
         didSet {
-            // Link preferences with module instance
-            (preferences as? SessionReplayPreferences)?.module = module
-
-            // Pass changes into the module
+            // Convert detached preferences before linking them with the module
             module.preferences = SplunkSessionReplayPreferences(preferences: preferences)
+
+            // Link preferences with the newly configured module instance
+            (preferences as? SessionReplayPreferences)?.module = module
         }
     }
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayInteractionCapture.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayInteractionCapture.swift
@@ -1,0 +1,98 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+internal import CiscoSessionReplay
+
+/// The interaction capture object implements public API for interaction category controls.
+final class SessionReplayInteractionCapture: SessionReplayModuleInteractionCapture {
+
+    // MARK: - Private
+
+    unowned var module: CiscoSessionReplay.SessionReplay?
+
+    private let detachedCapture = CiscoSessionReplay.InteractionCapture()
+
+    private var capture: CiscoSessionReplay.InteractionCapture {
+        module?.preferences.interactionCapture ?? detachedCapture
+    }
+
+
+    // MARK: - Categories
+
+    var isKeyboardEnabled: Bool {
+        get {
+            capture.isKeyboardEnabled
+        }
+        set {
+            capture.isKeyboardEnabled = newValue
+        }
+    }
+
+    var isTouchEnabled: Bool {
+        get {
+            capture.isTouchEnabled
+        }
+        set {
+            capture.isTouchEnabled = newValue
+        }
+    }
+
+    var isGestureEnabled: Bool {
+        get {
+            capture.isGestureEnabled
+        }
+        set {
+            capture.isGestureEnabled = newValue
+        }
+    }
+
+    var isFocusEnabled: Bool {
+        get {
+            capture.isFocusEnabled
+        }
+        set {
+            capture.isFocusEnabled = newValue
+        }
+    }
+
+    var isRageTapEnabled: Bool {
+        get {
+            capture.isRageTapEnabled
+        }
+        set {
+            capture.isRageTapEnabled = newValue
+        }
+    }
+
+
+    // MARK: - Initialization
+
+    init(for module: CiscoSessionReplay.SessionReplay? = nil) {
+        self.module = module
+    }
+
+
+    // MARK: - Bulk updates
+
+    func enableAll() {
+        capture.enableAll()
+    }
+
+    func disableAll() {
+        capture.disableAll()
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
@@ -28,7 +28,7 @@ import Foundation
 ///
 /// - Note: If you want to set up a parameter, you can change the appropriate property
 ///         or use the proper method. Both approaches are comparable and give the same result.
-public final class SessionReplayPreferences: SessionReplayModulePreferences, Codable {
+public final class SessionReplayPreferences: SessionReplayModulePreferences {
 
     // MARK: - Internal
 
@@ -88,13 +88,65 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences, Cod
             self.interactionCapture = interactionCapture
         }
     }
+}
 
+
+extension SessionReplayPreferences: Codable {
 
     // MARK: - Codable
 
-    /// Interaction capture contains runtime-only state and is intentionally excluded.
     private enum CodingKeys: String, CodingKey {
         case renderingMode
+        case interactionCapture
+    }
+
+    private struct InteractionCaptureState: Codable {
+        let isKeyboardEnabled: Bool
+        let isTouchEnabled: Bool
+        let isGestureEnabled: Bool
+        let isFocusEnabled: Bool
+        let isRageTapEnabled: Bool
+
+        init(_ capture: any SessionReplayModuleInteractionCapture) {
+            isKeyboardEnabled = capture.isKeyboardEnabled
+            isTouchEnabled = capture.isTouchEnabled
+            isGestureEnabled = capture.isGestureEnabled
+            isFocusEnabled = capture.isFocusEnabled
+            isRageTapEnabled = capture.isRageTapEnabled
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            isKeyboardEnabled = try container.decodeIfPresent(Bool.self, forKey: .isKeyboardEnabled) ?? true
+            isTouchEnabled = try container.decodeIfPresent(Bool.self, forKey: .isTouchEnabled) ?? true
+            isGestureEnabled = try container.decodeIfPresent(Bool.self, forKey: .isGestureEnabled) ?? true
+            isFocusEnabled = try container.decodeIfPresent(Bool.self, forKey: .isFocusEnabled) ?? true
+            isRageTapEnabled = try container.decodeIfPresent(Bool.self, forKey: .isRageTapEnabled) ?? true
+        }
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.init()
+
+        renderingMode = try container.decodeIfPresent(RenderingMode.self, forKey: .renderingMode)
+
+        if let state = try container.decodeIfPresent(InteractionCaptureState.self, forKey: .interactionCapture) {
+            interactionCapture.isKeyboardEnabled = state.isKeyboardEnabled
+            interactionCapture.isTouchEnabled = state.isTouchEnabled
+            interactionCapture.isGestureEnabled = state.isGestureEnabled
+            interactionCapture.isFocusEnabled = state.isFocusEnabled
+            interactionCapture.isRageTapEnabled = state.isRageTapEnabled
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(renderingMode, forKey: .renderingMode)
+        try container.encode(InteractionCaptureState(interactionCapture), forKey: .interactionCapture)
     }
 }
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
@@ -82,7 +82,7 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences {
         interactionCapture: (any SessionReplayModuleInteractionCapture)? = nil
     ) {
         self.module = module
-        renderingMode = RenderingMode(with: module?.preferences.renderingMode)
+        renderingMode = module?.preferences.renderingMode.map(RenderingMode.init(with:))
 
         if let interactionCapture {
             self.interactionCapture = interactionCapture

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Module/SessionReplayPreferences.swift
@@ -32,26 +32,20 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences, Cod
 
     // MARK: - Internal
 
-    unowned var module: CiscoSessionReplay.SessionReplay?
-
-
-    // MARK: - Initialization
-
-    required init() {
-        module = nil
+    unowned var module: CiscoSessionReplay.SessionReplay? {
+        didSet {
+            (interactionCapture as? SessionReplayInteractionCapture)?.module = module
+        }
     }
 
-    init(for module: CiscoSessionReplay.SessionReplay?) {
-        self.module = module
-        renderingMode = RenderingMode(with: module?.preferences.renderingMode)
-    }
+    // MARK: - Interaction capture
 
-
-    // MARK: - Codable
-
-    private enum CodingKeys: String, CodingKey {
-        case renderingMode
-    }
+    /// Configuration that controls which detected interaction categories are captured.
+    ///
+    /// All categories are enabled by default. Updating this object affects only
+    /// interactions received after the change.
+    public private(set) lazy var interactionCapture: any SessionReplayModuleInteractionCapture =
+        SessionReplayInteractionCapture(for: module)
 
 
     // MARK: - Rendering
@@ -79,6 +73,29 @@ public final class SessionReplayPreferences: SessionReplayModulePreferences, Cod
 
         return self
     }
+
+
+    // MARK: - Initialization
+
+    init(
+        for module: CiscoSessionReplay.SessionReplay? = nil,
+        interactionCapture: (any SessionReplayModuleInteractionCapture)? = nil
+    ) {
+        self.module = module
+        renderingMode = RenderingMode(with: module?.preferences.renderingMode)
+
+        if let interactionCapture {
+            self.interactionCapture = interactionCapture
+        }
+    }
+
+
+    // MARK: - Codable
+
+    /// Interaction capture contains runtime-only state and is intentionally excluded.
+    private enum CodingKeys: String, CodingKey {
+        case renderingMode
+    }
 }
 
 
@@ -90,7 +107,7 @@ extension SessionReplayPreferences {
     ///
     /// - Parameter renderingMode: The ``RenderingMode`` to use for the session replay.
     public convenience init(renderingMode: RenderingMode) {
-        self.init(for: nil)
+        self.init()
 
         self.renderingMode = renderingMode
     }

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperational+Preferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperational+Preferences.swift
@@ -25,7 +25,9 @@ extension SessionReplayNonOperational {
         get {
             logAccess(toApi: #function)
 
-            return SessionReplayPreferences()
+            return SessionReplayPreferences(
+                interactionCapture: SessionReplayNonOperationalCapture(logger: logger)
+            )
         }
 
         // swiftlint:disable unused_setter_value

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperational.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperational.swift
@@ -24,9 +24,9 @@ internal import SplunkCommon
 /// but we still need to keep the API available to the user.
 final class SessionReplayNonOperational: SessionReplayModule {
 
-    // MARK: - Private
+    // MARK: - Internal
 
-    private let logger: DefaultLogAgent
+    let logger: DefaultLogAgent
 
 
     // MARK: - Sensitivity

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperationalCapture.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Proxies/Non-Operational/SessionReplayNonOperationalCapture.swift
@@ -1,0 +1,118 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+internal import CiscoLogger
+
+/// The class implementing interaction capture API in non-operational mode.
+final class SessionReplayNonOperationalCapture: SessionReplayModuleInteractionCapture {
+
+    // MARK: - Private
+
+    private let logger: LogAgent
+
+
+    // MARK: - Initialization
+
+    init(logger: LogAgent) {
+        self.logger = logger
+    }
+
+
+    // MARK: - Categories
+
+    // swiftlint:disable unused_setter_value
+
+    var isKeyboardEnabled: Bool {
+        get {
+            logAccess(toApi: #function)
+
+            return false
+        }
+        set {
+            logAccess(toApi: #function)
+        }
+    }
+
+    var isTouchEnabled: Bool {
+        get {
+            logAccess(toApi: #function)
+
+            return false
+        }
+        set {
+            logAccess(toApi: #function)
+        }
+    }
+
+    var isGestureEnabled: Bool {
+        get {
+            logAccess(toApi: #function)
+
+            return false
+        }
+        set {
+            logAccess(toApi: #function)
+        }
+    }
+
+    var isFocusEnabled: Bool {
+        get {
+            logAccess(toApi: #function)
+
+            return false
+        }
+        set {
+            logAccess(toApi: #function)
+        }
+    }
+
+    var isRageTapEnabled: Bool {
+        get {
+            logAccess(toApi: #function)
+
+            return false
+        }
+        set {
+            logAccess(toApi: #function)
+        }
+    }
+
+    // swiftlint:enable unused_setter_value
+
+
+    // MARK: - Bulk updates
+
+    func enableAll() {
+        logAccess(toApi: #function)
+    }
+
+    func disableAll() {
+        logAccess(toApi: #function)
+    }
+
+
+    // MARK: - Logging
+
+    func logAccess(toApi named: String) {
+        logger.log(level: .notice, isPrivate: false) {
+            """
+            Attempt to access the Interaction Capture API of a remotely disabled Session Replay module. \n
+            API: `\(named)`
+            """
+        }
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleInteractionCapture.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleInteractionCapture.swift
@@ -1,0 +1,51 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Defines a public API for controlling which detected interaction categories are captured.
+///
+/// All categories are enabled by default. Changes apply only to interactions received
+/// after the corresponding property is updated.
+public protocol SessionReplayModuleInteractionCapture: AnyObject {
+
+    // MARK: - Categories
+
+    /// Indicates whether soft keyboard interactions are captured.
+    var isKeyboardEnabled: Bool { get set }
+
+    /// Indicates whether pointer and touch interactions are captured.
+    var isTouchEnabled: Bool { get set }
+
+    /// Indicates whether recognized gesture interactions are captured.
+    ///
+    /// Rage tap interactions are controlled separately by ``isRageTapEnabled``.
+    var isGestureEnabled: Bool { get set }
+
+    /// Indicates whether focus-change interactions are captured.
+    var isFocusEnabled: Bool { get set }
+
+    /// Indicates whether rage tap interactions are captured.
+    var isRageTapEnabled: Bool { get set }
+
+
+    // MARK: - Bulk updates
+
+    /// Enables capture for every configurable interaction category.
+    func enableAll()
+
+    /// Disables capture for every configurable interaction category.
+    func disableAll()
+}

--- a/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferences.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferences.swift
@@ -18,6 +18,15 @@ limitations under the License.
 /// Defines a public API for the user's preferred settings.
 public protocol SessionReplayModulePreferences {
 
+    // MARK: - Interaction capture
+
+    /// Configuration that controls which detected interaction categories are captured.
+    ///
+    /// All categories are enabled by default. Updating this object affects only
+    /// interactions received after the change.
+    var interactionCapture: any SessionReplayModuleInteractionCapture { get }
+
+
     // MARK: - Rendering
 
     /// The video ``RenderingMode`` for captured data.

--- a/SplunkAgent/Sources/SplunkAgent/SplunkAgent.docc/Modules/Session-Replay.md
+++ b/SplunkAgent/Sources/SplunkAgent/SplunkAgent.docc/Modules/Session-Replay.md
@@ -38,6 +38,9 @@ capture?.isRageTapEnabled = false
 Use ``SessionReplayModuleInteractionCapture/enableAll()`` or
 ``SessionReplayModuleInteractionCapture/disableAll()`` to update every configurable category at once.
 
+Interaction capture preferences are included when ``SessionReplayPreferences`` is encoded. When decoding
+older or partial data, missing interaction categories remain enabled by default.
+
 ## Privacy and Sensitivity
 
 By default, common sensitive views like `UITextField` and `UITextView` are masked. You can mark any `UIView` as sensitive to ensure it is redacted from the recording.

--- a/SplunkAgent/Sources/SplunkAgent/SplunkAgent.docc/Modules/Session-Replay.md
+++ b/SplunkAgent/Sources/SplunkAgent/SplunkAgent.docc/Modules/Session-Replay.md
@@ -23,6 +23,21 @@ Session Replay must be started manually.
 agent?.sessionReplay.start()
 ```
 
+## Interaction Capture
+
+Use ``SessionReplayModulePreferences/interactionCapture`` to control which categories of user interactions
+are included in Session Replay. All categories are enabled by default, and changes affect only interactions
+captured after the setting is updated.
+
+```swift
+let capture = agent?.sessionReplay.preferences.interactionCapture
+capture?.isKeyboardEnabled = false
+capture?.isRageTapEnabled = false
+```
+
+Use ``SessionReplayModuleInteractionCapture/enableAll()`` or
+``SessionReplayModuleInteractionCapture/disableAll()`` to update every configurable category at once.
+
 ## Privacy and Sensitivity
 
 By default, common sensitive views like `UITextField` and `UITextView` are masked. You can mark any `UIView` as sensitive to ensure it is redacted from the recording.

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleInteractionCaptureObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Session Replay/Public API/API-1.0-SessionReplayModuleInteractionCaptureObjC.swift
@@ -1,0 +1,125 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import SplunkAgent
+
+/// The interaction capture object controls which detected interaction categories are captured.
+@objc(SPLKSessionReplayModuleInteractionCapture)
+// swiftlint:disable:next type_name
+public final class SessionReplayModuleInteractionCaptureObjC: NSObject {
+
+    // MARK: - Internal
+
+    private unowned let owner: SplunkRumObjC
+
+    private var capture: any SessionReplayModuleInteractionCapture {
+        owner.agent.sessionReplay.preferences.interactionCapture
+    }
+
+
+    // MARK: - Categories
+
+    /// Indicates whether soft keyboard interactions are captured.
+    @objc(keyboardEnabled)
+    public var keyboardEnabled: Bool {
+        @objc(isKeyboardEnabled)
+        get {
+            capture.isKeyboardEnabled
+        }
+        @objc(setKeyboardEnabled:)
+        set {
+            capture.isKeyboardEnabled = newValue
+        }
+    }
+
+    /// Indicates whether pointer and touch interactions are captured.
+    @objc(touchEnabled)
+    public var touchEnabled: Bool {
+        @objc(isTouchEnabled)
+        get {
+            capture.isTouchEnabled
+        }
+        @objc(setTouchEnabled:)
+        set {
+            capture.isTouchEnabled = newValue
+        }
+    }
+
+    /// Indicates whether recognized gesture interactions are captured.
+    ///
+    /// Rage tap interactions are controlled separately by ``rageTapEnabled``.
+    @objc(gestureEnabled)
+    public var gestureEnabled: Bool {
+        @objc(isGestureEnabled)
+        get {
+            capture.isGestureEnabled
+        }
+        @objc(setGestureEnabled:)
+        set {
+            capture.isGestureEnabled = newValue
+        }
+    }
+
+    /// Indicates whether focus-change interactions are captured.
+    @objc(focusEnabled)
+    public var focusEnabled: Bool {
+        @objc(isFocusEnabled)
+        get {
+            capture.isFocusEnabled
+        }
+        @objc(setFocusEnabled:)
+        set {
+            capture.isFocusEnabled = newValue
+        }
+    }
+
+    /// Indicates whether rage tap interactions are captured.
+    @objc(rageTapEnabled)
+    public var rageTapEnabled: Bool {
+        @objc(isRageTapEnabled)
+        get {
+            capture.isRageTapEnabled
+        }
+        @objc(setRageTapEnabled:)
+        set {
+            capture.isRageTapEnabled = newValue
+        }
+    }
+
+
+    // MARK: - Category control
+
+    /// Enables capture for every configurable interaction category.
+    @objc(enableAll)
+    public func enableAll() {
+        capture.enableAll()
+    }
+
+    /// Disables capture for every configurable interaction category.
+    @objc(disableAll)
+    public func disableAll() {
+        capture.disableAll()
+    }
+
+
+    // MARK: - Initialization
+
+    init(for owner: SplunkRumObjC) {
+        self.owner = owner
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgentObjC/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferencesObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Modules/Session Replay/Public API/API-1.0-SessionReplayModulePreferencesObjC.swift
@@ -27,6 +27,13 @@ public final class SessionReplayModulePreferencesObjC: NSObject {
     private unowned let owner: SplunkRumObjC
 
 
+    // MARK: - Interaction capture
+
+    /// Configuration that controls which detected interaction categories are captured.
+    @objc
+    public let interactionCapture: SessionReplayModuleInteractionCaptureObjC
+
+
     // MARK: - Rendering
 
     /// The video rendering mode for captured data.
@@ -58,5 +65,6 @@ public final class SessionReplayModulePreferencesObjC: NSObject {
 
     init(for owner: SplunkRumObjC) {
         self.owner = owner
+        interactionCapture = SessionReplayModuleInteractionCaptureObjC(for: owner)
     }
 }

--- a/SplunkAgent/Sources/SplunkAgentObjC/Testing Support/AgentTestingObjC.swift
+++ b/SplunkAgent/Sources/SplunkAgentObjC/Testing Support/AgentTestingObjC.swift
@@ -61,9 +61,38 @@ public class AgentTestingObjC: NSObject {
     ///
     /// - Returns: A newly initialized agent instance.
     public static func buildTestAgent(with configuration: AgentConfigurationObjC?, testNamed named: String? = nil) -> SplunkRumObjC {
+        buildTestAgent(
+            with: configuration,
+            sessionReplay: false,
+            testNamed: named
+        )
+    }
+
+    /// Private method for creating test instances of the agent with optional Session Replay support.
+    ///
+    /// **Warning:** This method is not meant for client applications and may produce
+    ///            unexpected results, which are not supported by the product.
+    ///
+    /// - Parameters:
+    ///   - configuration: A `SPLKAgentConfiguration` for the initial SDK setup.
+    ///   - sessionReplay: Whether an operational Session Replay proxy should be linked with the agent.
+    ///   - named: A `NSString` with the name of the test being performed.
+    ///
+    /// - Returns: A newly initialized agent instance.
+    @objc(buildTestAgentWith:sessionReplay:testNamed:)
+    public static func buildTestAgent(
+        with configuration: AgentConfigurationObjC?,
+        sessionReplay: Bool,
+        testNamed named: String? = nil
+    ) -> SplunkRumObjC {
         let configuration = configuration ?? buildTestConfiguration()
+        let sessionReplayModule = sessionReplay ? SplunkRum.buildTestSessionReplay() : nil
+
+        sessionReplayModule?.preferences.interactionCapture.enableAll()
+
         let agent = SplunkRum.buildTestInstance(
             with: configuration.agentConfiguration(),
+            sessionReplay: sessionReplayModule,
             testNamed: named
         )
 

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Builders/AgentTestBuilderObjC.h
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Builders/AgentTestBuilderObjC.h
@@ -24,5 +24,6 @@ limitations under the License.
 
 + (SPLKAgent *)buildDefault;
 + (SPLKAgent *)buildDefaultForTestNamed:(NSString *)testName;
++ (SPLKAgent *)buildWithOperationalSessionReplayForTestNamed:(NSString *)testName;
 
 @end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Builders/AgentTestBuilderObjC.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Builders/AgentTestBuilderObjC.m
@@ -36,4 +36,14 @@ limitations under the License.
     return agent;
 }
 
++ (SPLKAgent *)buildWithOperationalSessionReplayForTestNamed:(NSString *)testName {
+    SPLKAgentConfiguration *configuration = [STSAgentTesting buildTestConfiguration];
+
+    SPLKAgent *agent = [STSAgentTesting buildTestAgentWith:configuration
+                                             sessionReplay:YES
+                                                 testNamed:testName];
+
+    return agent;
+}
+
 @end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureObjCTests.m
@@ -40,10 +40,12 @@ limitations under the License.
 - (void)setUp {
     [super setUp];
 
-    agent = [AgentTestBuilderObjC buildDefaultForTestNamed:@"sessionReplayInteractionCaptureTest"];
+    agent = [AgentTestBuilderObjC
+        buildWithOperationalSessionReplayForTestNamed:@"sessionReplayInteractionCaptureTest"];
 }
 
 - (void)tearDown {
+    [agent.sessionReplay.preferences.interactionCapture enableAll];
     agent = nil;
 
     [super tearDown];
@@ -56,26 +58,29 @@ limitations under the License.
     SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
 
     XCTAssertNotNil(capture);
-    XCTAssertFalse([capture isKeyboardEnabled]);
-    XCTAssertFalse([capture isTouchEnabled]);
-    XCTAssertFalse([capture isGestureEnabled]);
-    XCTAssertFalse([capture isFocusEnabled]);
-    XCTAssertFalse([capture isRageTapEnabled]);
+    XCTAssertTrue([capture isKeyboardEnabled]);
+    XCTAssertTrue([capture isTouchEnabled]);
+    XCTAssertTrue([capture isGestureEnabled]);
+    XCTAssertTrue([capture isFocusEnabled]);
+    XCTAssertTrue([capture isRageTapEnabled]);
 }
 
 - (void)testSetters {
     SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
 
-    capture.keyboardEnabled = YES;
-    capture.touchEnabled = YES;
-    capture.gestureEnabled = YES;
-    capture.focusEnabled = YES;
-    capture.rageTapEnabled = YES;
-
+    capture.keyboardEnabled = NO;
     XCTAssertFalse([capture isKeyboardEnabled]);
+
+    capture.touchEnabled = NO;
     XCTAssertFalse([capture isTouchEnabled]);
+
+    capture.gestureEnabled = NO;
     XCTAssertFalse([capture isGestureEnabled]);
+
+    capture.focusEnabled = NO;
     XCTAssertFalse([capture isFocusEnabled]);
+
+    capture.rageTapEnabled = NO;
     XCTAssertFalse([capture isRageTapEnabled]);
 }
 
@@ -85,14 +90,6 @@ limitations under the License.
 - (void)testBulkUpdates {
     SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
 
-    [capture enableAll];
-
-    XCTAssertFalse(capture.keyboardEnabled);
-    XCTAssertFalse(capture.touchEnabled);
-    XCTAssertFalse(capture.gestureEnabled);
-    XCTAssertFalse(capture.focusEnabled);
-    XCTAssertFalse(capture.rageTapEnabled);
-
     [capture disableAll];
 
     XCTAssertFalse(capture.keyboardEnabled);
@@ -100,6 +97,14 @@ limitations under the License.
     XCTAssertFalse(capture.gestureEnabled);
     XCTAssertFalse(capture.focusEnabled);
     XCTAssertFalse(capture.rageTapEnabled);
+
+    [capture enableAll];
+
+    XCTAssertTrue(capture.keyboardEnabled);
+    XCTAssertTrue(capture.touchEnabled);
+    XCTAssertTrue(capture.gestureEnabled);
+    XCTAssertTrue(capture.focusEnabled);
+    XCTAssertTrue(capture.rageTapEnabled);
 }
 
 @end

--- a/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureObjCTests.m
+++ b/SplunkAgent/Tests/SplunkAgentObjCTests/PublicAPI/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureObjCTests.m
@@ -1,0 +1,105 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#import <XCTest/XCTest.h>
+#import "../../Builders/AgentTestBuilderObjC.h"
+
+@import SplunkAgentObjC;
+
+
+@interface SessionReplayModuleInteractionCaptureObjCTests : XCTestCase
+
+@property SPLKAgent *agent;
+
+@end
+
+
+@implementation SessionReplayModuleInteractionCaptureObjCTests
+
+// MARK: - Private
+
+@synthesize agent;
+
+
+// MARK: - Tests lifecycle
+
+- (void)setUp {
+    [super setUp];
+
+    agent = [AgentTestBuilderObjC buildDefaultForTestNamed:@"sessionReplayInteractionCaptureTest"];
+}
+
+- (void)tearDown {
+    agent = nil;
+
+    [super tearDown];
+}
+
+
+// MARK: - Categories
+
+- (void)testInitialValues {
+    SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
+
+    XCTAssertNotNil(capture);
+    XCTAssertFalse([capture isKeyboardEnabled]);
+    XCTAssertFalse([capture isTouchEnabled]);
+    XCTAssertFalse([capture isGestureEnabled]);
+    XCTAssertFalse([capture isFocusEnabled]);
+    XCTAssertFalse([capture isRageTapEnabled]);
+}
+
+- (void)testSetters {
+    SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
+
+    capture.keyboardEnabled = YES;
+    capture.touchEnabled = YES;
+    capture.gestureEnabled = YES;
+    capture.focusEnabled = YES;
+    capture.rageTapEnabled = YES;
+
+    XCTAssertFalse([capture isKeyboardEnabled]);
+    XCTAssertFalse([capture isTouchEnabled]);
+    XCTAssertFalse([capture isGestureEnabled]);
+    XCTAssertFalse([capture isFocusEnabled]);
+    XCTAssertFalse([capture isRageTapEnabled]);
+}
+
+
+// MARK: - Bulk updates
+
+- (void)testBulkUpdates {
+    SPLKSessionReplayModuleInteractionCapture *capture = agent.sessionReplay.preferences.interactionCapture;
+
+    [capture enableAll];
+
+    XCTAssertFalse(capture.keyboardEnabled);
+    XCTAssertFalse(capture.touchEnabled);
+    XCTAssertFalse(capture.gestureEnabled);
+    XCTAssertFalse(capture.focusEnabled);
+    XCTAssertFalse(capture.rageTapEnabled);
+
+    [capture disableAll];
+
+    XCTAssertFalse(capture.keyboardEnabled);
+    XCTAssertFalse(capture.touchEnabled);
+    XCTAssertFalse(capture.gestureEnabled);
+    XCTAssertFalse(capture.focusEnabled);
+    XCTAssertFalse(capture.rageTapEnabled);
+}
+
+@end

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-ModuleProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-ModuleProxyTests.swift
@@ -66,6 +66,10 @@ final class SessionReplayAPI10ModuleProxyTests: XCTestCase {
         _ = SessionReplayPreferences(renderingMode: .native)
     }
 
+    func testDetachedPreferencesHaveNoRenderingMode() {
+        XCTAssertNil(SessionReplayPreferences().renderingMode)
+    }
+
 
     // MARK: - Interaction capture
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-ModuleProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-ModuleProxyTests.swift
@@ -67,6 +67,51 @@ final class SessionReplayAPI10ModuleProxyTests: XCTestCase {
     }
 
 
+    // MARK: - Interaction capture
+
+    func testAssignedPreferencesPreserveInteractionCapture() {
+        let preferences = SessionReplayPreferences()
+        preferences.interactionCapture.isKeyboardEnabled = false
+        preferences.interactionCapture.isTouchEnabled = true
+        preferences.interactionCapture.isGestureEnabled = false
+        preferences.interactionCapture.isFocusEnabled = true
+        preferences.interactionCapture.isRageTapEnabled = false
+
+        moduleProxy.preferences = preferences
+
+        let moduleCapture = moduleProxy.module.preferences.interactionCapture
+        XCTAssertFalse(moduleCapture.isKeyboardEnabled)
+        XCTAssertTrue(moduleCapture.isTouchEnabled)
+        XCTAssertFalse(moduleCapture.isGestureEnabled)
+        XCTAssertTrue(moduleCapture.isFocusEnabled)
+        XCTAssertFalse(moduleCapture.isRageTapEnabled)
+
+        preferences.interactionCapture.enableAll()
+
+        XCTAssertTrue(moduleCapture.isKeyboardEnabled)
+        XCTAssertTrue(moduleCapture.isTouchEnabled)
+        XCTAssertTrue(moduleCapture.isGestureEnabled)
+        XCTAssertTrue(moduleCapture.isFocusEnabled)
+        XCTAssertTrue(moduleCapture.isRageTapEnabled)
+    }
+
+    func testInteractionCaptureReferenceUsesCurrentModulePreferences() {
+        let capture = moduleProxy.preferences.interactionCapture
+        moduleProxy.preferences = SessionReplayPreferences(renderingMode: .native)
+
+        capture.disableAll()
+
+        let moduleCapture = moduleProxy.module.preferences.interactionCapture
+        XCTAssertFalse(moduleCapture.isKeyboardEnabled)
+        XCTAssertFalse(moduleCapture.isTouchEnabled)
+        XCTAssertFalse(moduleCapture.isGestureEnabled)
+        XCTAssertFalse(moduleCapture.isFocusEnabled)
+        XCTAssertFalse(moduleCapture.isRageTapEnabled)
+
+        moduleCapture.enableAll()
+    }
+
+
     // MARK: - State
 
     func testState() {

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-NonOperationalProxyTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-NonOperationalProxyTests.swift
@@ -55,6 +55,43 @@ final class SessionReplayAPI10NoOpProxyTests: XCTestCase {
     }
 
 
+    // MARK: - Interaction capture
+
+    func testInteractionCapture() {
+        let capture = moduleProxy.preferences.interactionCapture
+
+        capture.disableAll()
+
+        XCTAssertFalse(capture.isKeyboardEnabled)
+        XCTAssertFalse(capture.isTouchEnabled)
+        XCTAssertFalse(capture.isGestureEnabled)
+        XCTAssertFalse(capture.isFocusEnabled)
+        XCTAssertFalse(capture.isRageTapEnabled)
+
+        capture.enableAll()
+
+        XCTAssertFalse(capture.isKeyboardEnabled)
+        XCTAssertFalse(capture.isTouchEnabled)
+        XCTAssertFalse(capture.isGestureEnabled)
+        XCTAssertFalse(capture.isFocusEnabled)
+        XCTAssertFalse(capture.isRageTapEnabled)
+    }
+
+    func testInteractionCaptureOutlivesModule() {
+        weak var moduleReference: SessionReplayNonOperational?
+        let capture: any SessionReplayModuleInteractionCapture
+
+        do {
+            let module = SessionReplayTestBuilder.buildNonOperational()
+            moduleReference = module
+            capture = module.preferences.interactionCapture
+        }
+
+        XCTAssertNil(moduleReference)
+        XCTAssertFalse(capture.isKeyboardEnabled)
+    }
+
+
     // MARK: - State
 
     func testState() {

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureTests.swift
@@ -62,10 +62,63 @@ final class SessionReplayInteractionCaptureTests: XCTestCase {
     }
 
 
+    // MARK: - Codable
+
+    func testPreferencesCodableRoundTripPreservesInteractionCapture() throws {
+        let preferences = SessionReplayPreferences(renderingMode: .wireframeOnly)
+        let capture = preferences.interactionCapture
+        capture.isKeyboardEnabled = false
+        capture.isTouchEnabled = true
+        capture.isGestureEnabled = false
+        capture.isFocusEnabled = true
+        capture.isRageTapEnabled = false
+
+        let data = try JSONEncoder().encode(preferences)
+        let decodedPreferences = try JSONDecoder().decode(SessionReplayPreferences.self, from: data)
+        let decodedCapture = decodedPreferences.interactionCapture
+
+        XCTAssertEqual(decodedPreferences.renderingMode, .wireframeOnly)
+        XCTAssertFalse(decodedCapture.isKeyboardEnabled)
+        XCTAssertTrue(decodedCapture.isTouchEnabled)
+        XCTAssertFalse(decodedCapture.isGestureEnabled)
+        XCTAssertTrue(decodedCapture.isFocusEnabled)
+        XCTAssertFalse(decodedCapture.isRageTapEnabled)
+    }
+
+    func testPreferencesDecodingLegacyPayloadUsesInteractionCaptureDefaults() throws {
+        let data = try JSONEncoder().encode(LegacyPreferences(renderingMode: .native))
+
+        let preferences = try JSONDecoder().decode(SessionReplayPreferences.self, from: data)
+
+        XCTAssertEqual(preferences.renderingMode, .native)
+        assertAllCategoriesEnabled(preferences.interactionCapture)
+    }
+
+    func testPreferencesDecodingPartialInteractionCaptureUsesCategoryDefaults() throws {
+        let data = Data(
+            #"{"interactionCapture":{"isKeyboardEnabled":false,"isRageTapEnabled":false}}"#.utf8
+        )
+
+        let capture = try JSONDecoder()
+            .decode(SessionReplayPreferences.self, from: data)
+            .interactionCapture
+
+        XCTAssertFalse(capture.isKeyboardEnabled)
+        XCTAssertTrue(capture.isTouchEnabled)
+        XCTAssertTrue(capture.isGestureEnabled)
+        XCTAssertTrue(capture.isFocusEnabled)
+        XCTAssertFalse(capture.isRageTapEnabled)
+    }
+
+
     // MARK: - Fixtures
 
     private func makeCapture() -> any SessionReplayModuleInteractionCapture {
         SessionReplayPreferences(renderingMode: .native).interactionCapture
+    }
+
+    private struct LegacyPreferences: Encodable {
+        let renderingMode: RenderingMode?
     }
 
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-SessionReplayModuleInteractionCaptureTests.swift
@@ -1,0 +1,97 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SplunkAgent
+import XCTest
+
+final class SessionReplayInteractionCaptureTests: XCTestCase {
+
+    // MARK: - Default state
+
+    func testInitialValues() {
+        assertAllCategoriesEnabled(makeCapture())
+    }
+
+
+    // MARK: - Category properties
+
+    func testSetters() {
+        let capture = makeCapture()
+
+        capture.isKeyboardEnabled = false
+        capture.isTouchEnabled = false
+        capture.isGestureEnabled = false
+        capture.isFocusEnabled = false
+        capture.isRageTapEnabled = false
+
+        assertAllCategoriesDisabled(capture)
+    }
+
+
+    // MARK: - Bulk updates
+
+    func testDisableAll() {
+        let capture = makeCapture()
+
+        capture.disableAll()
+
+        assertAllCategoriesDisabled(capture)
+    }
+
+    func testEnableAll() {
+        let capture = makeCapture()
+        capture.disableAll()
+
+        capture.enableAll()
+
+        assertAllCategoriesEnabled(capture)
+    }
+
+
+    // MARK: - Fixtures
+
+    private func makeCapture() -> any SessionReplayModuleInteractionCapture {
+        SessionReplayPreferences(renderingMode: .native).interactionCapture
+    }
+
+
+    // MARK: - Assertions
+
+    private func assertAllCategoriesEnabled(
+        _ capture: any SessionReplayModuleInteractionCapture,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(capture.isKeyboardEnabled, file: file, line: line)
+        XCTAssertTrue(capture.isTouchEnabled, file: file, line: line)
+        XCTAssertTrue(capture.isGestureEnabled, file: file, line: line)
+        XCTAssertTrue(capture.isFocusEnabled, file: file, line: line)
+        XCTAssertTrue(capture.isRageTapEnabled, file: file, line: line)
+    }
+
+    private func assertAllCategoriesDisabled(
+        _ capture: any SessionReplayModuleInteractionCapture,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(capture.isKeyboardEnabled, file: file, line: line)
+        XCTAssertFalse(capture.isTouchEnabled, file: file, line: line)
+        XCTAssertFalse(capture.isGestureEnabled, file: file, line: line)
+        XCTAssertFalse(capture.isFocusEnabled, file: file, line: line)
+        XCTAssertFalse(capture.isRageTapEnabled, file: file, line: line)
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/Modules/SessionReplay/API-1.0-TypeConversions.swift
@@ -22,6 +22,43 @@ import XCTest
 
 final class SessionReplayAPI10TypeConversionsTests: XCTestCase {
 
+    // MARK: - Interaction capture
+
+    func testInteractionCaptureToModuleConversion() {
+        let proxyPreferences = SessionReplayPreferences()
+        proxyPreferences.interactionCapture.isKeyboardEnabled = false
+        proxyPreferences.interactionCapture.isTouchEnabled = true
+        proxyPreferences.interactionCapture.isGestureEnabled = false
+        proxyPreferences.interactionCapture.isFocusEnabled = true
+        proxyPreferences.interactionCapture.isRageTapEnabled = false
+
+        let modulePreferences = SplunkSessionReplayPreferences(preferences: proxyPreferences)
+
+        XCTAssertFalse(modulePreferences.interactionCapture.isKeyboardEnabled)
+        XCTAssertTrue(modulePreferences.interactionCapture.isTouchEnabled)
+        XCTAssertFalse(modulePreferences.interactionCapture.isGestureEnabled)
+        XCTAssertTrue(modulePreferences.interactionCapture.isFocusEnabled)
+        XCTAssertFalse(modulePreferences.interactionCapture.isRageTapEnabled)
+    }
+
+    func testInteractionCaptureToProxyConversion() {
+        let modulePreferences = SplunkSessionReplayPreferences(renderingMode: .default)
+        modulePreferences.interactionCapture.isKeyboardEnabled = true
+        modulePreferences.interactionCapture.isTouchEnabled = false
+        modulePreferences.interactionCapture.isGestureEnabled = true
+        modulePreferences.interactionCapture.isFocusEnabled = false
+        modulePreferences.interactionCapture.isRageTapEnabled = true
+
+        let proxyPreferences = SessionReplayPreferences(srPreferences: modulePreferences)
+
+        XCTAssertTrue(proxyPreferences.interactionCapture.isKeyboardEnabled)
+        XCTAssertFalse(proxyPreferences.interactionCapture.isTouchEnabled)
+        XCTAssertTrue(proxyPreferences.interactionCapture.isGestureEnabled)
+        XCTAssertFalse(proxyPreferences.interactionCapture.isFocusEnabled)
+        XCTAssertTrue(proxyPreferences.interactionCapture.isRageTapEnabled)
+    }
+
+
     // MARK: - Rendering mode
 
     func testRenderingModesToProxyConversion() {

--- a/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
+++ b/SplunkNavigation/Sources/SplunkNavigation/Navigation.swift
@@ -215,8 +215,7 @@ public final class Navigation: Sendable {
         case .navigationControllerDidShow:
             await processNavigationControllerDidShow(event: event)
 
-
-        default:
+        @unknown default:
             break
         }
     }

--- a/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
+++ b/SplunkOpenTelemetryBackgroundExporter/Sources/SplunkOpenTelemetryBackgroundExporter/OTLPBackgroundHTTPBaseExporter.swift
@@ -259,7 +259,7 @@ public class OTLPBackgroundHTTPBaseExporter {
                 continue
             }
 
-            if let existingTaskDescription = allTaskDescriptions.first(where: { $0.id == requestId }) {
+            if allTaskDescriptions.first(where: { $0.id == requestId }) != nil {
                 if cancelledTaskIds.contains(requestId) {
                     let taskDescription = RequestDescriptor(
                         id: requestId,


### PR DESCRIPTION
## Title: Expose Session Replay interaction capture controls

### Description

This PR exposes the Session Replay interaction capture configuration through the Agent’s Swift and Objective-C proxy APIs.

The new API delegates to the underlying Session Replay module while preserving configuration across preference replacement and providing safe no-op behavior when Session Replay is unavailable.

## Changes

- Expose Session Replay interaction capture controls through the Agent’s Swift and Objective-C APIs.
- Support keyboard, touch, gesture, focus, and rage-tap categories, including bulk enable and disable operations.
- Bridge the configuration to the underlying Session Replay module while preserving values across preference replacement and providing safe no-op behavior when the module is unavailable.
- Add backward-compatible Codable support, documentation, and test coverage.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Run the targeted Swift and Objective-C Session Replay API tests using the local Session Replay source dependency.
- Verify that category changes propagate to the underlying module and persist when preferences are replaced.

## Dependencies ‼️

- Depends on the corresponding Session Replay implementation.
- Updated Session Replay binary artifacts must be published and registered in `Package.swift` before this PR can compile using the default binary dependency.