### PR TITLE
Wire new Session Replay modules into the binary target registry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -544,16 +544,76 @@ func generateBinaryWrapperTargets() -> [Target] {
             dependencies: ["CiscoRuntimeCache", resolveDependency("logger")],
             path: "TargetWrappers/CiscoRuntimeCacheWrapper/Sources"
         ),
+        // TBD: transitive dependency wrappers for the SR modules added in
+        // smartlook-ios-sdk-private on develop. Pending checksum/URL bump
+        // to the next Session Replay staticlib release.
+        .target(
+            name: "CiscoVideoEncoderWrapper",
+            dependencies: [
+                "CiscoVideoEncoder",
+                resolveDependency("common"),
+                resolveDependency("diskStorage"),
+                resolveDependency("logger")
+            ],
+            path: "TargetWrappers/CiscoVideoEncoderWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoScreenshotWrapper",
+            dependencies: [
+                "CiscoScreenshot",
+                resolveDependency("common"),
+                resolveDependency("logger")
+            ],
+            path: "TargetWrappers/CiscoScreenshotWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoWireframeWrapper",
+            dependencies: [
+                "CiscoWireframe",
+                resolveDependency("common"),
+                resolveDependency("logger"),
+                resolveDependency("runtimeCache"),
+                resolveDependency("screenshot")
+            ],
+            path: "TargetWrappers/CiscoWireframeWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoDataExporterWrapper",
+            dependencies: [
+                "CiscoDataExporter",
+                resolveDependency("common"),
+                resolveDependency("interactions"),
+                resolveDependency("wireframe")
+            ],
+            path: "TargetWrappers/CiscoDataExporterWrapper/Sources"
+        ),
+        .target(
+            name: "CiscoSnapshotManagerWrapper",
+            dependencies: [
+                "CiscoSnapshotManager",
+                resolveDependency("common"),
+                resolveDependency("logger"),
+                resolveDependency("screenshot"),
+                resolveDependency("wireframe")
+            ],
+            path: "TargetWrappers/CiscoSnapshotManagerWrapper/Sources"
+        ),
         .target(
             name: "CiscoSessionReplayWrapper",
             dependencies: [
                 "CiscoSessionReplay",
+                resolveDependency("common"),
                 resolveDependency("instanceManager"),
                 resolveDependency("diskStorage"),
                 resolveDependency("runtimeCache"),
                 resolveDependency("interactions"),
                 resolveDependency("logger"),
-                resolveDependency("swizzling")
+                resolveDependency("swizzling"),
+                resolveDependency("videoEncoder"),
+                resolveDependency("screenshot"),
+                resolveDependency("wireframe"),
+                resolveDependency("dataExporter"),
+                resolveDependency("snapshotManager")
             ],
             path: "TargetWrappers/CiscoSessionReplayWrapper/Sources"
         )
@@ -707,6 +767,43 @@ struct SessionReplayBinaryRegistry {
             checksum: "4c31e2c817364363f167d28bfe0cc2b94f8adc7e03e9afa9d8cb7e0009392520",
             productName: "CiscoRuntimeCache",
             wrapperName: "CiscoRuntimeCacheWrapper"
+        ),
+        // TBD: URL/checksum will be filled in once the next Session Replay
+        // release publishes staticlib artifacts for the following modules.
+        "videoEncoder": BinaryTargetInfo(
+            name: "CiscoVideoEncoder",
+            url: "https://sdk.smartlook.com/cisco-session-replay/ios/1.1.2/staticlib/cisco-video-encoder-1.1.2.265.zip",
+            checksum: "XXX",
+            productName: "CiscoVideoEncoder",
+            wrapperName: "CiscoVideoEncoderWrapper"
+        ),
+        "screenshot": BinaryTargetInfo(
+            name: "CiscoScreenshot",
+            url: "https://sdk.smartlook.com/cisco-session-replay/ios/1.1.2/staticlib/cisco-screenshot-1.1.2.265.zip",
+            checksum: "XXX",
+            productName: "CiscoScreenshot",
+            wrapperName: "CiscoScreenshotWrapper"
+        ),
+        "wireframe": BinaryTargetInfo(
+            name: "CiscoWireframe",
+            url: "https://sdk.smartlook.com/cisco-session-replay/ios/1.1.2/staticlib/cisco-wireframe-1.1.2.265.zip",
+            checksum: "XXX",
+            productName: "CiscoWireframe",
+            wrapperName: "CiscoWireframeWrapper"
+        ),
+        "dataExporter": BinaryTargetInfo(
+            name: "CiscoDataExporter",
+            url: "https://sdk.smartlook.com/cisco-session-replay/ios/1.1.2/staticlib/cisco-data-exporter-1.1.2.265.zip",
+            checksum: "XXX",
+            productName: "CiscoDataExporter",
+            wrapperName: "CiscoDataExporterWrapper"
+        ),
+        "snapshotManager": BinaryTargetInfo(
+            name: "CiscoSnapshotManager",
+            url: "https://sdk.smartlook.com/cisco-session-replay/ios/1.1.2/staticlib/cisco-snapshot-manager-1.1.2.265.zip",
+            checksum: "XXX",
+            productName: "CiscoSnapshotManager",
+            wrapperName: "CiscoSnapshotManagerWrapper"
         )
     ]
 }

--- a/TargetWrappers/CiscoDataExporterWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoDataExporterWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoScreenshotWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoScreenshotWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoSnapshotManagerWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoSnapshotManagerWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoVideoEncoderWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoVideoEncoderWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation

--- a/TargetWrappers/CiscoWireframeWrapper/Sources/Empty.swift
+++ b/TargetWrappers/CiscoWireframeWrapper/Sources/Empty.swift
@@ -1,0 +1,20 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// MARK: Empty stub file. Serves as a compilation unit for the binary wrapper targets.
+
+import Foundation


### PR DESCRIPTION
## Summary

`smartlook-ios-sdk-private` on `develop` extends `CiscoSessionReplay`'s dependency graph with five additional modules:

- `CiscoVideoEncoder`
- `CiscoScreenshot`
- `CiscoWireframe`
- `CiscoDataExporter`
- `CiscoSnapshotManager`

The agent's binary target registry (`Package.swift`) currently pins Session Replay `1.1.2.265` and only knows about the original nine modules. As soon as the next SR release bumps and starts requiring these transitive dependencies, SPM resolve would fail because the binary targets / wrappers do not exist.

This PR unblocks that upgrade path by:

- Adding five entries to `SessionReplayBinaryRegistry.targets` (`videoEncoder`, `screenshot`, `wireframe`, `dataExporter`, `snapshotManager`).
- Adding five matching wrappers under `TargetWrappers/*Wrapper/Sources/Empty.swift`, wired with the transitive dependencies observed in `smartlook-ios-sdk-private` (`Package.swift` on `develop`):
  - `CiscoVideoEncoder` → common, diskStorage, logger
  - `CiscoScreenshot` → common, logger
  - `CiscoWireframe` → common, logger, runtimeCache, screenshot
  - `CiscoDataExporter` → common, interactions, wireframe
  - `CiscoSnapshotManager` → common, logger, screenshot, wireframe
- Extending `CiscoSessionReplayWrapper.dependencies` to include all five new wrappers (plus an explicit `common` for completeness).

`swift package dump-package` succeeds with the new graph.

## TBD before merge

URLs and checksums are placeholders. Each new registry entry uses:

- URL pointing at `1.1.2/staticlib/cisco-<module>-1.1.2.265.zip` (mirroring the existing pattern, but the artifact does not exist yet at these paths).
- `checksum: "XXX"` with a `TBD` comment above the block.

Before merging this PR the following must happen:

1. `smartlook-ios-sdk-private` release pipeline publishes staticlib zips for the five new modules (see follow-up in [smartlook/smartlook-ios-sdk-private#585](https://github.com/smartlook/smartlook-ios-sdk-private/pull/585) — static Mach-O variant is currently not built by the default release invocation).
2. Update the URLs to the actual `<version>/staticlib/...` paths.
3. Update `checksum: "XXX"` to the SHA-256 of each published zip.
4. Remove the `TBD` marker comments.

## Test plan

- [ ] `swift package dump-package` passes (verified locally on this branch).
- [ ] Once the SR release publishes the missing artifacts, `swift package resolve` succeeds against the real URLs/checksums.
- [ ] Downstream: SplunkAgent target still links successfully against `CiscoSessionReplay` with the extended graph.

## Related

- Jira: DEMRUM-6120 (Update iOS SDK release pipelines for new Session Replay modules)
- smartlook: https://github.com/smartlook/smartlook-ios-sdk-private/pull/585