### PR TITLE
DEMRUM-6382: Update Server Timing Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed Server-Timing `traceparent` parsing to support bitmask trace flags, including the W3C random trace ID flag.
+
 ## [2.4.1] - 2026-08-13
 
 ### Changed

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+HTTP.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+HTTP.swift
@@ -77,7 +77,8 @@ func getIPAddressFromResponse(_ response: HTTPURLResponse) -> String? {
 ///   - valStr: The server-timing header value string.
 func addLinkToSpan(span: Span, valStr: String) {
 
-    let serverTimingPattern = #"traceparent;desc=['"]00-([0-9a-f]{32})-([0-9a-f]{16})-01['"]"#
+    // Trace flags are a bitmask. Linking only needs the identifiers, so accept the complete flag byte.
+    let serverTimingPattern = #"traceparent;desc=['"]00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}['"]"#
     guard let regex = try? NSRegularExpression(pattern: serverTimingPattern) else {
         NetworkInstrumentationManager.shared.logger.log(level: .fault) {
             "Regex failed to compile"

--- a/SplunkNetwork/Tests/SplunkNetworkTests/SpanLinkingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/SpanLinkingTests.swift
@@ -100,14 +100,26 @@ final class SpanLinkingTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testAddLinkToSpan_ValidTraceParent() {
+    func testAddLinkToSpan_ValidTraceParent_AllLevelTwoFlags() {
+        for traceFlags in ["00", "01", "02", "03"] {
+            let mockSpan = MockSpan()
+            let valStr = "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-\(traceFlags)'"
+
+            addLinkToSpan(span: mockSpan, valStr: valStr)
+
+            XCTAssertEqual(mockSpan.attributes[NetworkSpanAttributeKeys.linkTraceId]?.description, "0af7651916cd43dd8448eb211c80319c")
+            XCTAssertEqual(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId]?.description, "b7ad6b7169203331")
+        }
+    }
+
+    func testAddLinkToSpan_InvalidTraceFlags() {
         let mockSpan = MockSpan()
-        let valStr = "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'"
+        let valStr = "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0g'"
 
         addLinkToSpan(span: mockSpan, valStr: valStr)
 
-        XCTAssertEqual(mockSpan.attributes[NetworkSpanAttributeKeys.linkTraceId]?.description, "0af7651916cd43dd8448eb211c80319c")
-        XCTAssertEqual(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId]?.description, "b7ad6b7169203331")
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkTraceId])
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId])
     }
 
     func testAddLinkToSpan_ValidTraceParent_DoubleQuotes() {


### PR DESCRIPTION
## Title: Update Server Timing Parser

### Description
- The iOS RUM SDK’s Server-Timing parser requires traceparent values to end in 01. Newer Java and Python agents emit valid values ending in 03, causing the header to be rejected and breaking RUM-to-backend trace correlation.
- Update the parser to accept any valid two-digit hexadecimal flags value, since iOS only extracts the trace and span IDs and does not interpret the flags

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

