### PR TITLE
DEMRUM-6448: Repair EndOfSpan race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Fixed Server-Timing `traceparent` parsing to support bitmask trace flags, including the W3C random trace ID flag.
+* Fixed URLSession network span finalization races that could drop Server-Timing links and response attributes, duplicate attribute processing, or end spans on nonterminal task states.
 
 ## [2.4.1] - 2026-08-13
 

--- a/SplunkCommon/Sources/SplunkCommon/Span/Span+Extensions.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Span/Span+Extensions.swift
@@ -22,9 +22,11 @@ import OpenTelemetryApi
 @_spi(SplunkInternal)
 extension Span {
 
-    /// Clears the existing value for a key and sets a new value atomically.
+    /// Clears the existing value for a key and then sets a new value.
     ///
-    /// This is useful for ensuring clean attribute updates without leftover values.
+    /// This is useful for ensuring clean attribute updates without leftover values. The two
+    /// underlying `Span.setAttribute` calls are not an atomic transaction; callers must serialize
+    /// this operation with span finalization when they can run concurrently.
     ///
     /// - Parameters:
     ///   - key: The attribute key to clear and set
@@ -37,7 +39,7 @@ extension Span {
         setAttribute(key: key, value: value)
     }
 
-    /// Clears the existing value for a key and sets a new value atomically.
+    /// Clears the existing value for a key and then sets a new value.
     ///
     /// This is a convenience method that accepts Any and converts it to AttributeValue.
     ///
@@ -50,7 +52,7 @@ extension Span {
 
     // MARK: - SemanticConventions Convenience Methods
 
-    /// Clears the existing value for a semantic attribute key and sets a new value atomically.
+    /// Clears the existing value for a semantic attribute key and then sets a new value.
     ///
     /// This is useful for ensuring clean attribute updates without leftover values.
     /// Works with any `SemanticConventions` nested enum (e.g., `SemanticConventions.Http`, `SemanticConventions.Url`).
@@ -62,7 +64,7 @@ extension Span {
         clearAndSetAttribute(key: key.rawValue, value: value)
     }
 
-    /// Clears the existing value for a semantic attribute key and sets a new value atomically.
+    /// Clears the existing value for a semantic attribute key and then sets a new value.
     ///
     /// This is a convenience method that accepts Any and converts it to AttributeValue.
     /// Works with any `SemanticConventions` nested enum (e.g., `SemanticConventions.Http`, `SemanticConventions.Url`).

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+DownloadTaskSwizzlers.swift
@@ -110,8 +110,11 @@ func swizzleDownloadTaskWithRequestAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, request, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapDownloadCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
                 return castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
             }
         )
@@ -158,8 +161,11 @@ func swizzleDownloadTaskWithURLAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, url, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapDownloadCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapDownloadCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
                 let castedRequestIMP = unsafeBitCast(
                     originalRequestIMP,
                     to: (@convention(c) (URLSession, Selector, URLRequest, DownloadHandler?) -> URLSessionDownloadTask).self

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
@@ -87,8 +87,13 @@ func startHttpSpan(request: URLRequest?) -> Span? {
 /// - Parameters:
 ///   - span: The span to end.
 ///   - task: The completed URL session task.
-func endHttpSpan(span: Span, task: URLSessionTask) {
-    let httpResponse: HTTPURLResponse? = task.response as? HTTPURLResponse
+func endHttpSpan(
+    span: Span,
+    task: URLSessionTask,
+    fallbackResponse: URLResponse? = nil,
+    fallbackError: Error? = nil
+) {
+    let httpResponse = task.response as? HTTPURLResponse ?? fallbackResponse as? HTTPURLResponse
     if let httpResponse {
         span.clearAndSetAttribute(key: SemanticConventions.Http.responseStatusCode, value: httpResponse.statusCode)
         for (key, val) in httpResponse.allHeaderFields {
@@ -117,7 +122,7 @@ func endHttpSpan(span: Span, task: URLSessionTask) {
         addCapturedResponseHeaders(from: httpResponse, to: span)
     }
 
-    if let error = task.error {
+    if let error = task.error ?? fallbackError {
         span.clearAndSetAttribute(key: NetworkSpanAttributeKeys.error, value: true)
         span.clearAndSetAttribute(key: SemanticConventions.Error.message, value: error.localizedDescription)
         span.clearAndSetAttribute(key: SemanticConventions.Error.type, value: String(describing: type(of: error)))

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Span.swift
@@ -87,6 +87,8 @@ func startHttpSpan(request: URLRequest?) -> Span? {
 /// - Parameters:
 ///   - span: The span to end.
 ///   - task: The completed URL session task.
+///   - fallbackResponse: A response supplied by the completion handler when the task has no response.
+///   - fallbackError: An error supplied by the completion handler when the task has no error.
 func endHttpSpan(
     span: Span,
     task: URLSessionTask,

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Swizzling.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+Swizzling.swift
@@ -30,20 +30,21 @@ extension URLSessionTask {
         if !isSupportedTask(task: self) {
             return
         }
-        if state == Self.State.running {
+        // Only a completed task has stable response, metrics, and error information. Suspended and
+        // canceling are intermediate states and must not finalize the span.
+        guard shouldFinalizeNetworkSpan(for: state) else {
             return
         }
+
         if currentRequest?.url == nil {
             return
         }
 
-        // Check for span from task creation first, then from resume
-        let span = getCreationSpan(for: self) ?? objc_getAssociatedObject(self, &associatedKeySpanResume) as? Span
-        guard let span else {
+        guard let finalizationCoordinator = getSpanFinalizationCoordinator(for: self) else {
             return
         }
 
-        endHttpSpan(span: span, task: self)
+        finalizationCoordinator.finalize(task: self)
     }
 
     @objc
@@ -79,11 +80,19 @@ extension URLSessionTask {
 
         // Fallback: create span at resume time (no header injection possible).
         // Covers tasks created before agent initialization or via un-swizzled APIs.
-        startHttpSpan(request: currentRequest)
-            .map { span in
-                objc_setAssociatedObject(self, &associatedKeySpanResume, span, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
-            }
+        guard let span = startHttpSpan(request: currentRequest) else {
+            return
+        }
+
+        let finalizationCoordinator = NetworkSpanFinalizationCoordinator(span: span)
+        objc_setAssociatedObject(self, &associatedKeySpanResume, span, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+        setSpanFinalizationCoordinator(finalizationCoordinator, for: self)
     }
+}
+
+/// Returns whether a URL session task state has stable terminal response information.
+func shouldFinalizeNetworkSpan(for state: URLSessionTask.State) -> Bool {
+    state == .completed
 }
 
 /// Swizzles two methods on a given class.

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreation.swift
@@ -24,6 +24,7 @@ import OpenTelemetryApi
 var associatedKeySpan: UInt8 = 0
 var associatedKeyInstrumented: UInt8 = 1
 var associatedKeySkipped: UInt8 = 2
+var associatedKeyFinalizationCoordinator: UInt8 = 3
 
 // MARK: - Original IMP Storage
 
@@ -224,6 +225,24 @@ func createTaskWithInstrumentation<T: URLSessionTask>(
     createOriginalTask: () -> T,
     createInstrumentedTask: (_ instrumentedRequest: URLRequest, _ span: Span) -> T
 ) -> T {
+    createTaskWithInstrumentation(
+        request: request,
+        createOriginalTask: createOriginalTask,
+        createInstrumentedTask: { instrumentedRequest, span, _ in
+            createInstrumentedTask(instrumentedRequest, span)
+        }
+    )
+}
+
+func createTaskWithInstrumentation<T: URLSessionTask>(
+    request: URLRequest,
+    createOriginalTask: () -> T,
+    createInstrumentedTask: (
+        _ instrumentedRequest: URLRequest,
+        _ span: Span,
+        _ finalizationCoordinator: NetworkSpanFinalizationCoordinator
+    ) -> T
+) -> T {
     switch instrumentationDecision(for: request) {
     case .skipInstrumentation:
         return markSkippedForInstrumentation(createOriginalTask())
@@ -236,10 +255,12 @@ func createTaskWithInstrumentation<T: URLSessionTask>(
             return markSkippedForInstrumentation(createOriginalTask())
         }
 
+        let finalizationCoordinator = NetworkSpanFinalizationCoordinator(span: span)
         let instrumentedRequest = injectTraceContextIfEnabled(into: request, span: span)
         return markInstrumentedAtCreation(
-            createInstrumentedTask(instrumentedRequest, span),
-            span: span
+            createInstrumentedTask(instrumentedRequest, span, finalizationCoordinator),
+            span: span,
+            finalizationCoordinator: finalizationCoordinator
         )
     }
 }
@@ -273,30 +294,22 @@ func injectTraceContextIfEnabled(into request: URLRequest, span: Span) -> URLReq
     return TraceContextInjector.injectTraceContext(into: request, spanContext: span.context)
 }
 
-/// Wraps an optional completion handler to end the span when the request completes.
+/// Wraps an optional completion handler to finalize the span when the request completes.
 ///
-/// For tasks instrumented at creation time, two span-ending paths exist:
-/// 1. `splunkSwizzledSetState` (in `Instrumentation+Swizzling.swift`) calls `endHttpSpan`,
-///    which sets rich attributes (status code, server-timing link, response body size,
-///    peer address, protocol version, error details, request body size).
-/// 2. This wrapped completion handler calls `endHttpSpanFromCompletion`, which sets
-///    status code, configured captured response headers, and error attributes.
-///
-/// On Apple platforms, `setState:` fires before the completion handler, so `endHttpSpan`
-/// runs first and the span receives the full attribute set. The subsequent `end()` call
-/// from the completion handler is a no-op (OpenTelemetry ignores writes to ended spans).
+/// The completion handler and task-state callback share one coordinator. Whichever observes
+/// completion first performs task-aware enrichment and ends the span exactly once.
 func wrapCompletionHandler(
     _ completion: ((Data?, URLResponse?, Error?) -> Void)?,
-    span: Span
+    finalizationCoordinator: NetworkSpanFinalizationCoordinator
 ) -> (Data?, URLResponse?, Error?) -> Void {
     guard let originalCompletion = completion else {
         return { _, response, error in
-            endHttpSpanFromCompletion(span: span, response: response, error: error)
+            finalizationCoordinator.finalize(response: response, error: error)
         }
     }
 
     return { data, response, error in
-        endHttpSpanFromCompletion(span: span, response: response, error: error)
+        finalizationCoordinator.finalize(response: response, error: error)
         originalCompletion(data, response, error)
     }
 }
@@ -308,36 +321,18 @@ func wrapCompletionHandler(
 /// to ``wrapCompletionHandler``.
 func wrapDownloadCompletionHandler(
     _ completion: ((URL?, URLResponse?, Error?) -> Void)?,
-    span: Span
+    finalizationCoordinator: NetworkSpanFinalizationCoordinator
 ) -> (URL?, URLResponse?, Error?) -> Void {
     guard let originalCompletion = completion else {
         return { _, response, error in
-            endHttpSpanFromCompletion(span: span, response: response, error: error)
+            finalizationCoordinator.finalize(response: response, error: error)
         }
     }
 
     return { url, response, error in
-        endHttpSpanFromCompletion(span: span, response: response, error: error)
+        finalizationCoordinator.finalize(response: response, error: error)
         originalCompletion(url, response, error)
     }
-}
-
-/// Ends a span from a completion handler with fallback attributes.
-///
-/// This is a safety net for tasks whose span was not already ended by `splunkSwizzledSetState`.
-/// See ``wrapCompletionHandler`` for details on the dual-path span lifecycle.
-func endHttpSpanFromCompletion(span: Span, response: URLResponse?, error: Error?) {
-    if let httpResponse = response as? HTTPURLResponse {
-        span.clearAndSetAttribute(key: SemanticConventions.Http.responseStatusCode, value: httpResponse.statusCode)
-        addCapturedResponseHeaders(from: httpResponse, to: span)
-    }
-
-    if let error {
-        span.clearAndSetAttribute(key: NetworkSpanAttributeKeys.error, value: true)
-        span.clearAndSetAttribute(key: SemanticConventions.Error.message, value: error.localizedDescription)
-    }
-
-    span.end()
 }
 
 // MARK: - Check if Task was Instrumented at Creation
@@ -360,8 +355,15 @@ func markSkippedForInstrumentation<T: URLSessionTask>(_ task: T) -> T {
     return task
 }
 
-func markInstrumentedAtCreation<T: URLSessionTask>(_ task: T, span: Span) -> T {
+func markInstrumentedAtCreation<T: URLSessionTask>(
+    _ task: T,
+    span: Span,
+    finalizationCoordinator: NetworkSpanFinalizationCoordinator? = nil
+) -> T {
+    let coordinator = finalizationCoordinator ?? NetworkSpanFinalizationCoordinator(span: span)
+    coordinator.attach(to: task)
     objc_setAssociatedObject(task, &associatedKeySpan, span, .OBJC_ASSOCIATION_RETAIN)
+    objc_setAssociatedObject(task, &associatedKeyFinalizationCoordinator, coordinator, .OBJC_ASSOCIATION_RETAIN)
     objc_setAssociatedObject(task, &associatedKeyInstrumented, true, .OBJC_ASSOCIATION_RETAIN)
     return task
 }
@@ -369,4 +371,18 @@ func markInstrumentedAtCreation<T: URLSessionTask>(_ task: T, span: Span) -> T {
 /// Gets the span associated with a task during creation.
 func getCreationSpan(for task: URLSessionTask) -> Span? {
     objc_getAssociatedObject(task, &associatedKeySpan) as? Span
+}
+
+/// Gets the exactly-once span finalizer associated with an instrumented task.
+func getSpanFinalizationCoordinator(for task: URLSessionTask) -> NetworkSpanFinalizationCoordinator? {
+    objc_getAssociatedObject(task, &associatedKeyFinalizationCoordinator) as? NetworkSpanFinalizationCoordinator
+}
+
+/// Associates an exactly-once span finalizer with a task instrumented during `resume()`.
+func setSpanFinalizationCoordinator(
+    _ coordinator: NetworkSpanFinalizationCoordinator,
+    for task: URLSessionTask
+) {
+    coordinator.attach(to: task)
+    objc_setAssociatedObject(task, &associatedKeyFinalizationCoordinator, coordinator, .OBJC_ASSOCIATION_RETAIN)
 }

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+TaskCreationSwizzlers.swift
@@ -107,8 +107,11 @@ func swizzleDataTaskWithRequestAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, request, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
                 return castedIMP(session, selector, instrumentedRequest, wrappedCompletion)
             }
         )
@@ -155,8 +158,11 @@ func swizzleDataTaskWithURLAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, url, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
 
                 // Call the ORIGINAL (un-swizzled) request-based method directly.
                 // This bypasses the request-based swizzle, preventing double instrumentation
@@ -271,8 +277,11 @@ func swizzleUploadTaskWithRequestFromDataAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, request, data, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
                 return castedIMP(session, selector, instrumentedRequest, data, wrappedCompletion)
             }
         )
@@ -309,8 +318,11 @@ func swizzleUploadTaskWithRequestFromFileAndCompletion() {
             createOriginalTask: {
                 castedIMP(session, selector, request, fileURL, completion)
             },
-            createInstrumentedTask: { instrumentedRequest, span in
-                let wrappedCompletion = wrapCompletionHandler(completion, span: span)
+            createInstrumentedTask: { instrumentedRequest, _, finalizationCoordinator in
+                let wrappedCompletion = wrapCompletionHandler(
+                    completion,
+                    finalizationCoordinator: finalizationCoordinator
+                )
                 return castedIMP(session, selector, instrumentedRequest, fileURL, wrappedCompletion)
             }
         )

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/NetworkSpanFinalizationCoordinator.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/NetworkSpanFinalizationCoordinator.swift
@@ -1,0 +1,127 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+
+/// Coordinates the competing URL session completion paths for one network span.
+///
+/// Both the task-state swizzle and a wrapped completion handler can observe completion. This
+/// coordinator ensures that exactly one of them enriches and ends the span. The task is retained
+/// weakly because it retains this coordinator through an associated object.
+///
+/// Safety: all mutable state is protected by `lock`. Finalization is claimed under the lock, but
+/// attribute writes and `Span.end()` run after unlocking so callbacks into the telemetry pipeline
+/// cannot deadlock or re-enter the coordinator while it is locked.
+final class NetworkSpanFinalizationCoordinator: @unchecked Sendable {
+
+    // MARK: - Private properties
+
+    private let lock = NSLock()
+    private weak var task: URLSessionTask?
+    private var pendingCompletion: (response: URLResponse?, error: Error?)?
+    private var isFinalized = false
+
+
+    // MARK: - Properties
+
+    let span: Span
+
+
+    // MARK: - Initialization
+
+    init(span: Span) {
+        self.span = span
+    }
+
+
+    // MARK: - Coordination
+
+    /// Attaches the task after URLSession has returned it from its creation method.
+    func attach(to task: URLSessionTask) {
+        let pending: (response: URLResponse?, error: Error?)?
+
+        lock.lock()
+        self.task = task
+        if !isFinalized, let storedCompletion = pendingCompletion {
+            isFinalized = true
+            pendingCompletion = nil
+            pending = storedCompletion
+        }
+        else {
+            pending = nil
+        }
+        lock.unlock()
+
+        if let pending {
+            endHttpSpan(
+                span: span,
+                task: task,
+                fallbackResponse: pending.response,
+                fallbackError: pending.error
+            )
+        }
+    }
+
+    /// Finalizes from the task-state callback, using the completed task as the canonical data source.
+    func finalize(task: URLSessionTask) {
+        lock.lock()
+        guard !isFinalized else {
+            lock.unlock()
+            return
+        }
+
+        isFinalized = true
+        pendingCompletion = nil
+        lock.unlock()
+
+        endHttpSpan(span: span, task: task)
+    }
+
+    /// Finalizes from a completion handler while retaining task-derived enrichment when available.
+    func finalize(response: URLResponse?, error: Error?) {
+        let attachedTask: URLSessionTask
+
+        lock.lock()
+        guard !isFinalized else {
+            lock.unlock()
+            return
+        }
+
+        guard let task else {
+            // A URLSession task normally cannot complete before it has been returned and attached.
+            // Store the completion defensively so attachment can perform canonical finalization.
+            if pendingCompletion == nil {
+                pendingCompletion = (response, error)
+            }
+            lock.unlock()
+            return
+        }
+
+        isFinalized = true
+        pendingCompletion = nil
+        attachedTask = task
+        lock.unlock()
+
+        endHttpSpan(
+            span: span,
+            task: attachedTask,
+            fallbackResponse: response,
+            fallbackError: error
+        )
+    }
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationCoordinatorTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationCoordinatorTests.swift
@@ -1,0 +1,238 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import XCTest
+
+@testable import SplunkNetwork
+
+final class NetworkSpanFinalizationCoordinatorTests: XCTestCase {
+
+    // MARK: - Tests
+
+    func testConcurrentCallbacksFinalizeExactlyOnceWithRichTaskAttributes() {
+        let task = completedTask()
+        let span = ThreadSafeMockSpan()
+        let coordinator = NetworkSpanFinalizationCoordinator(span: span)
+        coordinator.attach(to: task)
+
+        let group = DispatchGroup()
+        for index in 0 ..< 100 {
+            group.enter()
+            DispatchQueue.global().async {
+                if index.isMultiple(of: 2) {
+                    coordinator.finalize(task: task)
+                }
+                else {
+                    coordinator.finalize(response: task.response, error: task.error)
+                }
+                group.leave()
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 5), .success)
+        XCTAssertEqual(span.endCount, 1)
+
+        let attributes = span.attributes
+        XCTAssertEqual(attributes[SemanticConventions.Http.responseStatusCode.rawValue], .int(207))
+        XCTAssertEqual(attributes[SemanticConventions.Http.responseBodySize.rawValue], .int(42))
+        XCTAssertEqual(attributes[SemanticConventions.Network.peerAddress.rawValue], .string("192.0.2.10"))
+        XCTAssertEqual(attributes[SemanticConventions.Network.protocolVersion.rawValue], .string("2"))
+        XCTAssertEqual(
+            attributes[NetworkSpanAttributeKeys.linkTraceId],
+            .string("0af7651916cd43dd8448eb211c80319c")
+        )
+        XCTAssertEqual(
+            attributes[NetworkSpanAttributeKeys.linkSpanId],
+            .string("b7ad6b7169203331")
+        )
+    }
+
+    func testCompletionBeforeTaskAttachmentFinalizesAfterAttachment() {
+        let task = completedTask()
+        let span = ThreadSafeMockSpan()
+        let coordinator = NetworkSpanFinalizationCoordinator(span: span)
+
+        coordinator.finalize(response: task.response, error: task.error)
+        XCTAssertEqual(span.endCount, 0)
+
+        coordinator.attach(to: task)
+        XCTAssertEqual(span.endCount, 1)
+        XCTAssertEqual(span.attributes[SemanticConventions.Http.responseStatusCode.rawValue], .int(207))
+
+        coordinator.finalize(task: task)
+        XCTAssertEqual(span.endCount, 1)
+    }
+
+    func testOnlyCompletedStateTriggersFinalization() {
+        XCTAssertFalse(shouldFinalizeNetworkSpan(for: .running))
+        XCTAssertFalse(shouldFinalizeNetworkSpan(for: .suspended))
+        XCTAssertFalse(shouldFinalizeNetworkSpan(for: .canceling))
+        XCTAssertTrue(shouldFinalizeNetworkSpan(for: .completed))
+    }
+
+
+    // MARK: - Helpers
+
+    private func completedTask() -> URLSessionDataTask {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FinalizationURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let completed = expectation(description: "Task completed")
+        guard let url = URL(string: "https://finalization.test/resource") else {
+            preconditionFailure("Static finalization test URL is invalid")
+        }
+
+        let task = session.dataTask(with: url) { _, _, _ in
+            completed.fulfill()
+        }
+
+        task.resume()
+        wait(for: [completed], timeout: 5)
+
+        return task
+    }
+}
+
+// MARK: - Test URL protocol
+
+private final class FinalizationURLProtocol: URLProtocol {
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url,
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 207,
+                httpVersion: "HTTP/2",
+                headerFields: [
+                    "Content-Length": "42",
+                    "Server": "h2",
+                    "Server-Timing": "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03'",
+                    "X-Forwarded-For": "192.0.2.10"
+                ]
+            )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(repeating: 0, count: 42))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Thread-safe span
+
+private final class ThreadSafeMockSpan: Span {
+    private let lock = NSLock()
+    private var storedAttributes: [String: AttributeValue] = [:]
+    private var storedEndCount = 0
+    private var ended = false
+
+    var attributes: [String: AttributeValue] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedAttributes
+    }
+
+    var endCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedEndCount
+    }
+
+    let context = SpanContext.create(
+        traceId: .random(),
+        spanId: .random(),
+        traceFlags: TraceFlags(),
+        traceState: TraceState()
+    )
+
+    var isRecording: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !ended
+    }
+
+    var status: Status = .unset
+    var name = "NetworkSpanFinalizationCoordinatorTests"
+    var kind: SpanKind {
+        .client
+    }
+
+    func setAttribute(key: String, value: AttributeValue?) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !ended else {
+            return
+        }
+
+        if let value {
+            storedAttributes[key] = value
+        }
+        else {
+            storedAttributes.removeValue(forKey: key)
+        }
+    }
+
+    func setAttributes(_ attributes: [String: AttributeValue]) {
+        for (key, value) in attributes {
+            setAttribute(key: key, value: value)
+        }
+    }
+
+    func addEvent(name _: String) {}
+    func addEvent(name _: String, timestamp _: Date) {}
+    func addEvent(name _: String, attributes _: [String: AttributeValue]) {}
+    func addEvent(name _: String, attributes _: [String: AttributeValue], timestamp _: Date) {}
+
+    func end() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !ended else {
+            return
+        }
+
+        ended = true
+        storedEndCount += 1
+    }
+
+    func end(time _: Date) {
+        end()
+    }
+
+    func recordException(_: SpanException) {}
+    func recordException(_: SpanException, timestamp _: Date) {}
+    func recordException(_: SpanException, attributes _: [String: AttributeValue]) {}
+    func recordException(_: SpanException, attributes _: [String: AttributeValue], timestamp _: Date) {}
+
+    var description: String {
+        name
+    }
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationCoordinatorTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationCoordinatorTests.swift
@@ -35,15 +35,16 @@ final class NetworkSpanFinalizationCoordinatorTests: XCTestCase {
         let group = DispatchGroup()
         for index in 0 ..< 100 {
             group.enter()
-            DispatchQueue.global().async {
-                if index.isMultiple(of: 2) {
-                    coordinator.finalize(task: task)
+            DispatchQueue.global()
+                .async {
+                    if index.isMultiple(of: 2) {
+                        coordinator.finalize(task: task)
+                    }
+                    else {
+                        coordinator.finalize(response: task.response, error: task.error)
+                    }
+                    group.leave()
                 }
-                else {
-                    coordinator.finalize(response: task.response, error: task.error)
-                }
-                group.leave()
-            }
         }
 
         XCTAssertEqual(group.wait(timeout: .now() + 5), .success)

--- a/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationIntegrationTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/NetworkSpanFinalizationIntegrationTests.swift
@@ -1,0 +1,161 @@
+//
+/*
+Copyright 2026 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import XCTest
+
+@testable import SplunkNetwork
+
+final class NetworkSpanFinalizationIntegrationTests: XCTestCase {
+
+    // MARK: - Test lifecycle
+
+    private static let exporter = FinalizationCollectingSpanExporter()
+    private static var networkModule: NetworkInstrumentation?
+    private static var originalTracerProvider: TracerProvider?
+
+    override static func setUp() {
+        super.setUp()
+
+        originalTracerProvider = OpenTelemetry.instance.tracerProvider
+
+        let processor = SimpleSpanProcessor(spanExporter: exporter)
+        let tracerProvider = TracerProviderBuilder()
+            .add(spanProcessor: processor)
+            .build()
+        OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
+
+        networkModule = NetworkInstrumentation()
+        let configuration = NetworkInstrumentationConfiguration(
+            isEnabled: true,
+            ignoreURLs: nil,
+            injectTraceHeaders: false,
+            capturedResponseHeaders: ["X-Finalization-Test"]
+        )
+        networkModule?.install(with: configuration, remoteConfiguration: nil)
+    }
+
+    override static func tearDown() {
+        networkModule?.uninstall()
+        networkModule = nil
+
+        if let originalTracerProvider {
+            OpenTelemetry.registerTracerProvider(tracerProvider: originalTracerProvider)
+        }
+
+        super.tearDown()
+    }
+
+    override func setUp() {
+        super.setUp()
+        Self.exporter.reset()
+    }
+
+
+    // MARK: - Tests
+
+    func testDataTaskWithCompletionExportsOneFullyEnrichedSpan() throws {
+        let url = URLSessionMockProtocol.url(path: "/finalization")
+        let expectation = expectation(description: "Completion called")
+        let session = URLSession(configuration: URLSessionMockProtocol.configuration())
+
+        let task = session.dataTask(with: url) { _, _, _ in
+            expectation.fulfill()
+        }
+        task.resume()
+
+        wait(for: [expectation], timeout: 10.0)
+        waitForTaskCompletion(task)
+        XCTAssertEqual(task.state, .completed)
+        waitForSpans(count: 1)
+
+        let spans = Self.exporter.spans.filter {
+            $0.attributes[SemanticConventions.Url.full.rawValue] == .string(url.absoluteString)
+        }
+        XCTAssertEqual(spans.count, 1, "The state and completion callbacks must finalize exactly one span")
+
+        let attributes = try XCTUnwrap(spans.first?.attributes)
+        XCTAssertEqual(attributes[SemanticConventions.Http.requestMethod.rawValue], .string("GET"))
+        XCTAssertEqual(attributes[SemanticConventions.Http.responseStatusCode.rawValue], .int(207))
+        XCTAssertEqual(attributes[SemanticConventions.Http.responseBodySize.rawValue], .int(42))
+        XCTAssertEqual(attributes[SemanticConventions.Network.peerAddress.rawValue], .string("192.0.2.10"))
+        XCTAssertEqual(attributes[SemanticConventions.Network.protocolVersion.rawValue], .string("2"))
+        XCTAssertEqual(
+            attributes[NetworkSpanAttributeKeys.linkTraceId],
+            .string("0af7651916cd43dd8448eb211c80319c")
+        )
+        XCTAssertEqual(
+            attributes[NetworkSpanAttributeKeys.linkSpanId],
+            .string("b7ad6b7169203331")
+        )
+        XCTAssertEqual(
+            attributes[NetworkSpanAttributeKeys.responseHeader("x-finalization-test")],
+            .string("preserved")
+        )
+    }
+
+
+    // MARK: - Waiting
+
+    private func waitForSpans(count: Int, timeout: TimeInterval = 5.0) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Self.exporter.spans.count < count, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    private func waitForTaskCompletion(_ task: URLSessionTask, timeout: TimeInterval = 5.0) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while task.state != .completed, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+}
+
+// MARK: - Span exporter
+
+private final class FinalizationCollectingSpanExporter: SpanExporter {
+    private let lock = NSLock()
+    private var collectedSpans: [SpanData] = []
+
+    var spans: [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        return collectedSpans
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        collectedSpans.removeAll()
+    }
+
+    func export(spans: [SpanData], explicitTimeout _: TimeInterval?) -> SpanExporterResultCode {
+        lock.lock()
+        defer { lock.unlock() }
+        collectedSpans.append(contentsOf: spans)
+        return .success
+    }
+
+    func flush(explicitTimeout _: TimeInterval?) -> SpanExporterResultCode {
+        .success
+    }
+
+    func shutdown(explicitTimeout _: TimeInterval?) {}
+}

--- a/SplunkNetwork/Tests/SplunkNetworkTests/URLSessionMockProtocol.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/URLSessionMockProtocol.swift
@@ -40,15 +40,40 @@ final class URLSessionMockProtocol: URLProtocol {
             return
         }
 
-        let data = responseData(for: request)
-        let response = HTTPURLResponse(
-            url: url,
-            statusCode: 200,
-            httpVersion: "HTTP/1.1",
-            headerFields: [
+        let isFinalizationResponse = url.path == "/finalization"
+        let data: Data
+        let statusCode: Int
+        let httpVersion: String
+        let headerFields: [String: String]
+
+        if isFinalizationResponse {
+            data = Data(repeating: 0x41, count: 42)
+            statusCode = 207
+            httpVersion = "HTTP/2"
+            headerFields = [
+                "Content-Length": "\(data.count)",
+                "Content-Type": "application/octet-stream",
+                "Server": "h2",
+                "Server-Timing": "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03'",
+                "X-Finalization-Test": "preserved",
+                "X-Forwarded-For": "192.0.2.10"
+            ]
+        }
+        else {
+            data = responseData(for: request)
+            statusCode = 200
+            httpVersion = "HTTP/1.1"
+            headerFields = [
                 "Content-Type": "application/json",
                 "Content-Length": "\(data.count)"
             ]
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: httpVersion,
+            headerFields: headerFields
         )
 
         if let response {


### PR DESCRIPTION
## Title: Repair end of span race condition

### Description
There is a race condition present with two ways to end the span, resulting in potentially different attributes added.
- Associate one coordinator with each instrumented task.
- Have both the state swizzle and completion wrapper call that coordinator.
- Give the coordinator access to the actual task, so even the completion path can use the richer task-derived finalization data.
- Under an NSLock, transition from pending to finalizing exactly once.
- Capture the task/response/error snapshot under coordination.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Confirm that all required attributes are sent with each span.
