### PR TITLE
DEMRUM-6128: Fix background launch detection to use process start timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Fixed Server-Timing `traceparent` parsing to support bitmask trace flags, including the W3C random trace ID flag.
+* Fixed background launch detection using an inconsistent reference timestamp, which could cause multi-hour cold-start spans when a process was prewarmed or background-launched before the SDK registered its lifecycle listeners.
 
 ## [2.4.1] - 2026-08-13
 

--- a/SplunkAppStart/Sources/SplunkAppStart/AppStart+Notifications.swift
+++ b/SplunkAppStart/Sources/SplunkAppStart/AppStart+Notifications.swift
@@ -54,11 +54,12 @@ extension AppStart {
                 let currentState = UIApplication.shared.applicationState
                 let isCurrentlyInBackground = currentState == .background
 
-                // If more than `backgroundLaunchThreshold` seconds have passed since didFinishLaunching,
+                // If more than `backgroundLaunchThreshold` seconds have passed since process creation,
                 // the app was likely running in background before coming to foreground
                 var significantDelayFromLaunch = false
-                if let launchTime = self.didFinishLaunchingTimestamp {
-                    significantDelayFromLaunch = Date().timeIntervalSince(launchTime) > self.backgroundLaunchThreshold
+                let referenceTime = self.processStartTimestamp ?? self.didFinishLaunchingTimestamp
+                if let referenceTime {
+                    significantDelayFromLaunch = Date().timeIntervalSince(referenceTime) > self.backgroundLaunchThreshold
                 }
 
                 if isCurrentlyInBackground || significantDelayFromLaunch {

--- a/SplunkAppStart/Tests/SplunkAppStartTests/AppStart tests/AppStartTests.swift
+++ b/SplunkAppStart/Tests/SplunkAppStartTests/AppStart tests/AppStartTests.swift
@@ -164,7 +164,7 @@ final class AppStartTests: XCTestCase {
         appStart.install(with: nil, remoteConfiguration: nil)
 
         // Process started long ago; didFinishLaunching was never observed (nil)
-        appStart.processStartTimestamp = Date().addingTimeInterval(-3600.0)
+        appStart.processStartTimestamp = Date().addingTimeInterval(-3_600.0)
 
         // Only willEnterForeground and didBecomeActive arrive (didFinishLaunching was missed)
         simulateWarmStartNotifications()
@@ -183,13 +183,16 @@ final class AppStartTests: XCTestCase {
         appStart.install(with: nil, remoteConfiguration: nil)
 
         // Process started hours ago
-        appStart.processStartTimestamp = Date().addingTimeInterval(-3600.0)
+        appStart.processStartTimestamp = Date().addingTimeInterval(-3_600.0)
         // didFinishLaunching occurred only 1 second ago (would not have triggered the old check)
         appStart.didFinishLaunchingTimestamp = Date().addingTimeInterval(-1.0)
 
         simulateWarmStartNotifications()
 
-        XCTAssertTrue(appStart.backgroundLaunchDetected == true, "backgroundLaunchDetected should be true based on processStartTimestamp even when didFinishLaunching is recent")
+        XCTAssertTrue(
+            appStart.backgroundLaunchDetected == true,
+            "backgroundLaunchDetected should be true based on processStartTimestamp even when didFinishLaunching is recent"
+        )
         try checkDeterminedType(.warm, in: destination)
     }
 

--- a/SplunkAppStart/Tests/SplunkAppStartTests/AppStart tests/AppStartTests.swift
+++ b/SplunkAppStart/Tests/SplunkAppStartTests/AppStart tests/AppStartTests.swift
@@ -133,6 +133,8 @@ final class AppStartTests: XCTestCase {
     /// The backgroundLaunchDetected flag should be automatically set to true
     /// because more than 10 seconds have passed since didFinishLaunching,
     /// resulting in a warm start instead of a cold start with hours-long duration.
+    /// Tests timing-based background launch detection using processStartTimestamp as the reference.
+    /// Simulates an app whose process was created more than 10 seconds before the user opened it.
     func testBackgroundLaunchDetectedByTiming() throws {
         let destination = DebugDestination()
 
@@ -140,21 +142,55 @@ final class AppStartTests: XCTestCase {
         appStart.destination = destination
         appStart.install(with: nil, remoteConfiguration: nil)
 
-        // Simulate didFinishLaunching happened more than 10 seconds ago
-        // (app was launched in background and stayed there)
-        appStart.didFinishLaunchingTimestamp = Date().addingTimeInterval(-15.0)
+        // Process was created more than 10 seconds ago (prewarmed or background-launched)
+        appStart.processStartTimestamp = Date().addingTimeInterval(-15.0)
 
-        // Now simulate user bringing app to foreground
-        // The willEnterForeground handler should detect this as a background launch
-        // because more than 10 seconds have passed since didFinishLaunching
         simulateWarmStartNotifications()
 
-        // Verify backgroundLaunchDetected was set to true by the timing check
         XCTAssertTrue(appStart.backgroundLaunchDetected == true, "backgroundLaunchDetected should be true due to timing check")
 
         // Should be warm start, NOT cold start
         try checkDeterminedType(.warm, in: destination)
         try checkDates(in: destination)
+    }
+
+    /// Tests Scenario 1: didFinishLaunching was missed (SDK registered too late), but processStartTimestamp
+    /// is old enough to trigger the background launch safeguard.
+    func testBackgroundLaunchDetectedWhenDidFinishLaunchingMissed() throws {
+        let destination = DebugDestination()
+
+        let appStart = AppStart()
+        appStart.destination = destination
+        appStart.install(with: nil, remoteConfiguration: nil)
+
+        // Process started long ago; didFinishLaunching was never observed (nil)
+        appStart.processStartTimestamp = Date().addingTimeInterval(-3600.0)
+
+        // Only willEnterForeground and didBecomeActive arrive (didFinishLaunching was missed)
+        simulateWarmStartNotifications()
+
+        XCTAssertTrue(appStart.backgroundLaunchDetected == true, "backgroundLaunchDetected should be true even when didFinishLaunching was missed")
+        try checkDeterminedType(.warm, in: destination)
+    }
+
+    /// Tests Scenario 2: didFinishLaunching is present but occurred only moments before
+    /// willEnterForeground, while processStartTimestamp is hours earlier.
+    func testBackgroundLaunchDetectedWhenDidFinishLaunchingLateButProcessStartOld() throws {
+        let destination = DebugDestination()
+
+        let appStart = AppStart()
+        appStart.destination = destination
+        appStart.install(with: nil, remoteConfiguration: nil)
+
+        // Process started hours ago
+        appStart.processStartTimestamp = Date().addingTimeInterval(-3600.0)
+        // didFinishLaunching occurred only 1 second ago (would not have triggered the old check)
+        appStart.didFinishLaunchingTimestamp = Date().addingTimeInterval(-1.0)
+
+        simulateWarmStartNotifications()
+
+        XCTAssertTrue(appStart.backgroundLaunchDetected == true, "backgroundLaunchDetected should be true based on processStartTimestamp even when didFinishLaunching is recent")
+        try checkDeterminedType(.warm, in: destination)
     }
 
     func testHotStart() throws {


### PR DESCRIPTION
## Title: DEMRUM-6128: Fix background launch detection to use process start timestamp

### Description

- Changed the background-launch safeguard reference timestamp from `didFinishLaunchingTimestamp` to `processStartTimestamp ?? didFinishLaunchingTimestamp` in `AppStart+Notifications.swift`
- This fixes two scenarios causing multi-hour cold-start spans: (1) `didFinishLaunching` missed entirely when SDK registers late (e.g. React Native), (2) process prewarmed or background-launched long before `didFinishLaunching`
- Updated `testBackgroundLaunchDetectedByTiming` and added two new tests covering both scenarios
- Root cause reported in SWAT-11541 / hypercare 4081390 (Sky Bet abnormal P99 cold startup times)

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [x] (Optional) I have added unit tests for my changes.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

Run `SplunkAppStartTests` on any iOS simulator. All 14 tests should pass, including the two new scenarios.

### Notes

This is a targeted fix for the immediate issue. The full launch provenance design (explicit `AppStartLaunchOrigin` through the bridge) is tracked separately in DEMRUM-4398.