### PR TITLE
DEMRUM-6019: Add app.previous_version to resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 * Set the periodic in-memory trace batch drain interval to 1 second, retaining the 100-span immediate drain threshold and lifecycle drains.
-* Added the optional `app.previous_version` resource attribute, which identifies the app version installed immediately before the current version for the same app installation.
+* Added the optional `app.previous_version` resource attribute, which identifies the app version installed immediately before the current version for the same app installation, including launches sampled out of telemetry.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 * Set the periodic in-memory trace batch drain interval to 1 second, retaining the 100-span immediate drain threshold and lifecycle drains.
+* Added the optional `app.previous_version` resource attribute, which identifies the app version installed immediately before the current version for the same app installation.
 
 ### Added
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager+Endpoint.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Events/Event Manager/DefaultEventManager+Endpoint.swift
@@ -140,10 +140,12 @@ extension DefaultEventManager {
     private static func buildResources(configuration: any AgentConfigurationProtocol) -> DefaultResources {
         // Will be used later by hybrid agents
         let hybridType: String? = nil
+        let appVersionTracker = AppVersionTracker(currentVersion: configuration.appVersion)
 
         return DefaultResources(
             appName: configuration.appName,
             appVersion: configuration.appVersion,
+            appPreviousVersion: appVersionTracker.previousVersion,
             appBuild: AppInfo.buildId ?? "-",
             appDeploymentEnvironment: configuration.deploymentEnvironment,
             agentHybridType: hybridType,

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
@@ -18,44 +18,18 @@ limitations under the License.
 import Foundation
 internal import SplunkCommon
 
-struct DefaultResources: AgentResources {
+enum AppInstallationStorage {
 
-    // MARK: - App info
+    static let installationIdKey = "app.installation.id"
 
-    var appName: String
+    static func identifier(using storage: KeyValueStorage) -> String {
+        if let existingInstallationId: String = try? storage.read(forKey: installationIdKey),
+           !existingInstallationId.isEmpty {
+            return existingInstallationId
+        }
 
-    var appVersion: String
-
-    var appPreviousVersion: String?
-
-    var appBuild: String
-
-    var appDeploymentEnvironment: String
-
-
-    // MARK: - Agent info
-
-    var agentHybridType: String?
-
-    var agentVersion: String
-
-
-    // MARK: - Device info
-
-    var deviceID: String
-
-    var deviceModelIdentifier: String
-
-    var deviceManufacturer: String
-
-
-    // MARK: - OS info
-
-    var osName: String
-
-    var osVersion: String
-
-    var osDescription: String
-
-    var osType: String
+        let newInstallationId = String.uniqueHexIdentifier(ofLength: 32)
+        try? storage.update(newInstallationId, forKey: installationIdKey)
+        return newInstallationId
+    }
 }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
@@ -23,8 +23,8 @@ enum AppInstallationStorage {
     static let installationIdKey = "app.installation.id"
 
     static func identifier(using storage: KeyValueStorage) -> String {
-        if let existingInstallationId: String = try? storage.read(forKey: installationIdKey),
-           !existingInstallationId.isEmpty {
+        let existingInstallationId: String? = try? storage.read(forKey: installationIdKey)
+        if let existingInstallationId, !existingInstallationId.isEmpty {
             return existingInstallationId
         }
 

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppInstallationStorage.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
@@ -1,0 +1,78 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+final class AppVersionTracker {
+
+    // MARK: - Internal
+
+    static let storageKey = "app.version.state"
+
+    let previousVersion: String?
+
+
+    // MARK: - Private
+
+    private struct StoredState: Codable {
+        let installationId: String
+        let currentVersion: String
+        let previousVersion: String?
+    }
+
+
+    // MARK: - Initialization
+
+    init(currentVersion: String, storage: KeyValueStorage = UserDefaultsStorage()) {
+        guard !currentVersion.isEmpty else {
+            previousVersion = nil
+            return
+        }
+
+        let installationId = AppInstallationStorage.identifier(using: storage)
+        let storedState: StoredState? = try? storage.read(forKey: Self.storageKey)
+
+        if let storedState,
+           storedState.installationId == installationId,
+           !storedState.currentVersion.isEmpty {
+            if storedState.currentVersion == currentVersion {
+                previousVersion = Self.nonEmpty(storedState.previousVersion)
+                return
+            }
+
+            previousVersion = storedState.currentVersion
+        }
+        else {
+            previousVersion = nil
+        }
+
+        let newState = StoredState(
+            installationId: installationId,
+            currentVersion: currentVersion,
+            previousVersion: previousVersion
+        )
+        try? storage.update(newState, forKey: Self.storageKey)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+
+        return value
+    }
+}

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
@@ -46,9 +46,7 @@ final class AppVersionTracker {
         let installationId = AppInstallationStorage.identifier(using: storage)
         let storedState: StoredState? = try? storage.read(forKey: Self.storageKey)
 
-        if let storedState,
-           storedState.installationId == installationId,
-           storedState.currentVersion == currentVersion {
+        if let storedState, storedState.installationId == installationId, storedState.currentVersion == currentVersion {
             previousVersion = Self.nonEmpty(storedState.previousVersion)
         }
         else {
@@ -65,9 +63,7 @@ final class AppVersionTracker {
         let storedState: StoredState? = try? storage.read(forKey: Self.storageKey)
         let previousVersion: String?
 
-        if let storedState,
-           storedState.installationId == installationId,
-           !storedState.currentVersion.isEmpty {
+        if let storedState, storedState.installationId == installationId, !storedState.currentVersion.isEmpty {
             if storedState.currentVersion == currentVersion {
                 previousVersion = Self.nonEmpty(storedState.previousVersion)
             }

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Resources/AppVersionTracker.swift
@@ -48,13 +48,32 @@ final class AppVersionTracker {
 
         if let storedState,
            storedState.installationId == installationId,
+           storedState.currentVersion == currentVersion {
+            previousVersion = Self.nonEmpty(storedState.previousVersion)
+        }
+        else {
+            previousVersion = nil
+        }
+    }
+
+    static func record(currentVersion: String, storage: KeyValueStorage = UserDefaultsStorage()) {
+        guard !currentVersion.isEmpty else {
+            return
+        }
+
+        let installationId = AppInstallationStorage.identifier(using: storage)
+        let storedState: StoredState? = try? storage.read(forKey: Self.storageKey)
+        let previousVersion: String?
+
+        if let storedState,
+           storedState.installationId == installationId,
            !storedState.currentVersion.isEmpty {
             if storedState.currentVersion == currentVersion {
                 previousVersion = Self.nonEmpty(storedState.previousVersion)
-                return
             }
-
-            previousVersion = storedState.currentVersion
+            else {
+                previousVersion = storedState.currentVersion
+            }
         }
         else {
             previousVersion = nil

--- a/SplunkAgent/Sources/SplunkAgent/Agent/Runtime Attributes/DefaultRuntimeAttributes.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Agent/Runtime Attributes/DefaultRuntimeAttributes.swift
@@ -105,17 +105,7 @@ final class DefaultRuntimeAttributes: AgentRuntimeAttributes {
         accessQueue = DispatchQueue(label: queueName, qos: .userInitiated)
 
         let storage = UserDefaultsStorage()
-        let storageKeyForAppInstallationId = "app.installation.id"
-
-        // Retrieve or generate a persistent app installation ID
-        if let existingAppInstallationId: String = try? storage.read(forKey: storageKeyForAppInstallationId), !existingAppInstallationId.isEmpty {
-            appInstallationId = existingAppInstallationId
-        }
-        else {
-            let newId = String.uniqueHexIdentifier(ofLength: 32)
-            try? storage.update(newId, forKey: storageKeyForAppInstallationId)
-            appInstallationId = newId
-        }
+        appInstallationId = AppInstallationStorage.identifier(using: storage)
     }
 
 

--- a/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
+++ b/SplunkAgent/Sources/SplunkAgent/Public API/SplunkRum.swift
@@ -176,6 +176,10 @@ public class SplunkRum: ObservableObject {
             return shared
         }
 
+        // Record the installed version before session sampling so sampled-out launches still
+        // participate in version transition tracking.
+        AppVersionTracker.record(currentVersion: configuration.appVersion)
+
         // Re-configure and call the Session Sampler
         shared.sessionSampler.configure(with: configuration)
         let samplingDecision = shared.sessionSampler.sample()

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
@@ -1,0 +1,122 @@
+//
+/*
+Copyright 2025 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import XCTest
+
+@testable import SplunkAgent
+
+final class AppVersionTrackerTests: XCTestCase {
+
+    private var storage: KeyValueStorage!
+
+
+    // MARK: - XCTestCase
+
+    override func setUp() {
+        super.setUp()
+
+        storage = UserDefaultsStorageTestBuilder.buildCleanStorage(named: "appVersionTrackerTests")
+        clearStorage()
+    }
+
+    override func tearDown() {
+        clearStorage()
+        storage = nil
+
+        super.tearDown()
+    }
+
+
+    // MARK: - Tests
+
+    func testFirstInstallationHasNoPreviousVersion() throws {
+        XCTAssertNil(try tracker(for: "5.2.0").previousVersion)
+    }
+
+    func testUpgradeRecordsTheInstalledVersionAsPrevious() throws {
+        _ = try tracker(for: "5.1.3")
+
+        let upgraded = try tracker(for: "5.2.0")
+
+        XCTAssertEqual(upgraded.previousVersion, "5.1.3")
+    }
+
+    func testRelaunchKeepsThePreviousVersion() throws {
+        _ = try tracker(for: "5.1.3")
+        _ = try tracker(for: "5.2.0")
+
+        let relaunched = try tracker(for: "5.2.0")
+
+        XCTAssertEqual(relaunched.previousVersion, "5.1.3")
+    }
+
+    func testSubsequentUpgradeReplacesThePreviousVersion() throws {
+        _ = try tracker(for: "5.1.3")
+        _ = try tracker(for: "5.2.0")
+
+        let subsequentUpgrade = try tracker(for: "5.3.0")
+
+        XCTAssertEqual(subsequentUpgrade.previousVersion, "5.2.0")
+    }
+
+    func testDowngradeRecordsTheVersionBeingDowngradedFrom() throws {
+        _ = try tracker(for: "5.1.3")
+        _ = try tracker(for: "5.2.0")
+        _ = try tracker(for: "5.3.0")
+
+        let downgrade = try tracker(for: "5.2.0")
+
+        XCTAssertEqual(downgrade.previousVersion, "5.3.0")
+    }
+
+    func testCleanReinstallHasNoPreviousVersion() throws {
+        _ = try tracker(for: "5.2.0")
+        let installationIdBeforeReinstall = try XCTUnwrap(
+            AppInstallationStorage.identifier(using: storage)
+        )
+
+        clearStorage()
+
+        let reinstalled = try tracker(for: "5.3.0")
+        let installationIdAfterReinstall = try XCTUnwrap(
+            AppInstallationStorage.identifier(using: storage)
+        )
+
+        XCTAssertNil(reinstalled.previousVersion)
+        XCTAssertNotEqual(installationIdAfterReinstall, installationIdBeforeReinstall)
+    }
+
+    func testEmptyCurrentVersionDoesNotCreatePreviousVersion() throws {
+        XCTAssertNil(try tracker(for: "").previousVersion)
+
+        let firstVersion = try tracker(for: "5.2.0")
+
+        XCTAssertNil(firstVersion.previousVersion)
+    }
+
+
+    // MARK: - Private methods
+
+    private func tracker(for version: String) throws -> AppVersionTracker {
+        AppVersionTracker(currentVersion: version, storage: try XCTUnwrap(storage))
+    }
+
+    private func clearStorage() {
+        try? storage?.delete(forKey: AppInstallationStorage.installationIdKey)
+        try? storage?.delete(forKey: AppVersionTracker.storageKey)
+    }
+}

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 final class AppVersionTrackerTests: XCTestCase {
 
-    private var storage: KeyValueStorage!
+    private var storage: KeyValueStorage?
 
 
     // MARK: - XCTestCase
@@ -85,15 +85,16 @@ final class AppVersionTrackerTests: XCTestCase {
 
     func testCleanReinstallHasNoPreviousVersion() throws {
         _ = try tracker(for: "5.2.0")
+        let testStorage = try XCTUnwrap(storage)
         let installationIdBeforeReinstall = try XCTUnwrap(
-            AppInstallationStorage.identifier(using: storage)
+            AppInstallationStorage.identifier(using: testStorage)
         )
 
         clearStorage()
 
         let reinstalled = try tracker(for: "5.3.0")
         let installationIdAfterReinstall = try XCTUnwrap(
-            AppInstallationStorage.identifier(using: storage)
+            AppInstallationStorage.identifier(using: testStorage)
         )
 
         XCTAssertNil(reinstalled.previousVersion)
@@ -112,12 +113,17 @@ final class AppVersionTrackerTests: XCTestCase {
     // MARK: - Private methods
 
     private func tracker(for version: String) throws -> AppVersionTracker {
-        AppVersionTracker.record(currentVersion: version, storage: try XCTUnwrap(storage))
-        return AppVersionTracker(currentVersion: version, storage: try XCTUnwrap(storage))
+        let storage = try XCTUnwrap(storage)
+        AppVersionTracker.record(currentVersion: version, storage: storage)
+        return AppVersionTracker(currentVersion: version, storage: storage)
     }
 
     private func clearStorage() {
-        try? storage?.delete(forKey: AppInstallationStorage.installationIdKey)
-        try? storage?.delete(forKey: AppVersionTracker.storageKey)
+        guard let storage else {
+            return
+        }
+
+        try? storage.delete(forKey: AppInstallationStorage.installationIdKey)
+        try? storage.delete(forKey: AppVersionTracker.storageKey)
     }
 }

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
@@ -1,6 +1,6 @@
 //
 /*
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/AppVersionTrackerTests.swift
@@ -112,7 +112,8 @@ final class AppVersionTrackerTests: XCTestCase {
     // MARK: - Private methods
 
     private func tracker(for version: String) throws -> AppVersionTracker {
-        AppVersionTracker(currentVersion: version, storage: try XCTUnwrap(storage))
+        AppVersionTracker.record(currentVersion: version, storage: try XCTUnwrap(storage))
+        return AppVersionTracker(currentVersion: version, storage: try XCTUnwrap(storage))
     }
 
     private func clearStorage() {

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/ResourcesTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/ResourcesTests.swift
@@ -92,4 +92,94 @@ final class ResourcesTests: XCTestCase {
         let agentVersion = try XCTUnwrap(otelResource.attributes["rum.sdk.version"])
         XCTAssertFalse(agentVersion.description.isEmpty)
     }
+
+    func testPreviousAppVersionIsIncludedWhenPresent() {
+        var resource = Resource()
+        let resources = DefaultResources(
+            appName: "Tests",
+            appVersion: "5.2.0",
+            appPreviousVersion: "5.1.3",
+            appBuild: "1",
+            appDeploymentEnvironment: "test",
+            agentHybridType: nil,
+            agentVersion: "1.0.0",
+            deviceID: "device",
+            deviceModelIdentifier: "iPhone",
+            deviceManufacturer: "Apple",
+            osName: "iOS",
+            osVersion: "18.0",
+            osDescription: "iOS 18.0",
+            osType: "darwin"
+        )
+
+        resource.merge(with: resources)
+
+        XCTAssertEqual(resource.attributes["app.version"], .string("5.2.0"))
+        XCTAssertEqual(resource.attributes["app.previous_version"], .string("5.1.3"))
+    }
+
+    func testPreviousAppVersionIsOmittedWhenAbsentOrEmpty() {
+        for previousVersion in [nil, ""] as [String?] {
+            var resource = Resource()
+            let resources = DefaultResources(
+                appName: "Tests",
+                appVersion: "5.2.0",
+                appPreviousVersion: previousVersion,
+                appBuild: "1",
+                appDeploymentEnvironment: "test",
+                agentHybridType: nil,
+                agentVersion: "1.0.0",
+                deviceID: "device",
+                deviceModelIdentifier: "iPhone",
+                deviceManufacturer: "Apple",
+                osName: "iOS",
+                osVersion: "18.0",
+                osDescription: "iOS 18.0",
+                osType: "darwin"
+            )
+
+            resource.merge(with: resources)
+
+            XCTAssertNil(resource.attributes["app.previous_version"])
+        }
+    }
+
+    func testPreviousAppVersionReachesErrorResourceAfterUpgrade() throws {
+        let storage = UserDefaultsStorage()
+        try? storage.delete(forKey: AppInstallationStorage.installationIdKey)
+        try? storage.delete(forKey: AppVersionTracker.storageKey)
+        defer {
+            try? storage.delete(forKey: AppInstallationStorage.installationIdKey)
+            try? storage.delete(forKey: AppVersionTracker.storageKey)
+        }
+
+        var firstConfiguration = try ConfigurationTestBuilder.buildDefault()
+        firstConfiguration.appVersion = "5.1.3"
+        let firstAgent = try AgentTestBuilder.build(with: firstConfiguration)
+        firstAgent.eventManager = try DefaultEventManager(with: firstConfiguration, agent: firstAgent)
+
+        let firstEventManager = try XCTUnwrap(firstAgent.eventManager as? DefaultEventManager)
+        let firstLogEventProcessor = try XCTUnwrap(
+            firstEventManager.logEventProcessor as? OTLPLogToSpanEventProcessor
+        )
+        XCTAssertNil(firstLogEventProcessor.resource?.attributes["app.previous_version"])
+
+        var upgradedConfiguration = firstConfiguration
+        upgradedConfiguration.appVersion = "5.2.0"
+        let upgradedAgent = try AgentTestBuilder.build(with: upgradedConfiguration)
+        upgradedAgent.eventManager = try DefaultEventManager(with: upgradedConfiguration, agent: upgradedAgent)
+
+        let upgradedEventManager = try XCTUnwrap(upgradedAgent.eventManager as? DefaultEventManager)
+        let upgradedLogEventProcessor = try XCTUnwrap(
+            upgradedEventManager.logEventProcessor as? OTLPLogToSpanEventProcessor
+        )
+        let upgradedResource = try XCTUnwrap(upgradedLogEventProcessor.resource)
+
+        XCTAssertEqual(upgradedResource.attributes["app.version"], .string("5.2.0"))
+        XCTAssertEqual(upgradedResource.attributes["app.previous_version"], .string("5.1.3"))
+        XCTAssertEqual(
+            firstAgent.runtimeAttributes.all["app.installation.id"] as? String,
+            upgradedAgent.runtimeAttributes.all["app.installation.id"] as? String
+        )
+    }
 }

--- a/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/ResourcesTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Agent/Resources/ResourcesTests.swift
@@ -155,6 +155,7 @@ final class ResourcesTests: XCTestCase {
 
         var firstConfiguration = try ConfigurationTestBuilder.buildDefault()
         firstConfiguration.appVersion = "5.1.3"
+        AppVersionTracker.record(currentVersion: firstConfiguration.appVersion)
         let firstAgent = try AgentTestBuilder.build(with: firstConfiguration)
         firstAgent.eventManager = try DefaultEventManager(with: firstConfiguration, agent: firstAgent)
 
@@ -166,6 +167,7 @@ final class ResourcesTests: XCTestCase {
 
         var upgradedConfiguration = firstConfiguration
         upgradedConfiguration.appVersion = "5.2.0"
+        AppVersionTracker.record(currentVersion: upgradedConfiguration.appVersion)
         let upgradedAgent = try AgentTestBuilder.build(with: upgradedConfiguration)
         upgradedAgent.eventManager = try DefaultEventManager(with: upgradedConfiguration, agent: upgradedAgent)
 

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -16,8 +16,10 @@ limitations under the License.
 */
 
 import XCTest
+import OpenTelemetryApi
 
 @testable import SplunkAgent
+@testable import SplunkOpenTelemetry
 
 final class API10AgentTests: XCTestCase {
 
@@ -92,9 +94,35 @@ final class API10AgentTests: XCTestCase {
         XCTAssertTrue(agent === anotherAgentInstance)
     }
 
+    func testInstall_recordsVersionBeforeSampling() throws {
+        let storage = UserDefaultsStorage()
+        try? storage.delete(forKey: AppInstallationStorage.installationIdKey)
+        try? storage.delete(forKey: AppVersionTracker.storageKey)
+        defer {
+            try? storage.delete(forKey: AppInstallationStorage.installationIdKey)
+            try? storage.delete(forKey: AppVersionTracker.storageKey)
+        }
+
+        var sampledOutConfiguration = try ConfigurationTestBuilder.buildDefaultSampledOut()
+        sampledOutConfiguration.appVersion = "5.2.0"
+        _ = try SplunkRum.install(with: sampledOutConfiguration)
+
+        SplunkRum.resetSharedInstance()
+
+        var sampledInConfiguration = try ConfigurationTestBuilder.buildDefault()
+        sampledInConfiguration.appVersion = "5.3.0"
+        let installedAgent = try SplunkRum.install(with: sampledInConfiguration)
+        let eventManager = try XCTUnwrap(installedAgent.eventManager as? DefaultEventManager)
+        let logEventProcessor = try XCTUnwrap(eventManager.logEventProcessor as? OTLPLogToSpanEventProcessor)
+        let resource = try XCTUnwrap(logEventProcessor.resource)
+
+        XCTAssertEqual(resource.attributes["app.version"], .string("5.3.0"))
+        XCTAssertEqual(resource.attributes["app.previous_version"], .string("5.2.0"))
+    }
+
     // MARK: - Private methods
 
-    private func expectedAgentStatus() -> Status {
+    private func expectedAgentStatus() -> SplunkAgent.Status {
         let isSupportedPlatform = PlatformSupport.current.scope == .full
 
         return isSupportedPlatform ? .running : .notRunning(.unsupportedPlatform)

--- a/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
+++ b/SplunkAgent/Tests/SplunkAgentTests/Public API/API-1.0-AgentTests.swift
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import XCTest
 import OpenTelemetryApi
+import XCTest
 
 @testable import SplunkAgent
 @testable import SplunkOpenTelemetry

--- a/SplunkCommon/Sources/SplunkCommon/Resources/AgentResources.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Resources/AgentResources.swift
@@ -80,10 +80,10 @@ public protocol AgentResources {
     var osType: String { get }
 }
 
-public extension AgentResources {
+extension AgentResources {
 
     /// The default is absent when a previous application version is not available.
-    var appPreviousVersion: String? {
+    public var appPreviousVersion: String? {
         nil
     }
 }

--- a/SplunkCommon/Sources/SplunkCommon/Resources/AgentResources.swift
+++ b/SplunkCommon/Sources/SplunkCommon/Resources/AgentResources.swift
@@ -31,6 +31,12 @@ public protocol AgentResources {
     /// Application version.
     var appVersion: String { get }
 
+    /// Application version installed immediately before the current version for this installation.
+    ///
+    /// This value remains unchanged across launches until the application version changes. It is
+    /// `nil` when no previous version exists.
+    var appPreviousVersion: String? { get }
+
     /// Application build number.
     var appBuild: String { get }
 
@@ -72,4 +78,12 @@ public protocol AgentResources {
 
     /// Operating system type, e.g. `darwin`.
     var osType: String { get }
+}
+
+public extension AgentResources {
+
+    /// The default is absent when a previous application version is not available.
+    var appPreviousVersion: String? {
+        nil
+    }
 }

--- a/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Resources/Resource+AgentResources.swift
+++ b/SplunkOpenTelemetry/Sources/SplunkOpenTelemetry/Resources/Resource+AgentResources.swift
@@ -20,6 +20,10 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import SplunkCommon
 
+private enum ResourceAttributeKeys {
+    static let appPreviousVersion = "app.previous_version"
+}
+
 /// Builds OTel Resource object from AgentResources.
 extension Resource {
 
@@ -54,6 +58,11 @@ extension Resource {
 
         // Add required attributes to the resource
         merge(other: Resource(attributes: requiredAttributes))
+
+        // A previous version is optional and must not be emitted as an empty string.
+        if let previousVersion = agentResources.appPreviousVersion, !previousVersion.isEmpty {
+            merge(other: Resource(attributes: [ResourceAttributeKeys.appPreviousVersion: .string(previousVersion)]))
+        }
 
         // Add optional hybrid agent type
         if let hybridType = agentResources.agentHybridType {


### PR DESCRIPTION
## Title: Add app.previous_version to resource attributes

### Description

- Add app.previous_version as an OpenTelemetry resource attribute in the iOS instrumentation.
- Attribute definition: The version installed immediately before the current app.version for the same app.installation.id. It remains unchanged across launches until another upgrade or downgrade occurs.
- The attribute must be omitted when there is no previously installed version; it must not be emitted as an empty string.

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [x] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [x] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

[Provide clear and step-by-step instructions on how reviewers can test the changes you've made.]

### Future Considerations (Optional)

[Mention any related upcoming work or considerations for the future.]
