### PR TITLE
DEMRUM-6409: Update Traceparent Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Fixed Server-Timing `traceparent` parsing to support bitmask trace flags, including the W3C random trace ID flag.
+* Fixed Server-Timing `traceparent` parsing to reject all-zero trace IDs and span IDs, which are invalid according to the OpenTelemetry trace context requirements.
 * Fixed URLSession network span finalization races that could drop Server-Timing links and response attributes, duplicate attribute processing, or end spans on nonterminal task states.
 * Fixed a crash during `NavigationSplitView` multiwindow resizing on iPad when automated navigation tracking is enabled. Fixes issue #711.
 

--- a/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+HTTP.swift
+++ b/SplunkNetwork/Sources/SplunkNetwork/URLSessionInstrumentation/Instrumentation+HTTP.swift
@@ -78,7 +78,7 @@ func getIPAddressFromResponse(_ response: HTTPURLResponse) -> String? {
 func addLinkToSpan(span: Span, valStr: String) {
 
     // Trace flags are a bitmask. Linking only needs the identifiers, so accept the complete flag byte.
-    let serverTimingPattern = #"traceparent;desc=['"]00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}['"]"#
+    let serverTimingPattern = #"traceparent;desc=['"]00-((?!0{32})[0-9a-f]{32})-((?!0{16})[0-9a-f]{16})-[0-9a-f]{2}['"]"#
     guard let regex = try? NSRegularExpression(pattern: serverTimingPattern) else {
         NetworkInstrumentationManager.shared.logger.log(level: .fault) {
             "Regex failed to compile"

--- a/SplunkNetwork/Tests/SplunkNetworkTests/SpanLinkingTests.swift
+++ b/SplunkNetwork/Tests/SplunkNetworkTests/SpanLinkingTests.swift
@@ -122,6 +122,26 @@ final class SpanLinkingTests: XCTestCase {
         XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId])
     }
 
+    func testAddLinkToSpan_InvalidZeroTraceId() {
+        let mockSpan = MockSpan()
+        let valStr = "traceparent;desc='00-00000000000000000000000000000000-b7ad6b7169203331-01'"
+
+        addLinkToSpan(span: mockSpan, valStr: valStr)
+
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkTraceId])
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId])
+    }
+
+    func testAddLinkToSpan_InvalidZeroSpanId() {
+        let mockSpan = MockSpan()
+        let valStr = "traceparent;desc='00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01'"
+
+        addLinkToSpan(span: mockSpan, valStr: valStr)
+
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkTraceId])
+        XCTAssertNil(mockSpan.attributes[NetworkSpanAttributeKeys.linkSpanId])
+    }
+
     func testAddLinkToSpan_ValidTraceParent_DoubleQuotes() {
         let mockSpan = MockSpan()
         let valStr = #"traceparent;desc="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01""#


### PR DESCRIPTION
## Title: Update Traceparent qualification regex to conform with Otel spec.

### Description

trace-id = 00000000000000000000000000000000 is accepted by current regex but an invalid value as per the spec.

This specification defines standard HTTP headers and a value format to propagate context information that enables distributed tracing scenarios. The specification standardizes how context information is sent and modified between services. Context information uniquely identifies individual requests in a distributed system and also defines a means to add and propagate provider-specific context information.
[Bullet list of the changes or enhancements made in this PR.]

- Update the regex for both trace-id and span-id
- Update validation tests

### Checklist

- [x] My code follows the project's coding standards.
- [x] I have run linters/formatters and fixed any issues.
- [x] There are no merge conflicts.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass locally.
- [ ] I have added license headers to all files.
- [x] I have added an entry to CHANGELOG for any user facing changes.
- [ ] \(Optional) I have added unit tests for my changes.
- [ ] \(Optional) I have updated the sample app for integration testing.
- [ ] \(Optional) I have updated any relevant documentation.

### Generative AI usage

- [ ] GAI was not used (or, no additional notation is required)
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Code was generated entirely by GAI

### How to Test These Changes

- Tested via all zerro insertion in the debugger.
